### PR TITLE
fix: LogsView empty state with troubleshooting guidance

### DIFF
--- a/src/kubeview/views/LogsView.tsx
+++ b/src/kubeview/views/LogsView.tsx
@@ -1,10 +1,12 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { cn } from '@/lib/utils';
+import { FileX } from 'lucide-react';
 import LogStream from '../components/logs/LogStream';
 import MultiContainerLogs from '../components/logs/MultiContainerLogs';
 import MultiPodLogs from '../components/logs/MultiPodLogs';
+import { EmptyState } from '../components/primitives/EmptyState';
 import { useK8sListWatch } from '../hooks/useK8sListWatch';
 
 interface LogsViewProps {
@@ -70,6 +72,7 @@ function BuildLogsView({ namespace, buildName }: { namespace: string; buildName:
 function WorkloadLogsView({ namespace, name, selector, kind }: {
   namespace: string; name: string; selector: string; kind: string;
 }) {
+  const navigate = useNavigate();
   const [selectedPod, setSelectedPod] = useState<string | null>(null);
 
   // Watch pods by label selector
@@ -127,7 +130,13 @@ function WorkloadLogsView({ namespace, name, selector, kind }: {
         ) : podNames.length > 0 ? (
           <MultiPodLogs namespace={namespace} podNames={podNames} />
         ) : (
-          <div className="flex items-center justify-center h-full text-slate-500 text-sm">No pods found</div>
+          <EmptyState
+            icon={<FileX className="w-8 h-8" />}
+            title="No pods found"
+            description="No pods match the label selector for this workload. The workload may be scaled to zero, or the label selector may not match any running pods. Check the replica count and selector labels."
+            action={{ label: 'Back to workload', onClick: () => navigate(-1) }}
+            className="h-full"
+          />
         )}
       </div>
     </div>

--- a/src/kubeview/views/__tests__/LogsView.test.tsx
+++ b/src/kubeview/views/__tests__/LogsView.test.tsx
@@ -1,16 +1,18 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 import React from 'react';
 
+const mockNavigate = vi.fn();
+let mockSearchParams = new URLSearchParams();
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom');
   return {
     ...actual,
-    useNavigate: () => vi.fn(),
-    useSearchParams: () => [new URLSearchParams()],
+    useNavigate: () => mockNavigate,
+    useSearchParams: () => [mockSearchParams],
   };
 });
 
@@ -59,6 +61,8 @@ describe('LogsView', () => {
   afterEach(() => {
     cleanup();
     mockPodQueryResult = { data: undefined, isLoading: false, error: null };
+    mockSearchParams = new URLSearchParams();
+    mockNavigate.mockReset();
   });
 
   it('renders heading with pod name and namespace', () => {
@@ -114,5 +118,22 @@ describe('LogsView', () => {
     mockPodQueryResult = { data: undefined, isLoading: true, error: null };
     const { container } = renderView({ namespace: 'default', podName: 'my-pod' });
     expect(container.querySelector('.kv-skeleton')).toBeDefined();
+  });
+
+  it('shows EmptyState with guidance when workload has no pods', () => {
+    mockSearchParams = new URLSearchParams({ selector: 'app=nginx', kind: 'Deployment' });
+    renderView({ namespace: 'default', podName: 'nginx' });
+    expect(screen.getByText('No pods found')).toBeDefined();
+    expect(screen.getByText(/scaled to zero/)).toBeDefined();
+    expect(screen.getByText(/label selector/)).toBeDefined();
+  });
+
+  it('shows Back to workload button that navigates back', () => {
+    mockSearchParams = new URLSearchParams({ selector: 'app=nginx', kind: 'Deployment' });
+    renderView({ namespace: 'default', podName: 'nginx' });
+    const backButton = screen.getByText('Back to workload');
+    expect(backButton).toBeDefined();
+    fireEvent.click(backButton);
+    expect(mockNavigate).toHaveBeenCalledWith(-1);
   });
 });


### PR DESCRIPTION
## Summary
- Replaced bare "No pods found" text with EmptyState component
- Added troubleshooting guidance about label selectors and scaling
- Added "Back to workload" action button

## Test plan
- [ ] View workload logs with no matching pods — verify guidance text
- [ ] Click "Back to workload" — navigates back
- [ ] `npx vitest --run` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)