### PR TITLE
fix: replace window.prompt with styled label dialog

### DIFF
--- a/src/kubeview/views/DetailView.tsx
+++ b/src/kubeview/views/DetailView.tsx
@@ -319,6 +319,19 @@ export default function DetailView({ gvrKey, namespace, name }: DetailViewProps)
   const [showDeleteConfirm, setShowDeleteConfirm] = React.useState(false);
   const [showDeleteProgress, setShowDeleteProgress] = React.useState(false);
   const [deleting, setDeleting] = React.useState(false);
+  const [showLabelDialog, setShowLabelDialog] = React.useState(false);
+  const [labelKey, setLabelKey] = React.useState('');
+  const [labelValue, setLabelValue] = React.useState('');
+
+  const addLabelButton = (
+    <button
+      disabled={!!actionLoading}
+      onClick={() => { setLabelKey(''); setLabelValue(''); setShowLabelDialog(true); }}
+      className="mt-2 text-xs text-blue-400 hover:text-blue-300 disabled:opacity-50"
+    >
+      {actionLoading === 'label' ? 'Adding...' : '+ Add label'}
+    </button>
+  );
 
   if (error) {
     const isNotFound = (error as Error).message?.includes('not found') || (error as Error).message?.includes('404');
@@ -617,6 +630,7 @@ export default function DetailView({ gvrKey, namespace, name }: DetailViewProps)
                         </div>
                       ))}
                     </div>
+                    {addLabelButton}
                   </DetailSection>
                 )}
                 {/* Annotations */}
@@ -666,6 +680,7 @@ export default function DetailView({ gvrKey, namespace, name }: DetailViewProps)
                         </div>
                       ))}
                     </div>
+                    {addLabelButton}
                   </DetailSection>
                 )}
                 {/* Annotations */}
@@ -805,28 +820,7 @@ export default function DetailView({ gvrKey, namespace, name }: DetailViewProps)
                     </div>
                   ))}
                 </div>
-                <button
-                  disabled={!!actionLoading}
-                  onClick={async () => {
-                    const input = window.prompt('Add label (key=value):');
-                    if (!input || !input.includes('=')) return;
-                    const [k, ...vParts] = input.split('=');
-                    const v = vParts.join('=');
-                    setActionLoading('label');
-                    try {
-                      await k8sPatch(apiPath, { metadata: { labels: { [k]: v } } });
-                      addToast({ type: 'success', title: `Label ${k}=${v} added` });
-                      queryClient.invalidateQueries({ queryKey: ['detail', apiPath] });
-                    } catch (err) {
-                      showErrorToast(err, 'Failed to add label');
-                    } finally {
-                      setActionLoading(null);
-                    }
-                  }}
-                  className="mt-2 text-xs text-blue-400 hover:text-blue-300 disabled:opacity-50"
-                >
-                  {actionLoading === 'label' ? 'Adding...' : '+ Add label'}
-                </button>
+                {addLabelButton}
               </DetailSection>
             )}
 
@@ -1017,6 +1011,78 @@ export default function DetailView({ gvrKey, namespace, name }: DetailViewProps)
               go(`/r/${gvrUrl}`, resourcePlural);
             }}
           />
+        </div>
+      </div>
+    )}
+
+    {/* Add Label Dialog */}
+    {showLabelDialog && (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" role="dialog" aria-label="Add label">
+        <div className="bg-slate-900 border border-slate-700 rounded-lg shadow-xl w-full max-w-md p-6">
+          <h3 className="text-sm font-semibold text-slate-200 mb-4">Add Label</h3>
+          <form
+            onSubmit={async (e) => {
+              e.preventDefault();
+              const k = labelKey.trim();
+              const v = labelValue.trim();
+              if (!k) return;
+              setActionLoading('label');
+              try {
+                await k8sPatch(apiPath, { metadata: { labels: { [k]: v } } });
+                addToast({ type: 'success', title: `Label ${k}=${v} added` });
+                queryClient.invalidateQueries({ queryKey: ['detail', apiPath] });
+                setShowLabelDialog(false);
+              } catch (err) {
+                showErrorToast(err, 'Failed to add label');
+              } finally {
+                setActionLoading(null);
+              }
+            }}
+          >
+            <div className="space-y-3">
+              <div>
+                <label htmlFor="label-key" className="block text-xs text-slate-400 mb-1">Key</label>
+                <input
+                  id="label-key"
+                  type="text"
+                  value={labelKey}
+                  onChange={(e) => setLabelKey(e.target.value)}
+                  placeholder="e.g. app.kubernetes.io/name"
+                  className="w-full px-3 py-1.5 text-sm bg-slate-800 border border-slate-600 rounded text-slate-200 placeholder-slate-500 focus:outline-none focus:border-blue-500"
+                  autoFocus
+                  required
+                />
+              </div>
+              <div>
+                <label htmlFor="label-value" className="block text-xs text-slate-400 mb-1">Value</label>
+                <input
+                  id="label-value"
+                  type="text"
+                  value={labelValue}
+                  onChange={(e) => setLabelValue(e.target.value)}
+                  placeholder="e.g. my-app"
+                  className="w-full px-3 py-1.5 text-sm bg-slate-800 border border-slate-600 rounded text-slate-200 placeholder-slate-500 focus:outline-none focus:border-blue-500"
+                />
+              </div>
+            </div>
+            <div className="flex justify-end gap-2 mt-5">
+              <button
+                type="button"
+                onClick={() => setShowLabelDialog(false)}
+                disabled={actionLoading === 'label'}
+                className="px-3 py-1.5 text-xs text-slate-400 hover:text-slate-200 rounded hover:bg-slate-800 transition-colors disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={actionLoading === 'label' || !labelKey.trim()}
+                className="px-3 py-1.5 text-xs text-white bg-blue-600 hover:bg-blue-500 rounded transition-colors disabled:opacity-50"
+              >
+                {actionLoading === 'label' ? 'Adding...' : 'Add'}
+              </button>
+            </div>
+          </form>
         </div>
       </div>
     )}

