### PR TITLE
feat: URL-persisted table filters for shareable filtered views

### DIFF
--- a/src/kubeview/views/TableView.tsx
+++ b/src/kubeview/views/TableView.tsx
@@ -110,21 +110,45 @@ export default function TableView({ gvrKey, namespace: namespaceProp }: TableVie
   const { allowed: canUpdate } = useCanI('update', resourceGroup, resourcePlural, activeNamespace);
   const { allowed: canCreate } = useCanI('create', resourceGroup, resourcePlural, activeNamespace);
 
+  // URL-persisted filters — read initial state from URL params
+  const updateUrlParam = React.useCallback((key: string, value: string, defaultValue: string) => {
+    const url = new URL(window.location.href);
+    if (value === defaultValue) url.searchParams.delete(key); else url.searchParams.set(key, value);
+    window.history.replaceState(null, '', url.toString());
+  }, []);
+
+  const urlParams = React.useMemo(() => new URLSearchParams(window.location.search), []);
+
   // State — debounced search
-  const [searchInput, setSearchInput] = React.useState('');
-  const [searchTerm, setSearchTerm] = React.useState('');
+  const [searchInput, setSearchInput] = React.useState(urlParams.get('q') || '');
+  const [searchTerm, setSearchTerm] = React.useState(urlParams.get('q') || '');
   const [columnFilters, setColumnFilters] = React.useState<Record<string, string>>({});
 
   React.useEffect(() => {
-    const timer = setTimeout(() => setSearchTerm(searchInput), 200);
+    const timer = setTimeout(() => {
+      setSearchTerm(searchInput);
+      updateUrlParam('q', searchInput, '');
+    }, 200);
     return () => clearTimeout(timer);
-  }, [searchInput]);
+  }, [searchInput, updateUrlParam]);
   const [showFilters, setShowFilters] = React.useState(false);
   const [showNLFilter, setShowNLFilter] = React.useState(false);
