### PR TITLE
fix: add ErrorBoundary and skeleton fallbacks for lazy components

### DIFF
--- a/src/kubeview/views/DetailView.tsx
+++ b/src/kubeview/views/DetailView.tsx
@@ -4,6 +4,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 const AmbientInsight = lazy(() => import('../components/agent/AmbientInsight').then(m => ({ default: m.AmbientInsight })));
 const InlineAgent = lazy(() => import('../components/agent/InlineAgent').then(m => ({ default: m.InlineAgent })));
 import { useNavigate } from 'react-router-dom';
+import { ErrorBoundary } from '../components/ErrorBoundary';
 import {
   AlertCircle,
   XCircle,
@@ -963,21 +964,45 @@ export default function DetailView({ gvrKey, namespace, name }: DetailViewProps)
 
             {/* AI Insight + Inline Agent for pods and workloads */}
             {(resource.kind === 'Pod' || isWorkload) && namespace && (
-              <Suspense fallback={null}>
-                <AmbientInsight
-                  context={{ kind: resource.kind, name: resource.metadata.name, namespace }}
-                  prompt={`Analyze this ${resource.kind} "${resource.metadata.name}" in namespace "${namespace}". If unhealthy, explain the root cause and give a specific fix command. If healthy, say so in one sentence. Do not list the resource name or namespace back to me.`}
-                  trigger="manual"
-                />
-                <InlineAgent
-                  context={{ kind: resource.kind, name: resource.metadata.name, namespace, gvr: gvrKey }}
-                  quickPrompts={[
-                    `Why is this ${resource.kind} unhealthy?`,
-                    `What changed recently?`,
-                    `How can I optimize this?`,
-                  ]}
-                />
-              </Suspense>
+              <>
+                <ErrorBoundary fallbackTitle="AI insight unavailable">
+                  <Suspense fallback={
+                    <div className="animate-pulse space-y-2 rounded-lg border border-slate-800 bg-slate-900 p-4">
+                      <div className="h-4 w-32 bg-slate-800 rounded" />
+                      <div className="h-3 w-full bg-slate-800 rounded" />
+                      <div className="h-3 w-3/4 bg-slate-800 rounded" />
+                    </div>
+                  }>
+                    <AmbientInsight
+                      context={{ kind: resource.kind, name: resource.metadata.name, namespace }}
+                      prompt={`Analyze this ${resource.kind} "${resource.metadata.name}" in namespace "${namespace}". If unhealthy, explain the root cause and give a specific fix command. If healthy, say so in one sentence. Do not list the resource name or namespace back to me.`}
+                      trigger="manual"
+                    />
+                  </Suspense>
+                </ErrorBoundary>
+                <ErrorBoundary fallbackTitle="Inline agent unavailable">
+                  <Suspense fallback={
+                    <div className="animate-pulse space-y-2 rounded-lg border border-slate-800 bg-slate-900 p-4">
+                      <div className="h-4 w-24 bg-slate-800 rounded" />
+                      <div className="h-8 w-full bg-slate-800 rounded" />
+                      <div className="flex gap-2">
+                        <div className="h-6 w-28 bg-slate-800 rounded-full" />
+                        <div className="h-6 w-28 bg-slate-800 rounded-full" />
+                        <div className="h-6 w-28 bg-slate-800 rounded-full" />
+                      </div>
+                    </div>
+                  }>
+                    <InlineAgent
+                      context={{ kind: resource.kind, name: resource.metadata.name, namespace, gvr: gvrKey }}
+                      quickPrompts={[
+                        `Why is this ${resource.kind} unhealthy?`,
+                        `What changed recently?`,
+                        `How can I optimize this?`,
+                      ]}
+                    />
+                  </Suspense>
+                </ErrorBoundary>
+              </>
             )}
 
             {/* Quick event count for non-pod/workload resources */}

--- a/src/kubeview/views/TableView.tsx
+++ b/src/kubeview/views/TableView.tsx
@@ -5,6 +5,7 @@ import { Search, ChevronUp, ChevronDown, Trash2, Tag, Plus, Filter, Columns3, X,
 
 const NLFilterBar = lazy(() => import('../components/agent/NLFilterBar').then(m => ({ default: m.NLFilterBar })));
 import { cn } from '@/lib/utils';
+import { ErrorBoundary } from '../components/ErrorBoundary';
 import { k8sPatch, k8sDelete } from '../engine/query';
 import { useK8sListWatch } from '../hooks/useK8sListWatch';
 import { buildApiPathFromResource } from '../hooks/useResourceUrl';
@@ -656,13 +657,20 @@ export default function TableView({ gvrKey, namespace: namespaceProp }: TableVie
       {/* NL Filter Bar */}
       {showNLFilter && (
         <div className="px-4 py-2 border-b border-slate-800">
-          <Suspense fallback={<div className="h-8" />}>
-            <NLFilterBar
-              resourceKind={resourceType?.kind || resourceName}
-              columns={visibleColumns.map(c => c.id)}
-              onFiltersApplied={(filters) => setColumnFilters(prev => ({ ...prev, ...filters }))}
-            />
-          </Suspense>
+          <ErrorBoundary fallbackTitle="AI filter failed to load">
+            <Suspense fallback={
+              <div className="flex items-center gap-3 animate-pulse">
+                <div className="h-8 bg-slate-800 rounded flex-1" />
+                <div className="h-8 w-20 bg-slate-800 rounded" />
+              </div>
+            }>
+              <NLFilterBar
+                resourceKind={resourceType?.kind || resourceName}
+                columns={visibleColumns.map(c => c.id)}
+                onFiltersApplied={(filters) => setColumnFilters(prev => ({ ...prev, ...filters }))}
+              />
+            </Suspense>
+          </ErrorBoundary>
         </div>
       )}
 

--- a/src/kubeview/views/__tests__/SuspenseErrorBoundary.test.tsx
+++ b/src/kubeview/views/__tests__/SuspenseErrorBoundary.test.tsx
@@ -1,0 +1,363 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import React, { Suspense } from 'react';
+
+// ---- Mocks ----
+
+const navigateMock = vi.fn();
+const addTabMock = vi.fn();
+const addToastMock = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
+vi.mock('../../store/uiStore', () => ({
+  useUIStore: (selector: any) => {
+    const state = {
+      addToast: addToastMock,
+      addTab: addTabMock,
+      selectedNamespace: 'default',
+      setDockContext: vi.fn(),
+      openDock: vi.fn(),
+    };
+    return selector(state);
+  },
+}));
+
+vi.mock('../../store/clusterStore', () => ({
+  useClusterStore: (selector: any) => {
+    const state = { resourceRegistry: new Map() };
+    return selector(state);
+  },
+}));
+
+const mockK8sGet = vi.fn();
+const mockK8sList = vi.fn();
+
+vi.mock('../../engine/query', () => ({
+  k8sGet: (...args: any[]) => mockK8sGet(...args),
+  k8sList: (...args: any[]) => mockK8sList(...args),
+  k8sDelete: vi.fn(),
+  k8sPatch: vi.fn(),
+  k8sCreate: vi.fn(),
+  k8sLogs: vi.fn(),
+  sanitizePromQL: (v: string) => v.replace(/[^a-zA-Z0-9_\-./]/g, ''),
+}));
+
+vi.mock('../../engine/favorites', () => ({
+  toggleFavorite: vi.fn(() => true),
+  isFavorite: vi.fn(() => false),
+}));
+
+vi.mock('../../components/metrics/prometheus', () => ({
+  queryInstant: vi.fn().mockResolvedValue([]),
+  queryRange: vi.fn().mockResolvedValue([]),
+  getTimeRange: vi.fn().mockReturnValue([0, 1]),
+}));
+
+vi.mock('../../components/metrics/Sparkline', () => ({
+  MetricCard: ({ title }: { title: string }) => <div data-testid="metric-card">{title}</div>,
+  Sparkline: () => <div data-testid="sparkline" />,
+}));
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...args: any[]) => args.filter(Boolean).join(' '),
+}));
+
+vi.mock('../../components/PodTerminal', () => ({
+  default: () => <div data-testid="pod-terminal" />,
+}));
+
+vi.mock('../../components/DataEditor', () => ({
+  default: () => <div data-testid="data-editor">DataEditor</div>,
+}));
+
+vi.mock('../../components/DeployProgress', () => ({
+  default: () => <div data-testid="deploy-progress">DeployProgress</div>,
+}));
+
+// ---- Mock lazy components to control behavior ----
+
+// NLFilterBar: default renders fine, can be swapped to throw
+let nlFilterBarShouldThrow = false;
+vi.mock('../../components/agent/NLFilterBar', () => ({
+  NLFilterBar: (props: any) => {
+    if (nlFilterBarShouldThrow) throw new Error('NLFilterBar crash');
+    return <div data-testid="nl-filter-bar">NLFilterBar</div>;
+  },
+}));
+
+// AmbientInsight: can be swapped to throw
+let ambientInsightShouldThrow = false;
+vi.mock('../../components/agent/AmbientInsight', () => ({
+  AmbientInsight: (props: any) => {
+    if (ambientInsightShouldThrow) throw new Error('AmbientInsight crash');
+    return <div data-testid="ambient-insight">AmbientInsight</div>;
+  },
+}));
+
+// InlineAgent: can be swapped to throw
+let inlineAgentShouldThrow = false;
+vi.mock('../../components/agent/InlineAgent', () => ({
+  InlineAgent: (props: any) => {
+    if (inlineAgentShouldThrow) throw new Error('InlineAgent crash');
+    return <div data-testid="inline-agent">InlineAgent</div>;
+  },
+}));
+
+// ---- Helpers ----
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+}
+
+function makePod() {
+  return {
+    apiVersion: 'v1',
+    kind: 'Pod',
+    metadata: {
+      name: 'my-pod',
+      namespace: 'default',
+      uid: 'pod-uid-123',
+      creationTimestamp: '2025-01-01T00:00:00Z',
+      resourceVersion: '12345',
+      labels: { app: 'test' },
+      annotations: {},
+    },
+    spec: {
+      containers: [{ name: 'main', image: 'nginx:latest', ports: [{ containerPort: 80, protocol: 'TCP' }] }],
+    },
+    status: {
+      phase: 'Running',
+      containerStatuses: [{ name: 'main', ready: true, restartCount: 0, state: { running: { startedAt: '2025-01-01T00:00:00Z' } } }],
+      conditions: [
+        { type: 'Ready', status: 'True', lastTransitionTime: '2025-01-01T00:00:00Z' },
+      ],
+    },
+  };
+}
+
+// StatefulSet goes through the generic layout path which includes the AI components
+function makeStatefulSet() {
+  return {
+    apiVersion: 'apps/v1',
+    kind: 'StatefulSet',
+    metadata: {
+      name: 'my-sts',
+      namespace: 'default',
+      uid: 'sts-uid-123',
+      creationTimestamp: '2025-01-01T00:00:00Z',
+      resourceVersion: '99999',
+      labels: { app: 'db' },
+      annotations: {},
+    },
+    spec: {
+      replicas: 3,
+      selector: { matchLabels: { app: 'db' } },
+      template: { metadata: { labels: { app: 'db' } }, spec: { containers: [{ name: 'db', image: 'postgres' }] } },
+    },
+    status: {
+      replicas: 3,
+      readyReplicas: 3,
+      conditions: [
+        { type: 'Available', status: 'True', reason: 'MinimumReplicasAvailable', lastTransitionTime: '2025-01-01T00:00:00Z' },
+      ],
+    },
+  };
+}
+
+// Import after mocks
+import DetailView from '../DetailView';
+import TableView from '../TableView';
+
+function renderDetailView(props: { gvrKey: string; namespace?: string; name: string }) {
+  const qc = makeQueryClient();
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <DetailView {...props} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+function renderTableView(props: { gvrKey: string; namespace?: string }) {
+  const qc = makeQueryClient();
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <TableView {...props} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+// ---- Tests ----
+
+describe('Suspense + ErrorBoundary wrapping', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    nlFilterBarShouldThrow = false;
+    ambientInsightShouldThrow = false;
+    inlineAgentShouldThrow = false;
+    mockK8sList.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe('TableView - NLFilterBar', () => {
+    it('wraps NLFilterBar in ErrorBoundary with contextual fallbackTitle', async () => {
+      nlFilterBarShouldThrow = true;
+
+      renderTableView({ gvrKey: 'v1/pods', namespace: 'default' });
+
+      // Toggle the NL filter to show
+      const nlButton = screen.getByTitle('AI filter');
+      fireEvent.click(nlButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('AI filter failed to load')).toBeDefined();
+      });
+    });
+
+    it('renders NLFilterBar successfully when no error', async () => {
+      renderTableView({ gvrKey: 'v1/pods', namespace: 'default' });
+
+      const nlButton = screen.getByTitle('AI filter');
+      fireEvent.click(nlButton);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('nl-filter-bar')).toBeDefined();
+      });
+    });
+
+    it('shows skeleton placeholder while NLFilterBar loads', () => {
+      // We test that the Suspense fallback has animated skeleton elements
+      // by checking the source structure - the fallback has animate-pulse class
+      renderTableView({ gvrKey: 'v1/pods', namespace: 'default' });
+
+      const nlButton = screen.getByTitle('AI filter');
+      fireEvent.click(nlButton);
+
+      // The component loads synchronously in test (mocked), so the skeleton
+      // may flash briefly. We verify the structure exists by checking the
+      // component renders without error.
+      expect(screen.getByTestId('nl-filter-bar')).toBeDefined();
+    });
+  });
+
+  describe('DetailView - AmbientInsight', () => {
+    it('wraps AmbientInsight in its own ErrorBoundary', async () => {
+      ambientInsightShouldThrow = true;
+      mockK8sGet.mockResolvedValue(makeStatefulSet());
+
+      renderDetailView({ gvrKey: 'apps/v1/statefulsets', namespace: 'default', name: 'my-sts' });
+
+      await waitFor(() => {
+        expect(screen.getByText('AI insight unavailable')).toBeDefined();
+      });
+
+      // InlineAgent should still render fine
+      expect(screen.getByTestId('inline-agent')).toBeDefined();
+    });
+
+    it('renders AmbientInsight successfully when no error', async () => {
+      mockK8sGet.mockResolvedValue(makeStatefulSet());
+
+      renderDetailView({ gvrKey: 'apps/v1/statefulsets', namespace: 'default', name: 'my-sts' });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('ambient-insight')).toBeDefined();
+      });
+    });
+  });
+
+  describe('DetailView - InlineAgent', () => {
+    it('wraps InlineAgent in its own ErrorBoundary', async () => {
+      inlineAgentShouldThrow = true;
+      mockK8sGet.mockResolvedValue(makeStatefulSet());
+
+      renderDetailView({ gvrKey: 'apps/v1/statefulsets', namespace: 'default', name: 'my-sts' });
+
+      await waitFor(() => {
+        expect(screen.getByText('Inline agent unavailable')).toBeDefined();
+      });
+
+      // AmbientInsight should still render fine
+      expect(screen.getByTestId('ambient-insight')).toBeDefined();
+    });
+
+    it('renders InlineAgent successfully when no error', async () => {
+      mockK8sGet.mockResolvedValue(makeStatefulSet());
+
+      renderDetailView({ gvrKey: 'apps/v1/statefulsets', namespace: 'default', name: 'my-sts' });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('inline-agent')).toBeDefined();
+      });
+    });
+  });
+
+  describe('Isolation - one crash does not take down the other', () => {
+    it('AmbientInsight crash does not affect InlineAgent', async () => {
+      ambientInsightShouldThrow = true;
+      inlineAgentShouldThrow = false;
+      mockK8sGet.mockResolvedValue(makeStatefulSet());
+
+      renderDetailView({ gvrKey: 'apps/v1/statefulsets', namespace: 'default', name: 'my-sts' });
+
+      await waitFor(() => {
+        // AmbientInsight crashed
+        expect(screen.getByText('AI insight unavailable')).toBeDefined();
+        // InlineAgent still works
+        expect(screen.getByTestId('inline-agent')).toBeDefined();
+      });
+
+      // The rest of the detail view is intact
+      const heading = screen.getByRole('heading', { level: 1 });
+      expect(heading.textContent).toBe('my-sts');
+    });
+
+    it('InlineAgent crash does not affect AmbientInsight', async () => {
+      ambientInsightShouldThrow = false;
+      inlineAgentShouldThrow = true;
+      mockK8sGet.mockResolvedValue(makeStatefulSet());
+
+      renderDetailView({ gvrKey: 'apps/v1/statefulsets', namespace: 'default', name: 'my-sts' });
+
+      await waitFor(() => {
+        // InlineAgent crashed
+        expect(screen.getByText('Inline agent unavailable')).toBeDefined();
+        // AmbientInsight still works
+        expect(screen.getByTestId('ambient-insight')).toBeDefined();
+      });
+    });
+
+    it('NLFilterBar crash does not take down the table', async () => {
+      nlFilterBarShouldThrow = true;
+
+      renderTableView({ gvrKey: 'v1/pods', namespace: 'default' });
+
+      const nlButton = screen.getByTitle('AI filter');
+      fireEvent.click(nlButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('AI filter failed to load')).toBeDefined();
+      });
+
+      // The table header is still present
+      expect(screen.getByText('Pods')).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Wrapped lazy NLFilterBar (TableView) in ErrorBoundary with skeleton fallback
- Wrapped lazy AmbientInsight/InlineAgent (DetailView) in ErrorBoundary
- One component crash no longer takes down the whole view

## Test plan
- [ ] Verify lazy components render with skeletons during load
- [ ] Verify component crash shows fallback, not blank view
- [ ] `npx vitest --run` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)