### PR TITLE
fix: numeric column sorting for restarts, replicas, age

### DIFF
--- a/src/kubeview/engine/enhancers/__tests__/enhancer-columns.test.ts
+++ b/src/kubeview/engine/enhancers/__tests__/enhancer-columns.test.ts
@@ -61,6 +61,11 @@ describe('podEnhancer', () => {
   it('has default sort by name asc', () => {
     expect(podEnhancer.defaultSort).toEqual({ column: 'name', direction: 'asc' });
   });
+
+  it('restarts column has numeric sortType', () => {
+    const col = podEnhancer.columns.find((c) => c.id === 'restarts');
+    expect(col?.sortType).toBe('number');
+  });
 });
 
 describe('deploymentEnhancer', () => {
@@ -178,6 +183,18 @@ describe('nodeEnhancer', () => {
     expect(ids).toContain('cordon-toggle');
     expect(ids).toContain('drain');
   });
+
+  it('cpu and pods columns have numeric sortType', () => {
+    const cpuCol = nodeEnhancer.columns.find((c) => c.id === 'cpu');
+    const podsCol = nodeEnhancer.columns.find((c) => c.id === 'pods');
+    expect(cpuCol?.sortType).toBe('number');
+    expect(podsCol?.sortType).toBe('number');
+  });
+
+  it('age column has date sortType', () => {
+    const ageCol = nodeEnhancer.columns.find((c) => c.id === 'age');
+    expect(ageCol?.sortType).toBe('date');
+  });
 });
 
 describe('serviceEnhancer', () => {
@@ -264,5 +281,10 @@ describe('secretEnhancer', () => {
   it('returns 0 for no data', () => {
     const secret = {};
     expect(access(secretEnhancer, 'keys', secret)).toBe(0);
+  });
+
+  it('keys column has numeric sortType', () => {
+    const col = secretEnhancer.columns.find((c) => c.id === 'keys');
+    expect(col?.sortType).toBe('number');
   });
 });

--- a/src/kubeview/engine/enhancers/nodes.tsx
+++ b/src/kubeview/engine/enhancers/nodes.tsx
@@ -101,6 +101,7 @@ export const nodeEnhancer: ResourceEnhancer = {
       },
       render: (value) => <span className="font-mono text-xs text-slate-300">{String(value)} cores</span>,
       sortable: true,
+      sortType: 'number',
       priority: 12,
     },
     {
@@ -125,6 +126,7 @@ export const nodeEnhancer: ResourceEnhancer = {
       },
       render: (value) => <span className="font-mono text-xs text-slate-300">{String(value)}</span>,
       sortable: true,
+      sortType: 'number',
       priority: 14,
     },
     {
@@ -157,16 +159,16 @@ export const nodeEnhancer: ResourceEnhancer = {
     {
       id: 'age',
       header: 'Age',
-      accessorFn: (resource) => {
-        const ts = resource.metadata.creationTimestamp;
-        if (!ts) return '-';
-        const ms = Date.now() - new Date(ts).getTime();
+      accessorFn: (resource) => resource.metadata.creationTimestamp,
+      render: (value) => {
+        if (!value) return <span className="text-xs text-slate-500">-</span>;
+        const ms = Date.now() - new Date(String(value)).getTime();
         const days = Math.floor(ms / 86400000);
-        if (days > 0) return `${days}d`;
-        return `${Math.floor(ms / 3600000)}h`;
+        const label = days > 0 ? `${days}d` : `${Math.floor(ms / 3600000)}h`;
+        return <span className="text-xs text-slate-500">{label}</span>;
       },
-      render: (value) => <span className="text-xs text-slate-500">{String(value)}</span>,
       sortable: true,
+      sortType: 'date',
       priority: 16,
     },
   ],

--- a/src/kubeview/engine/enhancers/pods.tsx
+++ b/src/kubeview/engine/enhancers/pods.tsx
@@ -91,6 +91,7 @@ export const podEnhancer: ResourceEnhancer = {
         );
       },
       sortable: true,
+      sortType: 'number',
       priority: 12,
     },
     {

--- a/src/kubeview/engine/enhancers/secrets.tsx
+++ b/src/kubeview/engine/enhancers/secrets.tsx
@@ -66,6 +66,7 @@ export const secretEnhancer: ResourceEnhancer = {
         );
       },
       sortable: true,
+      sortType: 'number',
       priority: 11,
     },
   ],