--- a/src/kubeview/views/__tests__/DetailView.test.tsx
+++ b/src/kubeview/views/__tests__/DetailView.test.tsx
@@ -417,4 +417,105 @@ describe('DetailView', () => {
       expect(screen.getAllByText('nginx:latest').length).toBeGreaterThanOrEqual(1);
     });
   });
+
+  describe('Add Label dialog', () => {
+    it('opens a modal dialog instead of window.prompt when Add label is clicked', async () => {
+      const pod = makePod();
+      mockK8sGet.mockResolvedValue(pod);
+
+      renderDetailView({ gvrKey: 'v1/pods', namespace: 'default', name: 'my-pod' });
+
+      // Wait for the Add label button to appear (labels section renders after resource loads)
+      await waitFor(() => {
+        expect(screen.getByText('+ Add label')).toBeDefined();
+      });
+
+      // Click the Add label button
+      const addLabelBtn = screen.getByText('+ Add label');
+      fireEvent.click(addLabelBtn);
+
+      // Dialog should appear with key and value inputs
+      await waitFor(() => {
+        expect(screen.getByRole('dialog', { name: 'Add label' })).toBeDefined();
+        expect(screen.getByLabelText('Key')).toBeDefined();
+        expect(screen.getByLabelText('Value')).toBeDefined();
+        expect(screen.getByText('Cancel')).toBeDefined();
+        expect(screen.getByText('Add')).toBeDefined();
+      });
+
+      // window.prompt should NOT have been called
+      const promptSpy = vi.spyOn(window, 'prompt');
+      expect(promptSpy).not.toHaveBeenCalled();
+      promptSpy.mockRestore();
+    });
+
+    it('submits label key/value and calls k8sPatch', async () => {
+      const pod = makePod();
+      mockK8sGet.mockResolvedValue(pod);
+      mockK8sPatch.mockResolvedValue({});
+
+      renderDetailView({ gvrKey: 'v1/pods', namespace: 'default', name: 'my-pod' });
+
+      await waitFor(() => {
+        expect(screen.getAllByText('my-pod').length).toBeGreaterThanOrEqual(1);
+      });
+
+      // Open dialog
+      fireEvent.click(screen.getByText('+ Add label'));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Key')).toBeDefined();
+      });
+
+      // Enter key and value
+      fireEvent.change(screen.getByLabelText('Key'), { target: { value: 'env' } });
+      fireEvent.change(screen.getByLabelText('Value'), { target: { value: 'production' } });
+
+      // Submit the form
+      fireEvent.click(screen.getByText('Add'));
+
+      await waitFor(() => {
+        expect(mockK8sPatch).toHaveBeenCalledWith(
+          '/api/v1/namespaces/default/pods/my-pod',
+          { metadata: { labels: { env: 'production' } } },
+        );
+      });
+
+      // Success toast
+      await waitFor(() => {
+        expect(addToastMock).toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'success', title: 'Label env=production added' }),
+        );
+      });
+    });
+
+    it('closes dialog when Cancel is clicked', async () => {
+      const pod = makePod();
+      mockK8sGet.mockResolvedValue(pod);
+
+      renderDetailView({ gvrKey: 'v1/pods', namespace: 'default', name: 'my-pod' });
+
+      await waitFor(() => {
+        expect(screen.getAllByText('my-pod').length).toBeGreaterThanOrEqual(1);
+      });
+
+      // Open dialog
+      fireEvent.click(screen.getByText('+ Add label'));
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog', { name: 'Add label' })).toBeDefined();
+      });
+
+      // Click Cancel
+      fireEvent.click(screen.getByText('Cancel'));
+
+      // Dialog should be gone
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog', { name: 'Add label' })).toBeNull();
+      });
+
+      // k8sPatch should NOT have been called
+      expect(mockK8sPatch).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Replaced `window.prompt()` for Add Label with a styled modal dialog
- Separate key/value input fields with proper validation
- Cancel and Add Label buttons with loading state

## Test plan
- [ ] Click "+ Add label" on resource detail — verify styled dialog appears
- [ ] Enter key/value, submit — verify label added with success toast
- [ ] Click Cancel — dialog closes without API call
- [ ] `npx vitest --run` — all 18 DetailView tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)