### PR TITLE
fix: WelcomeView cluster error recovery with retry and guidance

### DIFF
--- a/src/kubeview/views/WelcomeView.tsx
+++ b/src/kubeview/views/WelcomeView.tsx
@@ -3,11 +3,12 @@ import {
   ArrowRight, Shield, Bell, Settings,
   HardDrive, Package, Globe, Server, Puzzle, Users, Hammer,
   CheckCircle, XCircle, GitBranch, Clock, ChevronDown,
-  Github, HeartPulse, Search, AlertCircle,
+  Github, HeartPulse, Search, AlertCircle, RefreshCw,
   FileCode, History, GitGraph, ScrollText, Camera,
   Diff, Monitor, Terminal, Bot,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { useQueryClient } from '@tanstack/react-query';
 import { useUIStore } from '../store/uiStore';
 import { MetricGrid } from '../components/primitives/MetricGrid';
 import { useNavigateTab } from '../hooks/useNavigateTab';
@@ -23,6 +24,7 @@ export default function WelcomeView() {
   const openCommandPalette = useUIStore((s) => s.openCommandPalette);
   const connectionStatus = useUIStore((s) => s.connectionStatus);
   const go = useNavigateTab();
+  const queryClient = useQueryClient();
 
   const { data: nodes = [], isLoading: nodesLoading, isError: nodesError } = useK8sListWatch({ apiPath: '/api/v1/nodes' });
 
@@ -71,6 +73,8 @@ export default function WelcomeView() {
                 readyCount={readyCount}
                 isLoading={nodesLoading}
                 isError={nodesError}
+                onRetry={() => queryClient.invalidateQueries({ queryKey: ['k8s'] })}
+                onGoAdmin={() => go('/admin', 'Administration')}
               />
             </div>
           </div>
@@ -212,16 +216,40 @@ export default function WelcomeView() {
 
 /* ── Sub-components ── */
 
-function ClusterStatusPill({ isConnected, connectionStatus, nodeCount, readyCount, isLoading, isError }: {
+function ClusterStatusPill({ isConnected, connectionStatus, nodeCount, readyCount, isLoading, isError, onRetry, onGoAdmin }: {
   isConnected: boolean; connectionStatus: string; nodeCount: number; readyCount: number; isLoading: boolean; isError?: boolean;
+  onRetry?: () => void; onGoAdmin?: () => void;
 }) {
   // #8 error state
   if (isError && !isLoading) {
     return (
-      <span role="status" aria-live="polite" className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-red-950/30 border border-red-900/40 text-xs text-red-400">
-        <AlertCircle className="w-3 h-3" aria-hidden="true" />
-        Unable to reach cluster API
-      </span>
+      <div className="flex flex-col items-center gap-2">
+        <span role="status" aria-live="polite" className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-red-950/30 border border-red-900/40 text-xs text-red-400">
+          <AlertCircle className="w-3 h-3" aria-hidden="true" />
+          Unable to reach cluster API
+        </span>
+        <p className="text-xs text-slate-500">Make sure <code className="px-1 py-0.5 bg-slate-800 rounded text-slate-400">oc proxy --port=8001</code> is running</p>
+        <div className="flex items-center gap-2">
+          {onRetry && (
+            <button
+              onClick={onRetry}
+              className="inline-flex items-center gap-1.5 px-3 py-1 rounded-md bg-blue-600 hover:bg-blue-500 text-xs font-medium text-white transition-colors"
+            >
+              <RefreshCw className="w-3 h-3" aria-hidden="true" />
+              Retry
+            </button>
+          )}
+          {onGoAdmin && (
+            <button
+              onClick={onGoAdmin}
+              className="inline-flex items-center gap-1.5 px-3 py-1 rounded-md bg-slate-800 hover:bg-slate-700 text-xs font-medium text-slate-300 transition-colors"
+            >
+              <Settings className="w-3 h-3" aria-hidden="true" />
+              Administration
+            </button>
+          )}
+        </div>
+      </div>
     );
   }
   if (isLoading) {

--- a/src/kubeview/views/__tests__/WelcomeView.test.tsx
+++ b/src/kubeview/views/__tests__/WelcomeView.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -17,13 +17,21 @@ vi.mock('../../store/uiStore', () => ({
   }),
 }));
 vi.mock('../../hooks/useNavigateTab', () => ({ useNavigateTab: () => vi.fn() }));
+
+/** Shared mock data — can be overridden per-test via _mockListWatchData */
+const _mockListWatchData: Record<string, { data?: any[]; isLoading?: boolean; isError?: boolean }> = {};
+
 vi.mock('../../hooks/useK8sListWatch', () => ({
   useK8sListWatch: ({ apiPath }: { apiPath: string }) => {
+    // Allow per-test overrides
+    if (apiPath.includes('nodes') && _mockListWatchData.nodes) {
+      return { data: _mockListWatchData.nodes.data ?? [], isLoading: _mockListWatchData.nodes.isLoading ?? false, isError: _mockListWatchData.nodes.isError ?? false };
+    }
     if (apiPath.includes('nodes')) return { data: [
       { metadata: { name: 'node-1' }, status: { conditions: [{ type: 'Ready', status: 'True' }] } },
       { metadata: { name: 'node-2' }, status: { conditions: [{ type: 'Ready', status: 'True' }] } },
-    ], isLoading: false };
-    return { data: [], isLoading: false };
+    ], isLoading: false, isError: false };
+    return { data: [], isLoading: false, isError: false };
   },
 }));
 
@@ -132,5 +140,29 @@ describe('WelcomeView', () => {
     expect(screen.getByText(/^v\d+\.\d+\.\d+$/)).toBeDefined();
     const link = screen.getByText('GitHub').closest('a');
     expect(link?.getAttribute('href')).toBe('https://github.com/alimobrem/OpenshiftPulse');
+  });
+
+  describe('cluster error recovery', () => {
+    afterEach(() => {
+      delete _mockListWatchData.nodes;
+    });
+
+    it('shows retry button, hint text, and admin link when cluster API is unreachable', () => {
+      _mockListWatchData.nodes = { data: [], isLoading: false, isError: true };
+      renderView();
+      expect(screen.getByText('Unable to reach cluster API')).toBeDefined();
+      expect(screen.getByText(/oc proxy --port=8001/)).toBeDefined();
+      expect(screen.getByText('Retry')).toBeDefined();
+      expect(screen.getAllByText('Administration').length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('clicking Retry calls invalidateQueries', () => {
+      _mockListWatchData.nodes = { data: [], isLoading: false, isError: true };
+      renderView();
+      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+      fireEvent.click(screen.getByText('Retry'));
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['k8s'] });
+      invalidateSpy.mockRestore();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- When cluster API is unreachable, error state now shows actionable recovery options
- Added "Retry" button that re-fetches cluster data
- Added hint: "Make sure oc proxy --port=8001 is running"
- Added link to Administration view for connection settings

## Test plan
- [ ] Disconnect oc proxy — verify error state shows retry and guidance
- [ ] Click Retry — verify re-fetch attempt
- [ ] `npx vitest --run` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)