--- a/src/kubeview/engine/renderers/index.tsx
+++ b/src/kubeview/engine/renderers/index.tsx
@@ -28,6 +28,7 @@ export interface ColumnDef {
   accessorFn: (resource: K8sResource) => unknown;
   render: (value: unknown, resource: K8sResource) => ReactNode;
   sortable: boolean;
+  sortType?: 'string' | 'number' | 'date';  // default: 'string'
   width?: string;       // CSS width
   priority: number;     // lower = shown first, higher = hidden on small screens
 }
@@ -718,6 +719,7 @@ export function getDefaultColumns(namespaced: boolean): ColumnDef[] {
     accessorFn: (resource) => resource.metadata.creationTimestamp,
     render: renderAge,
     sortable: true,
+    sortType: 'date',
     width: '10%',
     priority: 2,
   });

--- a/src/kubeview/views/TableView.tsx
+++ b/src/kubeview/views/TableView.tsx
@@ -34,6 +34,36 @@ interface SortState {
   direction: SortDirection;
 }
 
+/**
+ * Compare two values according to the column's sortType.
+ * Exported for unit testing.
+ */
+export function compareValues(aValue: unknown, bValue: unknown, sortType?: 'string' | 'number' | 'date'): number {
+  // Handle null/undefined
+  if (aValue == null && bValue == null) return 0;
+  if (aValue == null) return 1;
+  if (bValue == null) return -1;
+
+  if (sortType === 'number') {
+    const aNum = Number(aValue);
+    const bNum = Number(bValue);
+    const aSafe = Number.isFinite(aNum) ? aNum : 0;
+    const bSafe = Number.isFinite(bNum) ? bNum : 0;
+    return aSafe - bSafe;
+  }
+
+  if (sortType === 'date') {
+    const aTime = new Date(String(aValue)).getTime();
+    const bTime = new Date(String(bValue)).getTime();
+    const aSafe = Number.isFinite(aTime) ? aTime : 0;
+    const bSafe = Number.isFinite(bTime) ? bTime : 0;
+    return aSafe - bSafe;
+  }
+
+  // Compare as strings by default
+  return String(aValue).localeCompare(String(bValue));
+}
+
 export default function TableView({ gvrKey, namespace: namespaceProp }: TableViewProps) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -187,17 +217,7 @@ export default function TableView({ gvrKey, namespace: namespaceProp }: TableVie
     sorted.sort((a, b) => {
       const aValue = column.accessorFn(a);
       const bValue = column.accessorFn(b);
-
-      // Handle null/undefined
-      if (aValue == null && bValue == null) return 0;
-      if (aValue == null) return 1;
-      if (bValue == null) return -1;
-
-      // Compare as strings by default
-      const aStr = String(aValue);
-      const bStr = String(bValue);
-
-      const comparison = aStr.localeCompare(bStr);
+      const comparison = compareValues(aValue, bValue, column.sortType);
       return sortState.direction === 'asc' ? comparison : -comparison;
     });
 

--- a/src/kubeview/views/__tests__/TableViewSort.test.ts
+++ b/src/kubeview/views/__tests__/TableViewSort.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { compareValues } from '../TableView';
+
+describe('compareValues', () => {
+  describe('string sort (default)', () => {
+    it('sorts strings alphabetically', () => {
+      expect(compareValues('alpha', 'beta')).toBeLessThan(0);
+      expect(compareValues('beta', 'alpha')).toBeGreaterThan(0);
+      expect(compareValues('same', 'same')).toBe(0);
+    });
+
+    it('sorts "10" after "9" lexicographically (known issue without sortType)', () => {
+      // "10" < "9" in lexicographic order because "1" < "9"
+      expect(compareValues('10', '9')).toBeLessThan(0);
+    });
+  });
+
+  describe('number sort', () => {
+    it('sorts 9 before 10 numerically', () => {
+      expect(compareValues(9, 10, 'number')).toBeLessThan(0);
+      expect(compareValues(10, 9, 'number')).toBeGreaterThan(0);
+    });
+
+    it('sorts string-encoded numbers correctly', () => {
+      expect(compareValues('9', '10', 'number')).toBeLessThan(0);
+      expect(compareValues('100', '20', 'number')).toBeGreaterThan(0);
+    });
+
+    it('treats equal numbers as equal', () => {
+      expect(compareValues(5, 5, 'number')).toBe(0);
+    });
+
+    it('handles zero', () => {
+      expect(compareValues(0, 5, 'number')).toBeLessThan(0);
+      expect(compareValues(5, 0, 'number')).toBeGreaterThan(0);
+    });
+
+    it('handles negative numbers', () => {
+      expect(compareValues(-1, 1, 'number')).toBeLessThan(0);
+    });
+
+    it('treats non-numeric values as 0', () => {
+      expect(compareValues('not-a-number', 5, 'number')).toBeLessThan(0);
+      expect(compareValues('abc', 'def', 'number')).toBe(0);
+      expect(compareValues('-', 10, 'number')).toBeLessThan(0);
+    });
+
+    it('handles NaN and Infinity gracefully (treated as 0)', () => {
+      expect(compareValues(NaN, 5, 'number')).toBeLessThan(0);
+      // Infinity is not finite, so it's treated as 0
+      expect(compareValues(Infinity, 5, 'number')).toBeLessThan(0);
+    });
+  });
+
+  describe('date sort', () => {
+    it('sorts dates chronologically', () => {
+      expect(compareValues('2025-01-01T00:00:00Z', '2025-06-01T00:00:00Z', 'date')).toBeLessThan(0);
+      expect(compareValues('2025-06-01T00:00:00Z', '2025-01-01T00:00:00Z', 'date')).toBeGreaterThan(0);
+    });
+
+    it('treats equal dates as equal', () => {
+      expect(compareValues('2025-01-01T00:00:00Z', '2025-01-01T00:00:00Z', 'date')).toBe(0);
+    });
+
+    it('treats invalid date strings as 0 (epoch)', () => {
+      expect(compareValues('not-a-date', '2025-01-01T00:00:00Z', 'date')).toBeLessThan(0);
+    });
+
+    it('handles "-" placeholder gracefully', () => {
+      // "-" is an invalid date, treated as 0
+      expect(compareValues('-', '2025-01-01T00:00:00Z', 'date')).toBeLessThan(0);
+    });
+  });
+
+  describe('null/undefined handling', () => {
+    it('sorts null values to the end', () => {
+      expect(compareValues(null, 'a')).toBe(1);
+      expect(compareValues('a', null)).toBe(-1);
+    });
+
+    it('sorts undefined values to the end', () => {
+      expect(compareValues(undefined, 'a')).toBe(1);
+      expect(compareValues('a', undefined)).toBe(-1);
+    });
+
+    it('treats two nulls as equal', () => {
+      expect(compareValues(null, null)).toBe(0);
+      expect(compareValues(undefined, undefined)).toBe(0);
+      expect(compareValues(null, undefined)).toBe(0);
+    });
+
+    it('null handling applies regardless of sortType', () => {
+      expect(compareValues(null, 5, 'number')).toBe(1);
+      expect(compareValues(null, '2025-01-01', 'date')).toBe(1);
+    });
+  });
+
+  describe('real-world restart count sorting', () => {
+    it('sorts restart counts in correct numeric order', () => {
+      const restarts = [10, 2, 0, 9, 100, 1];
+      const sorted = [...restarts].sort((a, b) => compareValues(a, b, 'number'));
+      expect(sorted).toEqual([0, 1, 2, 9, 10, 100]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Added `sortType` property to `ColumnDef` (string/number/date)
- TableView sort uses numeric comparison for number-typed columns
- Pod restarts, node capacity, secret data count annotated as numeric
- "10 restarts" now correctly sorts after "9 restarts"

## Test plan
- [ ] Sort pods by restarts — verify 9 < 10 (not 10 < 9)
- [ ] Sort nodes by capacity — verify numeric order
- [ ] `npx vitest --run` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)