### PR TITLE
feat: DetailView breadcrumb navigation

### DIFF
--- a/src/kubeview/views/DetailView.tsx
+++ b/src/kubeview/views/DetailView.tsx
@@ -23,6 +23,7 @@ import {
   ArrowRight,
   Box,
   Bug,
+  ChevronRight,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { k8sGet, k8sList, k8sDelete, k8sPatch, k8sCreate, k8sLogs } from '../engine/query';
@@ -386,14 +387,38 @@ export default function DetailView({ gvrKey, namespace, name }: DetailViewProps)
         {/* Header */}
         <div className="flex items-start justify-between">
           <div>
-            <div className="flex items-center gap-3 mb-2">
+            {/* Breadcrumb */}
+            <nav className="flex items-center gap-1.5 text-sm mb-1" aria-label="Breadcrumb">
               <button
                 onClick={() => navigate(-1)}
                 className="p-1 rounded hover:bg-slate-800 text-slate-400 hover:text-slate-200"
                 title="Go back"
               >
-                <ArrowLeft className="w-5 h-5" />
+                <ArrowLeft className="w-4 h-4" />
               </button>
+              <button
+                onClick={() => go(`/r/${gvrUrl}`, resourcePlural)}
+                className="text-blue-400 hover:text-blue-300 capitalize"
+                data-testid="breadcrumb-kind"
+              >
+                {resourcePlural}
+              </button>
+              {namespace && (
+                <>
+                  <ChevronRight className="w-3.5 h-3.5 text-slate-600" />
+                  <button
+                    onClick={() => go(`/r/${gvrUrl}?ns=${namespace}`, `${resourcePlural} (${namespace})`)}
+                    className="text-blue-400 hover:text-blue-300"
+                    data-testid="breadcrumb-namespace"
+                  >
+                    {namespace}
+                  </button>
+                </>
+              )}
+              <ChevronRight className="w-3.5 h-3.5 text-slate-600" />
+              <span className="text-slate-400" data-testid="breadcrumb-name">{name}</span>
+            </nav>
+            <div className="flex items-center gap-3 mb-2">
               <h1 className="text-2xl font-bold text-slate-100">{resource.metadata.name}</h1>
               <button
                 onClick={(e) => { e.stopPropagation(); navigator.clipboard.writeText(resource.metadata.name); addToast({ type: 'success', title: 'Name copied' }); }}

--- a/src/kubeview/views/__tests__/DetailView.test.tsx
+++ b/src/kubeview/views/__tests__/DetailView.test.tsx
@@ -417,4 +417,91 @@ describe('DetailView', () => {
       expect(screen.getAllByText('nginx:latest').length).toBeGreaterThanOrEqual(1);
     });
   });
+
+  describe('breadcrumb navigation', () => {
+    it('renders breadcrumb with kind, namespace, and name for namespaced resource', async () => {
+      mockK8sGet.mockResolvedValue(makeDeployment());
+
+      renderDetailView({ gvrKey: 'apps/v1/deployments', namespace: 'default', name: 'my-deployment' });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('breadcrumb-kind')).toBeDefined();
+      });
+
+      // Kind segment links to list view
+      const kindLink = screen.getByTestId('breadcrumb-kind');
+      expect(kindLink.textContent).toBe('deployments');
+
+      // Namespace segment present
+      const nsLink = screen.getByTestId('breadcrumb-namespace');
+      expect(nsLink.textContent).toBe('default');
+
+      // Name segment is plain text
+      const nameSpan = screen.getByTestId('breadcrumb-name');
+      expect(nameSpan.textContent).toBe('my-deployment');
+      expect(nameSpan.tagName).toBe('SPAN');
+    });
+
+    it('renders breadcrumb without namespace segment for cluster-scoped resource', async () => {
+      const node = {
+        apiVersion: 'v1',
+        kind: 'Node',
+        metadata: {
+          name: 'worker-1',
+          uid: 'node-uid-1',
+          creationTimestamp: '2025-01-01T00:00:00Z',
+          resourceVersion: '55555',
+          labels: { 'node-role.kubernetes.io/worker': '' },
+          annotations: {},
+        },
+        spec: {},
+        status: {
+          conditions: [{ type: 'Ready', status: 'True', lastTransitionTime: '2025-01-01T00:00:00Z' }],
+          nodeInfo: { kubeletVersion: 'v1.30.0', operatingSystem: 'linux', architecture: 'amd64', containerRuntimeVersion: 'cri-o://1.30.0' },
+        },
+      };
+      mockK8sGet.mockResolvedValue(node);
+
+      renderDetailView({ gvrKey: 'v1/nodes', name: 'worker-1' });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('breadcrumb-kind')).toBeDefined();
+      });
+
+      // Kind segment present
+      expect(screen.getByTestId('breadcrumb-kind').textContent).toBe('nodes');
+
+      // No namespace segment
+      expect(screen.queryByTestId('breadcrumb-namespace')).toBeNull();
+
+      // Name segment present
+      expect(screen.getByTestId('breadcrumb-name').textContent).toBe('worker-1');
+    });
+
+    it('kind breadcrumb navigates to list view on click', async () => {
+      mockK8sGet.mockResolvedValue(makePod());
+
+      renderDetailView({ gvrKey: 'v1/pods', namespace: 'default', name: 'my-pod' });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('breadcrumb-kind')).toBeDefined();
+      });
+
+      fireEvent.click(screen.getByTestId('breadcrumb-kind'));
+      expect(addTabMock).toHaveBeenCalledWith(expect.objectContaining({ path: '/r/v1~pods' }));
+    });
+
+    it('namespace breadcrumb navigates to namespace-filtered list on click', async () => {
+      mockK8sGet.mockResolvedValue(makePod());
+
+      renderDetailView({ gvrKey: 'v1/pods', namespace: 'default', name: 'my-pod' });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('breadcrumb-namespace')).toBeDefined();
+      });
+
+      fireEvent.click(screen.getByTestId('breadcrumb-namespace'));
+      expect(addTabMock).toHaveBeenCalledWith(expect.objectContaining({ path: '/r/v1~pods?ns=default' }));
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Added breadcrumb navigation to DetailView: Kind / Namespace / Name
- Kind links to resource list view, namespace to filtered list
- Cluster-scoped resources omit namespace segment
- Replaces lone back button with contextual navigation

## Test plan
- [ ] Navigate to a namespaced resource detail — verify breadcrumb shows all 3 segments
- [ ] Navigate to a cluster-scoped resource — verify no namespace segment
- [ ] Click kind breadcrumb — navigates to list view
- [ ] `npx vitest --run` — all 1610 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)