### PR TITLE
fix: show disabled RBAC buttons with tooltips instead of hiding

### DIFF
--- a/src/kubeview/components/metrics/__tests__/sparkline.test.ts
+++ b/src/kubeview/components/metrics/__tests__/sparkline.test.ts
@@ -61,9 +61,10 @@ describe('RBAC integration in TableView', () => {
     expect(source).toContain('{canCreate &&');
   });
 
-  it('hides Delete button when user lacks delete permission', () => {
+  it('disables Delete button when user lacks delete permission', () => {
     const source = fs.readFileSync(path.join(SRC, 'views/TableView.tsx'), 'utf-8');
-    expect(source).toContain('{canDelete &&');
+    expect(source).toContain('No delete permission');
+    expect(source).toContain('disabled={!canDelete');
   });
 
   it('disables Edit YAML when user lacks update permission', () => {

--- a/src/kubeview/components/primitives/ActionMenu.tsx
+++ b/src/kubeview/components/primitives/ActionMenu.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { cn } from '@/lib/utils';
 import { MoreHorizontal } from 'lucide-react';
 
-export type ActionMenuItem = { icon: React.ReactNode; label: string; onClick: () => void; danger?: boolean } | 'separator' | null;
+export type ActionMenuItem = { icon: React.ReactNode; label: string; onClick: () => void; danger?: boolean; disabled?: boolean; title?: string } | 'separator' | null;
 
 export function ActionMenu({ items }: { items: ActionMenuItem[] }) {
   const [open, setOpen] = React.useState(false);
@@ -27,9 +27,11 @@ export function ActionMenu({ items }: { items: ActionMenuItem[] }) {
                 <button
                   key={i}
                   onClick={() => { setOpen(false); item.onClick(); }}
+                  disabled={item.disabled}
+                  title={item.title}
                   className={cn(
-                    'w-full px-3 py-2 text-left text-sm flex items-center gap-2.5 transition-colors hover:bg-slate-700',
-                    item.danger ? 'text-red-400' : 'text-slate-300'
+                    'w-full px-3 py-2 text-left text-sm flex items-center gap-2.5 transition-colors',
+                    item.disabled ? 'text-slate-600 cursor-not-allowed' : item.danger ? 'text-red-400 hover:bg-slate-700' : 'text-slate-300 hover:bg-slate-700'
                   )}
                 >
                   {item.icon}

--- a/src/kubeview/views/DetailView.tsx
+++ b/src/kubeview/views/DetailView.tsx
@@ -53,6 +53,7 @@ import { ArgoSyncBadge } from '../components/ArgoSyncBadge';
 import { GitOpsInfoCard } from '../components/GitOpsInfoCard';
 import { ResourceHistoryPanel } from './argocd/ResourceHistoryPanel';
 import { useArgoSyncInfo } from '../hooks/useArgoCD';
+import { useCanI } from '../hooks/useCanI';
 
 interface DetailViewProps {
   gvrKey: string;
@@ -72,6 +73,11 @@ export default function DetailView({ gvrKey, namespace, name }: DetailViewProps)
   const gvrUrl = gvrKey.replace(/\//g, '~');
   const gvrParts = gvrKey.split('/');
   const resourcePlural = gvrParts[gvrParts.length - 1];
+  const resourceGroup = gvrParts.length === 3 ? gvrParts[0] : '';
+
+  // RBAC permission checks
+  const { allowed: canDelete } = useCanI('delete', resourceGroup, resourcePlural, namespace);
+  const { allowed: canUpdate } = useCanI('update', resourceGroup, resourcePlural, namespace);
 
   // Build API path for this specific resource
   const apiPath = React.useMemo(
@@ -445,20 +451,27 @@ export default function DetailView({ gvrKey, namespace, name }: DetailViewProps)
               </>
             )}
             {isScalable && (
-              <div className="flex items-center gap-0.5 px-1 py-0.5 rounded bg-slate-800/50">
-                <button onClick={() => handleScale(-1)} disabled={!!actionLoading} className="px-1.5 py-1 text-slate-400 rounded hover:bg-slate-700 hover:text-slate-200 transition-colors disabled:opacity-30">
+              <div className="flex items-center gap-0.5 px-1 py-0.5 rounded bg-slate-800/50" title={canUpdate ? undefined : 'No update permission'}>
+                <button onClick={() => handleScale(-1)} disabled={!canUpdate || !!actionLoading} className={cn('px-1.5 py-1 rounded transition-colors disabled:opacity-30', canUpdate ? 'text-slate-400 hover:bg-slate-700 hover:text-slate-200' : 'text-slate-700 cursor-not-allowed')}>
                   <Minus className="w-3 h-3" />
                 </button>
                 <span className={cn('px-2 py-0.5 text-xs font-mono text-slate-300', actionLoading === 'scale' && 'animate-pulse')}>
                   {(resource.spec as Deployment['spec'])?.replicas ?? 0}
                 </span>
-                <button onClick={() => handleScale(1)} disabled={!!actionLoading} className="px-1.5 py-1 text-slate-400 rounded hover:bg-slate-700 hover:text-slate-200 transition-colors disabled:opacity-30">
+                <button onClick={() => handleScale(1)} disabled={!canUpdate || !!actionLoading} className={cn('px-1.5 py-1 rounded transition-colors disabled:opacity-30', canUpdate ? 'text-slate-400 hover:bg-slate-700 hover:text-slate-200' : 'text-slate-700 cursor-not-allowed')}>
                   <Plus className="w-3 h-3" />
                 </button>
               </div>
             )}
             {isRestartable && (
-              <button onClick={handleRestart} disabled={!!actionLoading} className="px-2.5 py-1.5 text-xs text-slate-400 rounded hover:bg-slate-800 hover:text-orange-400 flex items-center gap-1.5 transition-colors disabled:opacity-50">
+              <button
+                onClick={handleRestart}
+                disabled={!canUpdate || !!actionLoading}
+                className={cn('px-2.5 py-1.5 text-xs rounded flex items-center gap-1.5 transition-colors disabled:opacity-50',
+                  canUpdate ? 'text-slate-400 hover:bg-slate-800 hover:text-orange-400' : 'text-slate-700 cursor-not-allowed'
+                )}
+                title={canUpdate ? 'Restart rollout' : 'No update permission'}
+              >
                 <RotateCw className={cn('w-3.5 h-3.5', actionLoading === 'restart' && 'animate-spin')} /> {actionLoading === 'restart' ? 'Restarting...' : 'Restart'}
               </button>
             )}
@@ -473,7 +486,7 @@ export default function DetailView({ gvrKey, namespace, name }: DetailViewProps)
                 { icon: <Activity className="w-3.5 h-3.5" />, label: 'Metrics', onClick: handleViewMetrics },
                 namespace ? { icon: <GitBranch className="w-3.5 h-3.5" />, label: 'Dependencies', onClick: () => go(`/deps/${gvrUrl}/${namespace}/${name}`, `${name} (Deps)`) } : null,
                 'separator',
-                { icon: <Trash2 className="w-3.5 h-3.5 text-red-400" />, label: 'Delete', onClick: () => setShowDeleteConfirm(true), danger: true },
+                { icon: <Trash2 className={cn('w-3.5 h-3.5', canDelete ? 'text-red-400' : 'text-slate-600')} />, label: canDelete ? 'Delete' : 'Delete (no permission)', onClick: () => setShowDeleteConfirm(true), danger: canDelete, disabled: !canDelete, title: canDelete ? undefined : 'No delete permission' },
               ]}
             />
           </div>

--- a/src/kubeview/views/TableView.tsx
+++ b/src/kubeview/views/TableView.tsx
@@ -551,7 +551,11 @@ export default function TableView({ gvrKey, namespace: namespaceProp }: TableVie
               <div className="flex items-center gap-2 mr-4">
                 <button
                   onClick={() => setShowBulkDeleteConfirm(true)}
-                  className="px-3 py-1.5 text-xs bg-red-600 text-white rounded hover:bg-red-700 flex items-center gap-1.5"
+                  disabled={!canDelete}
+                  className={cn('px-3 py-1.5 text-xs text-white rounded flex items-center gap-1.5',
+                    canDelete ? 'bg-red-600 hover:bg-red-700' : 'bg-slate-700 cursor-not-allowed opacity-50'
+                  )}
+                  title={canDelete ? `Delete ${selectedRows.size} selected` : 'No delete permission'}
                 >
                   <Trash2 className="w-3 h-3" />
                   Delete {selectedRows.size}
@@ -819,16 +823,18 @@ export default function TableView({ gvrKey, namespace: namespaceProp }: TableVie
                         >
                           <FileEdit className="w-3.5 h-3.5" />
                         </button>
-                        {canDelete && <button
+                        <button
                           onClick={(e) => { e.stopPropagation(); handleAction('delete-single', { resource }); }}
-                          disabled={inlineActionLoading === `${resource.metadata.uid}-delete-single`}
-                          className="inline-flex items-center px-1.5 py-1 text-xs text-slate-500 rounded hover:bg-red-900/50 hover:text-red-400 transition-colors disabled:opacity-50"
-                          title="Delete"
+                          disabled={!canDelete || inlineActionLoading === `${resource.metadata.uid}-delete-single`}
+                          className={cn('inline-flex items-center px-1.5 py-1 text-xs rounded transition-colors disabled:opacity-50',
+                            canDelete ? 'text-slate-500 hover:bg-red-900/50 hover:text-red-400' : 'text-slate-700 cursor-not-allowed'
+                          )}
+                          title={canDelete ? 'Delete' : 'No delete permission'}
                         >
                           {inlineActionLoading === `${resource.metadata.uid}-delete-single`
                             ? <Loader2 className="w-3.5 h-3.5 animate-spin" />
                             : <Trash2 className="w-3.5 h-3.5" />}
-                        </button>}
+                        </button>
                       </div>
                     </td>
                   </tr>

--- a/src/kubeview/views/__tests__/DetailViewRBAC.test.tsx
+++ b/src/kubeview/views/__tests__/DetailViewRBAC.test.tsx
@@ -1,0 +1,196 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+// ---- Mocks ----
+
+const navigateMock = vi.fn();
+const addTabMock = vi.fn();
+const addToastMock = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
+vi.mock('../../store/uiStore', () => ({
+  useUIStore: (selector: any) => {
+    const state = {
+      addToast: addToastMock,
+      addTab: addTabMock,
+      selectedNamespace: 'default',
+      setDockContext: vi.fn(),
+    };
+    return selector(state);
+  },
+}));
+
+vi.mock('../../store/clusterStore', () => ({
+  useClusterStore: (selector: any) => {
+    const state = { resourceRegistry: new Map() };
+    return selector(state);
+  },
+}));
+
+const mockK8sGet = vi.fn();
+const mockK8sList = vi.fn();
+
+vi.mock('../../engine/query', () => ({
+  k8sGet: (...args: any[]) => mockK8sGet(...args),
+  k8sList: (...args: any[]) => mockK8sList(...args),
+  k8sDelete: vi.fn().mockResolvedValue({}),
+  k8sPatch: vi.fn().mockResolvedValue({}),
+  sanitizePromQL: (v: string) => v.replace(/[^a-zA-Z0-9_\-./]/g, ''),
+}));
+
+vi.mock('../../engine/favorites', () => ({
+  toggleFavorite: vi.fn(() => true),
+  isFavorite: vi.fn(() => false),
+}));
+
+vi.mock('../../components/metrics/prometheus', () => ({
+  queryInstant: vi.fn().mockResolvedValue([]),
+  queryRange: vi.fn().mockResolvedValue([]),
+  getTimeRange: vi.fn().mockReturnValue([0, 1]),
+}));
+
+vi.mock('../../components/metrics/Sparkline', () => ({
+  MetricCard: ({ title }: { title: string }) => <div data-testid="metric-card">{title}</div>,
+  Sparkline: () => <div data-testid="sparkline" />,
+}));
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...args: any[]) => args.filter(Boolean).join(' '),
+}));
+
+vi.mock('../../components/PodTerminal', () => ({
+  default: ({ onClose }: any) => <div data-testid="pod-terminal"><button onClick={onClose}>Close Terminal</button></div>,
+}));
+
+vi.mock('../../components/DataEditor', () => ({
+  default: () => <div data-testid="data-editor">DataEditor</div>,
+}));
+
+vi.mock('../../components/DeployProgress', () => ({
+  default: () => <div data-testid="deploy-progress">DeployProgress</div>,
+}));
+
+// RBAC: deny both delete and update
+vi.mock('../../hooks/useCanI', () => ({
+  useCanI: () => ({ allowed: false, isLoading: false }),
+  useCanDelete: () => ({ allowed: false, isLoading: false }),
+  useCanCreate: () => ({ allowed: false, isLoading: false }),
+  useCanUpdate: () => ({ allowed: false, isLoading: false }),
+}));
+
+import DetailView from '../DetailView';
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+}
+
+function makeDeployment() {
+  return {
+    apiVersion: 'apps/v1',
+    kind: 'Deployment',
+    metadata: {
+      name: 'my-deployment',
+      namespace: 'default',
+      uid: 'deploy-uid-123',
+      creationTimestamp: '2025-01-01T00:00:00Z',
+      resourceVersion: '99999',
+      labels: { app: 'web' },
+      annotations: {},
+    },
+    spec: {
+      replicas: 3,
+      selector: { matchLabels: { app: 'web' } },
+      template: { metadata: { labels: { app: 'web' } }, spec: { containers: [{ name: 'web', image: 'nginx' }] } },
+    },
+    status: {
+      availableReplicas: 3,
+      readyReplicas: 3,
+      replicas: 3,
+      conditions: [
+        { type: 'Available', status: 'True', reason: 'MinimumReplicasAvailable', lastTransitionTime: '2025-01-01T00:00:00Z' },
+      ],
+    },
+  };
+}
+
+function renderDetailView(props: { gvrKey: string; namespace?: string; name: string }) {
+  const qc = makeQueryClient();
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <DetailView {...props} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('DetailView RBAC disabled buttons', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockK8sList.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shows scale controls as disabled when canUpdate is false', async () => {
+    mockK8sGet.mockResolvedValue(makeDeployment());
+
+    renderDetailView({ gvrKey: 'apps/v1/deployments', namespace: 'default', name: 'my-deployment' });
+
+    await waitFor(() => {
+      expect(screen.getAllByText('my-deployment').length).toBeGreaterThanOrEqual(1);
+    });
+
+    // Multiple elements may have "No update permission" (scale container + restart button)
+    const noPermElements = screen.getAllByTitle('No update permission');
+    expect(noPermElements.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows restart button as disabled with tooltip when canUpdate is false', async () => {
+    mockK8sGet.mockResolvedValue(makeDeployment());
+
+    renderDetailView({ gvrKey: 'apps/v1/deployments', namespace: 'default', name: 'my-deployment' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Restart')).toBeDefined();
+    });
+
+    // The restart button itself should be disabled
+    const restartBtn = screen.getByText('Restart').closest('button');
+    expect(restartBtn).toHaveProperty('disabled', true);
+    expect(restartBtn?.getAttribute('title')).toBe('No update permission');
+  });
+
+  it('shows delete menu item as disabled with tooltip when canDelete is false', async () => {
+    mockK8sGet.mockResolvedValue(makeDeployment());
+
+    renderDetailView({ gvrKey: 'apps/v1/deployments', namespace: 'default', name: 'my-deployment' });
+
+    await waitFor(() => {
+      expect(screen.getAllByText('my-deployment').length).toBeGreaterThanOrEqual(1);
+    });
+
+    // Open the more actions menu
+    const moreButton = screen.getByTitle('More actions');
+    fireEvent.click(moreButton);
+
+    // Delete menu item should show "no permission" text
+    const deleteItem = screen.getByText('Delete (no permission)');
+    expect(deleteItem).toBeDefined();
+
+    // Should be disabled
+    const deleteBtn = deleteItem.closest('button');
+    expect(deleteBtn).toHaveProperty('disabled', true);
+  });
+});

--- a/src/kubeview/views/__tests__/TableViewRBAC.test.tsx
+++ b/src/kubeview/views/__tests__/TableViewRBAC.test.tsx
@@ -1,0 +1,194 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import React from 'react';
+
+// --- Mocks ---
+
+const navigateMock = vi.fn();
+const addTabMock = vi.fn();
+const addToastMock = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
+vi.mock('../../store/uiStore', () => ({
+  useUIStore: Object.assign(
+    (selector: any) => {
+      const state = {
+        selectedNamespace: '*',
+        addTab: addTabMock,
+        addToast: addToastMock,
+        setConnectionStatus: vi.fn(),
+      };
+      return selector(state);
+    },
+    {
+      getState: () => ({
+        setSelectedNamespace: vi.fn(),
+      }),
+    },
+  ),
+}));
+
+vi.mock('../../store/clusterStore', () => ({
+  useClusterStore: (selector: any) => {
+    const state = { resourceRegistry: null };
+    return selector(state);
+  },
+}));
+
+const _mockWatchResult: { data: any[]; isLoading: boolean; error: Error | null } = {
+  data: [],
+  isLoading: false,
+  error: null,
+};
+
+vi.mock('../../hooks/useK8sListWatch', () => ({
+  useK8sListWatch: () => _mockWatchResult,
+}));
+
+vi.mock('../../engine/query', () => ({
+  k8sPatch: vi.fn().mockResolvedValue({}),
+  k8sDelete: vi.fn().mockResolvedValue({}),
+  k8sList: vi.fn().mockResolvedValue([]),
+}));
+
+// RBAC: deny delete, allow update and create
+vi.mock('../../hooks/useCanI', () => ({
+  useCanI: (verb: string) => ({
+    allowed: verb !== 'delete',
+    isLoading: false,
+  }),
+  useCanDelete: () => ({ allowed: false, isLoading: false }),
+  useCanCreate: () => ({ allowed: true, isLoading: false }),
+  useCanUpdate: () => ({ allowed: true, isLoading: false }),
+}));
+
+vi.mock('../../hooks/useResourceUrl', () => ({
+  buildApiPathFromResource: (r: any) =>
+    `/api/v1/namespaces/${r.metadata?.namespace ?? 'default'}/${r.kind?.toLowerCase() ?? 'resources'}/${r.metadata?.name ?? 'unknown'}`,
+}));
+
+vi.mock('../../engine/yamlUtils', () => ({
+  jsonToYaml: (obj: any) => JSON.stringify(obj, null, 2),
+}));
+
+vi.mock('../../components/feedback/ConfirmDialog', () => ({
+  ConfirmDialog: ({ open, title, onConfirm, onClose }: any) =>
+    open ? (
+      <div data-testid="confirm-dialog">
+        <span>{title}</span>
+        <button onClick={onConfirm}>Confirm</button>
+        <button onClick={onClose}>Cancel</button>
+      </div>
+    ) : null,
+}));
+
+vi.mock('../../components/DeployProgress', () => ({
+  default: () => <div data-testid="deploy-progress" />,
+}));
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...args: any[]) => args.filter(Boolean).join(' '),
+}));
+
+import TableView from '../TableView';
+
+function makePodResource(name: string, namespace = 'default') {
+  return {
+    apiVersion: 'v1',
+    kind: 'Pod',
+    metadata: {
+      name,
+      namespace,
+      uid: `uid-${name}`,
+      creationTimestamp: '2025-01-01T00:00:00Z',
+      labels: {},
+    },
+    spec: {},
+    status: { phase: 'Running', containerStatuses: [{ name: 'main', ready: true, restartCount: 0, state: { running: {} } }] },
+  };
+}
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+}
+
+function renderTable(gvrKey = 'v1/pods') {
+  const queryClient = createQueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <TableView gvrKey={gvrKey} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('TableView RBAC disabled buttons', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _mockWatchResult.data = [makePodResource('test-pod')];
+    _mockWatchResult.isLoading = false;
+    _mockWatchResult.error = null;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders delete button even when canDelete is false', () => {
+    renderTable('v1/pods');
+
+    const deleteButton = screen.getByTitle('No delete permission');
+    expect(deleteButton).toBeDefined();
+    expect(deleteButton.tagName).toBe('BUTTON');
+  });
+
+  it('delete button is disabled when canDelete is false', () => {
+    renderTable('v1/pods');
+
+    const deleteButton = screen.getByTitle('No delete permission');
+    expect(deleteButton).toHaveProperty('disabled', true);
+  });
+
+  it('delete button tooltip says "No delete permission"', () => {
+    renderTable('v1/pods');
+
+    const deleteButton = screen.getByTitle('No delete permission');
+    expect(deleteButton.getAttribute('title')).toBe('No delete permission');
+  });
+
+  it('bulk delete button is disabled when canDelete is false', () => {
+    _mockWatchResult.data = [makePodResource('pod-a'), makePodResource('pod-b')];
+    renderTable('v1/pods');
+
+    // Select all
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[0]);
+
+    // Bulk delete should appear but be disabled
+    const bulkDeleteBtn = screen.getByText('Delete 2');
+    expect(bulkDeleteBtn.closest('button')).toHaveProperty('disabled', true);
+  });
+
+  it('bulk delete button tooltip says "No delete permission"', () => {
+    _mockWatchResult.data = [makePodResource('pod-a'), makePodResource('pod-b')];
+    renderTable('v1/pods');
+
+    // Select all
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[0]);
+
+    // The bulk delete button should have the tooltip
+    const bulkDeleteBtn = screen.getByText('Delete 2').closest('button');
+    expect(bulkDeleteBtn?.getAttribute('title')).toBe('No delete permission');
+  });
+});


### PR DESCRIPTION
## Summary
- Disabled buttons now show with tooltip explaining missing permission instead of being hidden
- TableView: delete button visible but disabled with "No delete permission" tooltip
- DetailView: scale/restart buttons disabled with RBAC tooltips
- Follows existing pattern from YAML edit button

## Test plan
- [ ] View resource without delete permission — button visible but disabled with tooltip
- [ ] View deployment without update permission — scale/restart disabled with tooltip
- [ ] `npx vitest --run` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)