### PR TITLE
feat: AlertsView and FleetView empty states with guidance

### DIFF
--- a/src/kubeview/views/AlertsView.tsx
+++ b/src/kubeview/views/AlertsView.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { Bell, AlertTriangle, XCircle, CheckCircle, Clock, Search, VolumeX, ArrowRight, Plus, Trash2, X, ExternalLink, Filter, Activity } from 'lucide-react';
+import { Bell, AlertTriangle, XCircle, CheckCircle, Clock, Search, VolumeX, ArrowRight, Plus, Trash2, X, ExternalLink, Filter, Activity, BookOpen, BellOff } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useUIStore } from '../store/uiStore';
 import { useNavigateTab } from '../hooks/useNavigateTab';
@@ -12,6 +12,7 @@ import { MetricCard } from '../components/metrics/Sparkline';
 import { CHART_COLORS } from '../engine/colors';
 import { MetricGrid } from '../components/primitives/MetricGrid';
 import { showErrorToast } from '../engine/errorToast';
+import { EmptyState } from '../components/primitives/EmptyState';
 
 interface PrometheusAlert {
   labels: Record<string, string>;
@@ -496,7 +497,11 @@ export default function AlertsView() {
         {activeTab === 'firing' && (
           <div className="space-y-2">
             {filteredAlerts.length === 0 ? (
-              <div className="text-center py-12"><CheckCircle className="w-10 h-10 text-green-500 mx-auto mb-3" /><p className="text-slate-300">{severityFilter !== 'all' ? `No ${severityFilter} alerts` : 'No alerts firing'}</p></div>
+              <EmptyState
+                icon={<Bell className="w-8 h-8" />}
+                title={severityFilter !== 'all' ? `No ${severityFilter} alerts` : 'No alerts firing'}
+                description="Your cluster is healthy — no alerts are currently firing."
+              />
             ) : groupedAlerts ? (
               // Grouped view
               groupedAlerts.map(([groupName, alerts]) => (
@@ -523,6 +528,13 @@ export default function AlertsView() {
 
         {/* Rules */}
         {activeTab === 'rules' && (
+          filteredRules.length === 0 ? (
+            <EmptyState
+              icon={<BookOpen className="w-8 h-8" />}
+              title="No alert rules found"
+              description="Alert rules are configured in Prometheus. Make sure Alertmanager is connected and accessible."
+            />
+          ) : (
           <Card>
             <div className="divide-y divide-slate-800 max-h-[500px] overflow-auto">
               {filteredRules.map((rule, idx) => (
@@ -547,6 +559,7 @@ export default function AlertsView() {
               ))}
             </div>
           </Card>
+          )
         )}
 
         {/* Silences */}
@@ -704,7 +717,11 @@ export default function AlertsView() {
 
             {/* Active Silences */}
             {activeSilences.length === 0 && !showSilenceForm ? (
-              <div className="text-center py-12"><VolumeX className="w-10 h-10 text-slate-600 mx-auto mb-3" /><p className="text-slate-400">No active silences</p></div>
+              <EmptyState
+                icon={<BellOff className="w-8 h-8" />}
+                title="No active silences"
+                description="Silences temporarily mute alerts. Create one to suppress a noisy alert during maintenance."
+              />
             ) : (
               activeSilences.map((silence) => (
                 <Card key={silence.id}>

--- a/src/kubeview/views/FleetView.tsx
+++ b/src/kubeview/views/FleetView.tsx
@@ -14,6 +14,7 @@ import { useFleetStore } from '../store/fleetStore';
 import { useNavigateTab } from '../hooks/useNavigateTab';
 import { useUIStore } from '../store/uiStore';
 import { Card } from '../components/primitives/Card';
+import { EmptyState } from '../components/primitives/EmptyState';
 import { FleetCard } from './fleet/FleetCard';
 import type { HealthScoreInput } from '../engine/healthScore';
 import { computeHealthScore } from '../engine/healthScore';
@@ -203,18 +204,26 @@ export default function FleetView() {
         </div>
 
         {/* Cluster cards grid */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-          {sortedClusters.map((cluster) => (
-            <FleetCard
-              key={cluster.id}
-              cluster={cluster}
-              onClick={() => {
-                setActiveCluster(cluster.id);
-                go('/pulse', `${cluster.name} — Pulse`);
-              }}
-            />
-          ))}
-        </div>
+        {sortedClusters.length === 0 ? (
+          <EmptyState
+            icon={<Globe className="w-8 h-8" />}
+            title="No clusters connected"
+            description="Fleet mode requires Red Hat Advanced Cluster Management (ACM) or a multi-cluster hub. Connect additional clusters to compare health, drift, and compliance across your fleet."
+          />
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+            {sortedClusters.map((cluster) => (
+              <FleetCard
+                key={cluster.id}
+                cluster={cluster}
+                onClick={() => {
+                  setActiveCluster(cluster.id);
+                  go('/pulse', `${cluster.name} — Pulse`);
+                }}
+              />
+            ))}
+          </div>
+        )}
 
         {/* Active cluster indicator */}
         <div className="text-center text-xs text-slate-600">

--- a/src/kubeview/views/__tests__/AlertsView.test.tsx
+++ b/src/kubeview/views/__tests__/AlertsView.test.tsx
@@ -323,4 +323,28 @@ describe('AlertsView', () => {
     // Form should be closed
     expect(screen.queryByText('New Silence')).toBeNull();
   });
+
+  it('shows EmptyState with guidance when firing alerts tab is empty', () => {
+    renderAlerts();
+    const firingTab = screen.getByRole('button', { name: /^Firing \(/ });
+    fireEvent.click(firingTab);
+    expect(screen.getAllByText('No alerts firing').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText(/Your cluster is healthy.*no alerts are currently firing/)).toBeDefined();
+  });
+
+  it('shows EmptyState with guidance when rules tab is empty', () => {
+    renderAlerts();
+    const rulesTab = screen.getByRole('button', { name: /^Rules \(/ });
+    fireEvent.click(rulesTab);
+    expect(screen.getByText('No alert rules found')).toBeDefined();
+    expect(screen.getByText('Alert rules are configured in Prometheus. Make sure Alertmanager is connected and accessible.')).toBeDefined();
+  });
+
+  it('shows EmptyState with guidance when silences tab is empty', () => {
+    renderAlerts();
+    const silencesTab = screen.getByRole('button', { name: /^Silences \(/ });
+    fireEvent.click(silencesTab);
+    expect(screen.getByText('No active silences')).toBeDefined();
+    expect(screen.getByText('Silences temporarily mute alerts. Create one to suppress a noisy alert during maintenance.')).toBeDefined();
+  });
 });

--- a/src/kubeview/views/__tests__/FleetView.test.tsx
+++ b/src/kubeview/views/__tests__/FleetView.test.tsx
@@ -1,6 +1,43 @@
-import { describe, it, expect } from 'vitest';
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import React from 'react';
 import fs from 'fs';
 import path from 'path';
+
+const mockFleetState: Record<string, any> = {
+  fleetMode: 'multi',
+  clusters: [],
+  activeClusterId: 'local',
+  acmAvailable: false,
+  acmDetecting: false,
+  setActiveCluster: vi.fn(),
+  refreshAllHealth: vi.fn(),
+  detectACM: vi.fn(),
+};
+
+vi.mock('../../store/fleetStore', () => ({
+  useFleetStore: (sel?: (s: any) => any) => sel ? sel(mockFleetState) : mockFleetState,
+}));
+
+vi.mock('../../store/uiStore', () => ({
+  useUIStore: Object.assign(
+    (sel: (s: any) => any) => sel({ addToast: vi.fn() }),
+    { getState: () => ({}) },
+  ),
+}));
+
+vi.mock('../../hooks/useNavigateTab', () => ({
+  useNavigateTab: () => vi.fn(),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+
+import FleetView from '../FleetView';
 
 describe('FleetView navigation links', () => {
   const source = fs.readFileSync(
@@ -32,5 +69,21 @@ describe('FleetView navigation links', () => {
     expect(source).toContain('Bell');
     expect(source).toContain('GitCompare');
     expect(source).toContain('Box');
+  });
+});
+
+describe('FleetView empty state', () => {
+  it('shows "No clusters connected" EmptyState when clusters array is empty in multi-cluster mode', () => {
+    mockFleetState.fleetMode = 'multi';
+    mockFleetState.clusters = [];
+
+    render(
+      <MemoryRouter>
+        <FleetView />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('No clusters connected')).toBeDefined();
+    expect(screen.getByText(/Fleet mode requires Red Hat Advanced Cluster Management/)).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary
- AlertsView: Added EmptyState for firing alerts, rules, and silences tabs with contextual guidance
- FleetView: Added EmptyState when no clusters connected with ACM guidance

## Test plan
- [ ] View AlertsView with no firing alerts — verify "No alerts firing" empty state
- [ ] View AlertsView rules tab with no rules — verify Prometheus guidance
- [ ] View FleetView with no clusters — verify "No clusters connected" guidance
- [ ] `npx vitest --run` — all 1610 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)