### PR TITLE
fix: replace 8 silent catch blocks with proper error surfacing

### DIFF
--- a/src/kubeview/__tests__/silent-catch-blocks.test.ts
+++ b/src/kubeview/__tests__/silent-catch-blocks.test.ts
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+/**
+ * Tests that previously-silent catch blocks now surface errors properly.
+ *
+ * User-facing operations → showErrorToast
+ * Internal/best-effort operations → console.warn
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock uiStore before any imports that use it
+const mockAddToast = vi.fn();
+vi.mock('../store/uiStore', () => ({
+  useUIStore: Object.assign(
+    (selector: any) =>
+      selector({
+        selectedNamespace: '*',
+        addTab: vi.fn(),
+        addToast: mockAddToast,
+        impersonateUser: '',
+        impersonateGroups: [],
+      }),
+    {
+      getState: () => ({
+        selectedNamespace: '*',
+        addTab: vi.fn(),
+        addToast: mockAddToast,
+        impersonateUser: '',
+        impersonateGroups: [],
+      }),
+      setState: vi.fn(),
+      subscribe: vi.fn(),
+      destroy: vi.fn(),
+    },
+  ),
+}));
+vi.mock('../store/errorStore', () => ({
+  useErrorStore: Object.assign(() => ({}), {
+    getState: () => ({ errors: [], trackError: vi.fn() }),
+    setState: vi.fn(),
+    subscribe: vi.fn(),
+    destroy: vi.fn(),
+  }),
+}));
+
+import { showErrorToast } from '../engine/errorToast';
+import { PulseError } from '../engine/errors';
+import { saveSnapshots, type ClusterSnapshot } from '../engine/snapshot';
+
+function makeSnapshot(overrides: Partial<ClusterSnapshot> = {}): ClusterSnapshot {
+  return {
+    id: 'snap-1',
+    label: 'test',
+    timestamp: new Date().toISOString(),
+    clusterVersion: '4.17.0',
+    platform: 'AWS',
+    controlPlaneTopology: 'HighlyAvailable',
+    nodes: { count: 6, versions: ['v1.30.0'] },
+    clusterOperators: [],
+    crds: [],
+    storageClasses: [],
+    namespaceCount: 10,
+    ...overrides,
+  };
+}
+
+describe('silent catch block fixes', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockAddToast.mockClear();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  describe('showErrorToast (user-facing)', () => {
+    it('fires toast for user-facing errors', () => {
+      showErrorToast(new Error('network failure'), 'Failed to load Helm chart');
+      expect(mockAddToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          title: 'Failed to load Helm chart',
+          detail: 'network failure',
+        }),
+      );
+    });
+
+    it('fires toast for OperatorCatalog non-409 errors', () => {
+      // Simulate what the OperatorCatalogView catch block does for non-409
+      const err = new PulseError({
+        message: 'forbidden',
+        category: 'permission',
+        statusCode: 403,
+        context: { operation: 'create' },
+        userMessage: 'Forbidden',
+        suggestions: [],
+      });
+      if (!(err instanceof PulseError && err.statusCode === 409)) {
+        showErrorToast(err, 'Failed to create namespace');
+      }
+      expect(mockAddToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          title: 'Failed to create namespace',
+        }),
+      );
+    });
+
+    it('does NOT fire toast for 409 Conflict errors', () => {
+      const err = new PulseError({
+        message: 'already exists',
+        category: 'conflict',
+        statusCode: 409,
+        context: { operation: 'create' },
+        userMessage: 'Already exists',
+        suggestions: [],
+      });
+      if (!(err instanceof PulseError && err.statusCode === 409)) {
+        showErrorToast(err, 'Failed to create namespace');
+      }
+      expect(mockAddToast).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('console.warn (internal/best-effort)', () => {
+    it('snapshot: warns on localStorage failure', () => {
+      // Force localStorage.setItem to throw
+      const origSetItem = Storage.prototype.setItem;
+      Storage.prototype.setItem = () => {
+        throw new Error('QuotaExceededError');
+      };
+      try {
+        saveSnapshots(Array.from({ length: 20 }, (_, i) => makeSnapshot({ id: `snap-${i}` })));
+        expect(warnSpy).toHaveBeenCalledWith(
+          'Failed to save snapshot to localStorage:',
+          expect.any(Error),
+        );
+      } finally {
+        Storage.prototype.setItem = origSetItem;
+      }
+    });
+  });
+});

--- a/src/kubeview/components/CommandBar.tsx
+++ b/src/kubeview/components/CommandBar.tsx
@@ -405,7 +405,7 @@ export function CommandBar() {
                         const infraData = await infraRes.json();
                         server = infraData.status?.apiServerURL || server;
                       }
-                    } catch {}
+                    } catch (err) { console.warn('Failed to detect API server URL:', err); }
                     const loginCmd = `oc login --server=${server}`;
                     try {
                       await navigator.clipboard.writeText(loginCmd);

--- a/src/kubeview/components/DeployProgress.tsx
+++ b/src/kubeview/components/DeployProgress.tsx
@@ -311,7 +311,7 @@ function PodLogs({ namespace, podName }: { namespace: string; podName: string })
           const text = await res.text();
           if (!cancelled) setLogs(text.split('\n').filter(Boolean));
         }
-      } catch {}
+      } catch (err) { console.warn('Failed to fetch pod logs:', err); }
     };
     fetchLogs();
     const interval = setInterval(fetchLogs, 3000);

--- a/src/kubeview/components/logs/LogStream.tsx
+++ b/src/kubeview/components/logs/LogStream.tsx
@@ -115,7 +115,7 @@ export default function LogStream({
               if (prevResponse.ok) {
                 response = prevResponse;
               }
-            } catch {}
+            } catch (err) { console.warn('Failed to fetch previous container logs:', err); }
           } else {
             // Current has content — parse it directly and skip re-reading
             if (mounted) {

--- a/src/kubeview/engine/snapshot.ts
+++ b/src/kubeview/engine/snapshot.ts
@@ -53,7 +53,7 @@ export function saveSnapshots(snapshots: ClusterSnapshot[]) {
     localStorage.setItem(SNAPSHOTS_KEY, JSON.stringify(trimmed));
   } catch {
     const reduced = trimmed.slice(-5);
-    try { localStorage.setItem(SNAPSHOTS_KEY, JSON.stringify(reduced)); } catch {}
+    try { localStorage.setItem(SNAPSHOTS_KEY, JSON.stringify(reduced)); } catch (err) { console.warn('Failed to save snapshot to localStorage:', err); }
   }
 }
 

--- a/src/kubeview/views/AdminView.tsx
+++ b/src/kubeview/views/AdminView.tsx
@@ -334,7 +334,7 @@ export default function AdminView() {
         const daysLeft = Math.floor((expDate.getTime() - Date.now()) / 86400000);
         return { date: expDate, daysLeft };
       }
-    } catch {}
+    } catch (err) { console.warn('Failed to parse certificate expiry:', err); }
     return null;
   }, [routerCert]);
 

--- a/src/kubeview/views/CreateView.tsx
+++ b/src/kubeview/views/CreateView.tsx
@@ -143,7 +143,7 @@ export default function CreateView({ gvrKey }: CreateViewProps) {
             schemaYaml = generateSpecFromSchema(schema);
           }
         }
-      } catch {}
+      } catch (err) { console.warn('Failed to fetch CRD schema:', err); }
     }
 
     setYaml([

--- a/src/kubeview/views/OperatorCatalogView.tsx
+++ b/src/kubeview/views/OperatorCatalogView.tsx
@@ -8,10 +8,11 @@ import {
 import { cn } from '@/lib/utils';
 import { k8sList, k8sCreate, k8sDelete, k8sGet } from '../engine/query';
 import { useUIStore } from '../store/uiStore';
+import { showErrorToast } from '../engine/errorToast';
+import { PulseError } from '../engine/errors';
 import { useNavigateTab } from '../hooks/useNavigateTab';
 import { ConfirmDialog } from '../components/feedback/ConfirmDialog';
 import { Card } from '../components/primitives/Card';
-import { showErrorToast } from '../engine/errorToast';
 
 interface PackageManifest {
   metadata: { name: string; namespace?: string };
@@ -138,7 +139,9 @@ export default function OperatorCatalogView() {
       if (ns !== 'openshift-operators') {
         try {
           await k8sCreate('/api/v1/namespaces', { apiVersion: 'v1', kind: 'Namespace', metadata: { name: ns } });
-        } catch {} // might already exist
+        } catch (err: unknown) {
+          if (!(err instanceof PulseError && err.statusCode === 409)) showErrorToast(err, 'Failed to create namespace');
+        }
       }
 
       // Create OperatorGroup if namespace is not openshift-operators (which has a global one)
@@ -150,7 +153,9 @@ export default function OperatorCatalogView() {
             metadata: { name: `${pkg.metadata.name}-group`, namespace: ns },
             spec: { targetNamespaces: [ns] },
           });
-        } catch {} // might already exist
+        } catch (err: unknown) {
+          if (!(err instanceof PulseError && err.statusCode === 409)) showErrorToast(err, 'Failed to create OperatorGroup');
+        }
       }
 
       // Create Subscription

--- a/src/kubeview/views/create/HelmTab.tsx
+++ b/src/kubeview/views/create/HelmTab.tsx
@@ -220,7 +220,7 @@ export function HelmTab() {
             const parsed = parseHelmIndex(text, repo.name, repo.url);
             allCharts.push(...parsed);
           }
-        } catch {}
+        } catch (err) { showErrorToast(err, 'Failed to load Helm chart'); }
       }
 
       return allCharts;


### PR DESCRIPTION
## Summary
- Replaced 8 empty `catch {}` blocks across the codebase
- User-facing operations (operator install, Helm chart loading) now show error toasts via `showErrorToast()`
- Internal/best-effort operations (cert parsing, localStorage, infra detection) use `console.warn()`
- OperatorCatalogView: only swallows 409 Conflict, surfaces all other errors

## Test plan
- [ ] Install operator with network error — verify toast appears
- [ ] Load Helm charts with bad repo — verify error toast
- [ ] `npx vitest --run` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)