### PR TITLE
fix: improve tab titles with resource kind context

### DIFF
--- a/src/kubeview/components/TabBar.tsx
+++ b/src/kubeview/components/TabBar.tsx
@@ -5,6 +5,7 @@ import { useUIStore } from '../store/uiStore';
 import { cn } from '@/lib/utils';
 import { useEffect, useRef } from 'react';
 import { getResourceIcon } from '../engine/iconRegistry';
+import { pluralToKind } from '../engine/renderers/index';
 
 // Helper to get icon component from string name
 function getIcon(iconName?: string) {
@@ -12,7 +13,7 @@ function getIcon(iconName?: string) {
   return getResourceIcon(iconName);
 }
 
-function getTabTitle(path: string): string {
+export function getTabTitle(path: string): string {
   const parts = path.split('/').filter(Boolean);
 
   // /r/v1~nodes → "Nodes"
@@ -20,9 +21,12 @@ function getTabTitle(path: string): string {
   if (parts[0] === 'r' && parts.length >= 2) {
     const gvrParts = parts[1].split('~');
     const resource = gvrParts[gvrParts.length - 1];
-    // /r/v1~nodes/_/node-name → "node-name"
+    // /r/v1~pods/kube-system/coredns → "coredns (Pod)"
+    // /r/apps~v1~deployments/default/nginx → "nginx (Deployment)"
     if (parts.length >= 4) {
-      return parts[parts.length - 1];
+      const name = parts[parts.length - 1];
+      const kind = pluralToKind(resource);
+      return `${name} (${kind})`;
     }
     return resource.charAt(0).toUpperCase() + resource.slice(1);
   }

--- a/src/kubeview/components/__tests__/TabBar.test.ts
+++ b/src/kubeview/components/__tests__/TabBar.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { getTabTitle } from '../TabBar';
+
+describe('getTabTitle', () => {
+  // Detail paths: /r/{gvr}/{namespace}/{name} → "name (Kind)"
+  it('returns "name (Deployment)" for deployment detail path', () => {
+    expect(getTabTitle('/r/apps~v1~deployments/default/nginx')).toBe('nginx (Deployment)');
+  });
+
+  it('returns "name (Pod)" for pod detail path', () => {
+    expect(getTabTitle('/r/v1~pods/kube-system/coredns')).toBe('coredns (Pod)');
+  });
+
+  it('returns "name (Node)" for node detail path with _ namespace', () => {
+    expect(getTabTitle('/r/v1~nodes/_/worker-1')).toBe('worker-1 (Node)');
+  });
+
+  it('returns "name (Service)" for service detail path', () => {
+    expect(getTabTitle('/r/v1~services/default/kubernetes')).toBe('kubernetes (Service)');
+  });
+
+  it('returns "name (Statefulset)" for statefulsets', () => {
+    expect(getTabTitle('/r/apps~v1~statefulsets/default/redis')).toBe('redis (Statefulset)');
+  });
+
+  it('returns "name (Ingress)" for ingresses (pluralized with -es)', () => {
+    expect(getTabTitle('/r/networking.k8s.io~v1~ingresses/default/my-ingress')).toBe('my-ingress (Ingress)');
+  });
+
+  it('returns "name (Policy)" for policies (pluralized with -ies)', () => {
+    expect(getTabTitle('/r/networking.k8s.io~v1~networkpolicies/default/deny-all')).toBe('deny-all (Networkpolicy)');
+  });
+
+  // List paths: /r/{gvr} → "Plural"
+  it('returns "Deployments" for deployment list path', () => {
+    expect(getTabTitle('/r/apps~v1~deployments')).toBe('Deployments');
+  });
+
+  it('returns "Pods" for pod list path', () => {
+    expect(getTabTitle('/r/v1~pods')).toBe('Pods');
+  });
+
+  it('returns "Nodes" for node list path', () => {
+    expect(getTabTitle('/r/v1~nodes')).toBe('Nodes');
+  });
+
+  // YAML paths
+  it('returns "name (YAML)" for yaml path', () => {
+    expect(getTabTitle('/yaml/apps~v1~deployments/default/nginx')).toBe('nginx (YAML)');
+  });
+
+  // Logs paths
+  it('returns "name (Logs)" for logs path', () => {
+    expect(getTabTitle('/logs/default/my-pod')).toBe('my-pod (Logs)');
+  });
+
+  // Metrics paths
+  it('returns "name (Metrics)" for metrics path', () => {
+    expect(getTabTitle('/metrics/apps~v1~deployments/default/nginx')).toBe('nginx (Metrics)');
+  });
+
+  // Generic paths
+  it('returns capitalized last segment for generic paths', () => {
+    expect(getTabTitle('/workloads')).toBe('Workloads');
+  });
+
+  it('returns "Untitled" for root path', () => {
+    expect(getTabTitle('/')).toBe('Untitled');
+  });
+});

--- a/src/kubeview/engine/renderers/index.tsx
+++ b/src/kubeview/engine/renderers/index.tsx
@@ -79,6 +79,26 @@ export function kindToPlural(kind: string): string {
   return lower + 's';
 }
 
+/**
+ * Convert a plural resource name to a capitalized Kind.
+ * Inverse of kindToPlural for common K8s naming patterns.
+ * e.g. "deployments" → "Deployment", "networkpolicies" → "Networkpolicy"
+ */
+export function pluralToKind(plural: string): string {
+  const lower = plural.toLowerCase();
+  let singular: string;
+  if (lower.endsWith('ies')) {
+    singular = lower.slice(0, -3) + 'y';
+  } else if (lower.endsWith('ses') || lower.endsWith('zes')) {
+    singular = lower.slice(0, -2);
+  } else if (lower.endsWith('s')) {
+    singular = lower.slice(0, -1);
+  } else {
+    singular = lower;
+  }
+  return singular.charAt(0).toUpperCase() + singular.slice(1);
+}
+
 // Helper to compute age from timestamp
 function ageFromTimestamp(ts: string | undefined): string {
   if (!ts) return '-';

--- a/src/kubeview/views/DependencyView.tsx
+++ b/src/kubeview/views/DependencyView.tsx
@@ -5,6 +5,7 @@ import { buildDependencyGraph, type DependencyGraph, type GraphNode } from '@/li
 import { useUIStore } from '../store/uiStore';
 import { resourceDetailUrl } from '../engine/gvr';
 import { useNavigateTab } from '../hooks/useNavigateTab';
+import { pluralToKind } from '../engine/renderers/index';
 import { Card } from '../components/primitives/Card';
 
 interface DependencyViewProps {
@@ -113,9 +114,7 @@ export default function DependencyView({ gvrKey, namespace, name }: DependencyVi
   const kind = useMemo(() => {
     const parts = gvrKey.split('/');
     const plural = parts[parts.length - 1];
-    // Simple plural → singular + capitalize
-    const singular = plural.replace(/ies$/, 'y').replace(/ses$/, 's').replace(/s$/, '');
-    return singular.charAt(0).toUpperCase() + singular.slice(1);
+    return pluralToKind(plural);
   }, [gvrKey]);
 
   const [graph, setGraph] = useState<DependencyGraph | null>(null);


### PR DESCRIPTION
## Summary
- Tab titles from URLs were cryptic (just resource name like "nginx")
- Now shows "nginx (Deployment)" for detail views, giving users context
- Extracted `pluralToKind()` into shared renderer utility, deduplicating with DependencyView

## Test plan
- [ ] Verify tab titles show kind in parentheses for detail views
- [ ] Verify list view tab titles unchanged
- [ ] Run `npx vitest --run` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)