-  const [sortState, setSortState] = React.useState<SortState>({
-    column: enhancer?.defaultSort?.column || 'name',
-    direction: enhancer?.defaultSort?.direction || 'asc',
+  const [sortState, setSortStateInner] = React.useState<SortState>({
+    column: urlParams.get('sort') || enhancer?.defaultSort?.column || 'name',
+    direction: (urlParams.get('dir') as SortDirection) || enhancer?.defaultSort?.direction || 'asc',
   });
+  const setSortState = React.useCallback((updater: SortState | ((prev: SortState) => SortState)) => {
+    setSortStateInner((prev) => {
+      const next = typeof updater === 'function' ? updater(prev) : updater;
+      const defaultCol = enhancer?.defaultSort?.column || 'name';
+      const defaultDir = enhancer?.defaultSort?.direction || 'asc';
+      const url = new URL(window.location.href);
+      if (next.column === defaultCol) url.searchParams.delete('sort'); else url.searchParams.set('sort', next.column);
+      if (next.direction === defaultDir) url.searchParams.delete('dir'); else url.searchParams.set('dir', next.direction);
+      window.history.replaceState(null, '', url.toString());
+      return next;
+    });
+  }, [enhancer]);
   const [selectedRows, setSelectedRows] = React.useState<Set<string>>(new Set());
   const [perPage, setPerPage] = React.useState(25);
   const [previewResource, setPreviewResource] = React.useState<K8sResource | null>(null);
@@ -205,8 +229,20 @@ export default function TableView({ gvrKey, namespace: namespaceProp }: TableVie
   }, [filteredResources, sortState, columns]);
 
   // Paginate — reset to page 0 when filters change
-  const [currentPage, setCurrentPage] = React.useState(0);
-  React.useEffect(() => { setCurrentPage(0); }, [searchTerm, columnFilters, activeNamespace]);
+  const urlPage = parseInt(urlParams.get('page') || '0', 10);
+  const [currentPage, setCurrentPageInner] = React.useState(isNaN(urlPage) ? 0 : urlPage);
+  const setCurrentPage = React.useCallback((updater: number | ((prev: number) => number)) => {
+    setCurrentPageInner((prev) => {
+      const next = typeof updater === 'function' ? updater(prev) : updater;
+      updateUrlParam('page', String(next), '0');
+      return next;
+    });
+  }, [updateUrlParam]);
+  const isFirstRender = React.useRef(true);
+  React.useEffect(() => {
+    if (isFirstRender.current) { isFirstRender.current = false; return; }
+    setCurrentPage(0);
+  }, [searchTerm, columnFilters, activeNamespace]);
   const paginatedResources = React.useMemo(() => {
     const start = currentPage * perPage;
     return sortedResources.slice(start, start + perPage);

--- a/src/kubeview/views/__tests__/TableView.test.tsx
+++ b/src/kubeview/views/__tests__/TableView.test.tsx
@@ -505,4 +505,150 @@ describe('TableView', () => {
 
     vi.useRealTimers();
   });
+
+  describe('URL-persisted filters', () => {
+    let replaceStateSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      replaceStateSpy = vi.spyOn(window.history, 'replaceState');
+      // Reset URL to clean state
+      window.history.replaceState(null, '', window.location.pathname);
+    });
+
+    afterEach(() => {
+      replaceStateSpy.mockRestore();
+      window.history.replaceState(null, '', window.location.pathname);
+    });
+
+    it('reads search query from URL on mount', () => {
+      window.history.replaceState(null, '', '?q=nginx');
+
+      setMockWatch({
+        data: [makePodResource('nginx'), makePodResource('redis')],
+        isLoading: false,
+        error: null,
+      });
+
+      renderTable('v1/pods');
+
+      const searchInput = screen.getByPlaceholderText('Search...') as HTMLInputElement;
+      expect(searchInput.value).toBe('nginx');
+    });
+
+    it('reads sort column and direction from URL on mount', () => {
+      window.history.replaceState(null, '', '?sort=namespace&dir=desc');
+
+      setMockWatch({
+        data: [makePodResource('alpha', 'z-ns'), makePodResource('beta', 'a-ns')],
+        isLoading: false,
+        error: null,
+      });
+
+      renderTable('v1/pods');
+
+      // The Namespace column header should have a sort indicator (ChevronDown for desc)
+      const namespaceHeader = screen.getByText('Namespace');
+      const headerCell = namespaceHeader.closest('th');
+      // ChevronDown icon should be present for desc sort
+      expect(headerCell?.querySelector('svg')).not.toBeNull();
+    });
+
+    it('reads page number from URL on mount', () => {
+      window.history.replaceState(null, '', '?page=1');
+
+      // Create enough resources to have multiple pages
+      const pods = Array.from({ length: 30 }, (_, i) => makePodResource(`pod-${i}`));
+      setMockWatch({ data: pods, isLoading: false, error: null });
+
+      renderTable('v1/pods');
+
+      // Page 1 (second page) should show "26-30 of 30"
+      expect(screen.getByText(/26-30 of 30/)).toBeDefined();
+    });
+
+    it('updates URL when search input changes', () => {
+      vi.useFakeTimers();
+
+      setMockWatch({
+        data: [makePodResource('nginx')],
+        isLoading: false,
+        error: null,
+      });
+
+      renderTable('v1/pods');
+
+      const searchInput = screen.getByPlaceholderText('Search...');
+      fireEvent.change(searchInput, { target: { value: 'test-query' } });
+
+      // Advance past debounce
+      act(() => { vi.advanceTimersByTime(250); });
+
+      // replaceState should have been called with q=test-query
+      const lastCall = replaceStateSpy.mock.calls[replaceStateSpy.mock.calls.length - 1];
+      expect(lastCall[2]).toContain('q=test-query');
+
+      vi.useRealTimers();
+    });
+
+    it('updates URL when sort changes', () => {
+      setMockWatch({
+        data: [makePodResource('alpha'), makePodResource('beta')],
+        isLoading: false,
+        error: null,
+      });
+
+      renderTable('v1/pods');
+
+      // Click on Namespace header to sort
+      const namespaceHeader = screen.getByText('Namespace');
+      fireEvent.click(namespaceHeader);
+
+      const calls = replaceStateSpy.mock.calls;
+      const urlStrings = calls.map(c => String(c[2]));
+      const sortCall = urlStrings.find(u => u.includes('sort=namespace'));
+      expect(sortCall).toBeDefined();
+    });
+
+    it('updates URL when page changes', () => {
+      const pods = Array.from({ length: 30 }, (_, i) => makePodResource(`pod-${i}`));
+      setMockWatch({ data: pods, isLoading: false, error: null });
+
+      renderTable('v1/pods');
+
+      // Click Next button
+      const nextButton = screen.getByText('Next');
+      fireEvent.click(nextButton);
+
+      const calls = replaceStateSpy.mock.calls;
+      const urlStrings = calls.map(c => String(c[2]));
+      const pageCall = urlStrings.find(u => u.includes('page=1'));
+      expect(pageCall).toBeDefined();
+    });
+
+    it('removes default values from URL', () => {
+      vi.useFakeTimers();
+
+      window.history.replaceState(null, '', '?q=test');
+
+      setMockWatch({
+        data: [makePodResource('nginx')],
+        isLoading: false,
+        error: null,
+      });
+
+      renderTable('v1/pods');
+
+      // Clear the search
+      const searchInput = screen.getByPlaceholderText('Search...');
+      fireEvent.change(searchInput, { target: { value: '' } });
+
+      act(() => { vi.advanceTimersByTime(250); });
+
+      // The last replaceState call should not contain q=
+      const lastCall = replaceStateSpy.mock.calls[replaceStateSpy.mock.calls.length - 1];
+      expect(String(lastCall[2])).not.toContain('q=');
+
+      vi.useRealTimers();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Search, sort, direction, and page persisted in URL params (q, sort, dir, page)
- Filtered views can now be shared via URL with teammates
- Follows AlertsView's existing `replaceState` pattern
- Default values omitted from URL to keep it clean

## Test plan
- [ ] Filter pods, copy URL, open in new tab — same filter applied
- [ ] Sort by column, verify URL updates
- [ ] `npx vitest --run` — all 1676 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)