### PR TITLE
fix: TableView filtered empty state shows total count and active filters

### DIFF
--- a/src/kubeview/views/TableView.tsx
+++ b/src/kubeview/views/TableView.tsx
@@ -752,9 +752,27 @@ export default function TableView({ gvrKey, namespace: namespaceProp }: TableVie
                 <tr>
                   <td colSpan={visibleColumns.length + 2} className="px-4 py-12 text-center">
                     <p className="text-slate-400 text-sm">
-                      No matching {resourceKind.toLowerCase()}
-                      {searchTerm && <span> for "<span className="text-slate-200">{searchTerm}</span>"</span>}
+                      0 of {stampedResources.length} {resourceKind.toLowerCase()} match your filters
                     </p>
+                    {(searchTerm || Object.values(columnFilters).some(v => v)) && (
+                      <div className="mt-1 flex flex-wrap items-center justify-center gap-2 text-xs text-slate-500">
+                        {searchTerm && (
+                          <span>
+                            Search: "<span className="text-slate-300">{searchTerm}</span>"
+                          </span>
+                        )}
+                        {Object.entries(columnFilters)
+                          .filter(([, v]) => v)
+                          .map(([colId, value]) => {
+                            const col = visibleColumns.find((c) => c.id === colId);
+                            return (
+                              <span key={colId}>
+                                {col?.header || colId}: "<span className="text-slate-300">{value}</span>"
+                              </span>
+                            );
+                          })}
+                      </div>
+                    )}
                     {(searchTerm || Object.values(columnFilters).some(v => v)) && (
                       <button
                         onClick={() => { setSearchInput(''); setSearchTerm(''); setColumnFilters({}); }}

--- a/src/kubeview/views/__tests__/TableView.test.tsx
+++ b/src/kubeview/views/__tests__/TableView.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { render, screen, fireEvent, cleanup, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 import React from 'react';
@@ -399,5 +399,74 @@ describe('TableView', () => {
     // After search filters out everything, "Clear all filters" appears in table body
     // Since debounce is async, verify the table persists structurally
     expect(document.querySelector('table')).not.toBeNull();
+  });
+
+  it('shows total count and search term when search filters out all results', () => {
+    vi.useFakeTimers();
+
+    setMockWatch({
+      data: [makePodResource('nginx'), makePodResource('redis'), makePodResource('postgres')],
+      isLoading: false,
+      error: null,
+    });
+
+    renderTable('v1/pods');
+
+    // All three pods should be visible
+    expect(screen.getByText('nginx')).toBeDefined();
+    expect(screen.getByText('redis')).toBeDefined();
+    expect(screen.getByText('postgres')).toBeDefined();
+
+    // Search for something that matches nothing
+    const searchInput = screen.getByPlaceholderText('Search...');
+    fireEvent.change(searchInput, { target: { value: 'nonexistent' } });
+
+    // Advance past the 200ms debounce
+    act(() => { vi.advanceTimersByTime(250); });
+
+    // Should show "0 of 3 pods match your filters"
+    expect(screen.getByText(/0 of 3 pods match your filters/)).toBeDefined();
+
+    // Should show the active search term
+    expect(screen.getByText('nonexistent')).toBeDefined();
+
+    // Should show "Clear all filters" button
+    expect(screen.getByText('Clear all filters')).toBeDefined();
+
+    vi.useRealTimers();
+  });
+
+  it('shows column filter values in the filtered empty state', () => {
+    vi.useFakeTimers();
+
+    setMockWatch({
+      data: [makePodResource('nginx', 'web'), makePodResource('redis', 'cache')],
+      isLoading: false,
+      error: null,
+    });
+
+    renderTable('v1/pods');
+
+    // Enable column filters by clicking the filter toggle
+    const filterToggle = screen.getByTitle('Column filters');
+    fireEvent.click(filterToggle);
+
+    // Find the Namespace column filter input and type a non-matching value
+    const namespaceFilter = screen.getByPlaceholderText('Filter Namespace...');
+    fireEvent.change(namespaceFilter, { target: { value: 'nonexistent-ns' } });
+
+    // Advance past the debounce (column filters are not debounced but search is)
+    act(() => { vi.advanceTimersByTime(50); });
+
+    // Should show "0 of 2 pods match your filters"
+    expect(screen.getByText(/0 of 2 pods match your filters/)).toBeDefined();
+
+    // Should display the column filter value
+    expect(screen.getByText('nonexistent-ns')).toBeDefined();
+
+    // Should show "Clear all filters" button
+    expect(screen.getByText('Clear all filters')).toBeDefined();
+
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary
- Shows "0 of N resources match your filters" instead of bare "No matching"
- Displays active search term and column filter values
- Keeps "Clear all filters" button

## Test plan
- [ ] Filter table with non-matching search — verify "0 of N" count
- [ ] Apply column filters — verify filter values shown
- [ ] `npx vitest --run` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)