### PR TITLE
fix: TableView error state with retry + CommandBar namespace fetch reliability

### DIFF
--- a/src/kubeview/components/CommandBar.tsx
+++ b/src/kubeview/components/CommandBar.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Search, ChevronDown, Layers, Bell, User, Server, Plus, LogOut, Check } from 'lucide-react';
-import { useQuery } from '@tanstack/react-query';
+import { Search, ChevronDown, Layers, Bell, User, Server, Plus, LogOut, Check, Loader2, RefreshCw } from 'lucide-react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useUIStore } from '../store/uiStore';
 import { useClusterStore } from '../store/clusterStore';
 import { useFleetStore } from '../store/fleetStore';
@@ -12,7 +12,7 @@ import { cn } from '@/lib/utils';
 
 export function CommandBar() {
   const navigate = useNavigate();
-  const [namespaces, setNamespaces] = useState<string[]>([]);
+  const queryClient = useQueryClient();
   const [showNsDropdown, setShowNsDropdown] = useState(false);
   const [showUserMenu, setShowUserMenu] = useState(false);
   const [nsFilter, setNsFilter] = useState('');
@@ -102,14 +102,16 @@ export function CommandBar() {
   });
 
   // Fetch namespaces
-  useEffect(() => {
-    fetch('/api/kubernetes/api/v1/namespaces')
-      .then((res) => res.json())
-      .then((data) => {
-        if (data.items) setNamespaces(data.items.map((i: any) => i.metadata.name).sort());
-      })
-      .catch(() => {});
-  }, []);
+  const { data: namespaces = [], isLoading: namespacesLoading, error: namespacesError } = useQuery({
+    queryKey: ['toolbar', 'namespaces'],
+    queryFn: async () => {
+      const res = await fetch('/api/kubernetes/api/v1/namespaces');
+      if (!res.ok) throw new Error(`Failed to fetch namespaces: ${res.status}`);
+      const data = await res.json();
+      return (data.items || []).map((i: any) => i.metadata.name).sort() as string[];
+    },
+    staleTime: 60000,
+  });
 
   function go(path: string, title: string) {
     addTab({ title, path, pinned: false, closable: true });
@@ -286,7 +288,25 @@ export function CommandBar() {
                     {selectedNamespace === '*' && <span className="text-blue-400 text-xs">✓</span>}
                   </button>
                   <div className="border-t border-slate-700/50 my-1" />
-                  {namespaces
+                  {namespacesLoading && (
+                    <div className="px-3 py-4 flex items-center justify-center gap-2 text-xs text-slate-500">
+                      <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                      Loading namespaces...
+                    </div>
+                  )}
+                  {namespacesError && (
+                    <div className="px-3 py-4 text-center">
+                      <p className="text-xs text-red-400 mb-2">Failed to load namespaces</p>
+                      <button
+                        onClick={() => queryClient.invalidateQueries({ queryKey: ['toolbar', 'namespaces'] })}
+                        className="text-xs text-blue-400 hover:text-blue-300 flex items-center gap-1 mx-auto"
+                      >
+                        <RefreshCw className="w-3 h-3" />
+                        Retry
+                      </button>
+                    </div>
+                  )}
+                  {!namespacesLoading && !namespacesError && namespaces
                     .filter((ns) => !nsFilter || ns.toLowerCase().includes(nsFilter.toLowerCase()))
                     .map((ns) => (
                       <button
@@ -299,7 +319,7 @@ export function CommandBar() {
                         {selectedNamespace === ns && <span className="text-blue-400 text-xs">✓</span>}
                       </button>
                     ))}
-                  {nsFilter && namespaces.filter((ns) => ns.toLowerCase().includes(nsFilter.toLowerCase())).length === 0 && (
+                  {!namespacesLoading && !namespacesError && nsFilter && namespaces.filter((ns) => ns.toLowerCase().includes(nsFilter.toLowerCase())).length === 0 && (
                     <div className="px-3 py-4 text-center text-xs text-slate-500">No namespaces match "{nsFilter}"</div>
                   )}
                 </div>

--- a/src/kubeview/views/TableView.tsx
+++ b/src/kubeview/views/TableView.tsx
@@ -1,7 +1,7 @@
 import React, { lazy, Suspense } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
-import { Search, ChevronUp, ChevronDown, Trash2, Tag, Plus, Filter, Columns3, X, Download, Loader2, CheckCircle, XCircle, FileEdit, Sparkles, Inbox } from 'lucide-react';
+import { Search, ChevronUp, ChevronDown, Trash2, Plus, Filter, Columns3, X, Download, Loader2, CheckCircle, XCircle, FileEdit, Sparkles, Inbox, AlertTriangle, Home, RefreshCw } from 'lucide-react';
 
 const NLFilterBar = lazy(() => import('../components/agent/NLFilterBar').then(m => ({ default: m.NLFilterBar })));
 import { cn } from '@/lib/utils';
@@ -506,9 +506,29 @@ export default function TableView({ gvrKey, namespace: namespaceProp }: TableVie
   if (error) {
     return (
       <div className="h-full flex items-center justify-center bg-slate-950">
-        <div className="text-center">
-          <p className="text-red-400 text-sm">Error loading resources</p>
-          <p className="text-slate-500 text-xs mt-2">{(error as Error).message}</p>
+        <div className="text-center max-w-md">
+          <div className="mb-4 mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-red-950/50 border border-red-900/50">
+            <AlertTriangle className="w-7 h-7 text-red-400" />
+          </div>
+          <h2 className="text-lg font-semibold text-slate-100 mb-1">Error loading resources</h2>
+          <p className="text-sm text-red-400 mb-2">{(error as Error).message}</p>
+          <p className="text-xs text-slate-500 mb-6">Check your cluster connection and ensure you have permission to list {resourceKind.toLowerCase()}.</p>
+          <div className="flex items-center justify-center gap-3">
+            <button
+              onClick={() => queryClient.invalidateQueries({ queryKey: ['k8s', 'list', apiPath] })}
+              className="px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-500 transition-colors flex items-center gap-2 font-medium"
+            >
+              <RefreshCw className="w-4 h-4" />
+              Retry
+            </button>
+            <button
+              onClick={() => navigate('/')}
+              className="px-4 py-2 text-sm bg-slate-800 text-slate-300 rounded-lg hover:bg-slate-700 transition-colors flex items-center gap-2 border border-slate-700"
+            >
+              <Home className="w-4 h-4" />
+              Go Home
+            </button>
+          </div>
         </div>
       </div>
     );

--- a/src/kubeview/views/__tests__/TableView.test.tsx
+++ b/src/kubeview/views/__tests__/TableView.test.tsx
@@ -233,7 +233,7 @@ describe('TableView', () => {
     expect(document.querySelector('.animate-pulse')).toBeDefined();
   });
 
-  it('shows error state', () => {
+  it('shows error state with retry and go home buttons', () => {
     setMockWatch({
       data: [],
       isLoading: false,
@@ -242,8 +242,55 @@ describe('TableView', () => {
 
     renderTable('v1/pods');
 
+    // Error icon, title, and message
     expect(screen.getByText('Error loading resources')).toBeDefined();
     expect(screen.getByText('Forbidden')).toBeDefined();
+
+    // Suggestion text
+    expect(screen.getByText(/Check your cluster connection/)).toBeDefined();
+
+    // Retry and Go Home buttons
+    expect(screen.getByText('Retry')).toBeDefined();
+    expect(screen.getByText('Go Home')).toBeDefined();
+  });
+
+  it('retry button invalidates queries on error state', () => {
+    setMockWatch({
+      data: [],
+      isLoading: false,
+      error: new Error('Connection refused'),
+    });
+
+    const queryClient = createQueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <TableView gvrKey="v1/pods" />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const retryButton = screen.getByText('Retry');
+    fireEvent.click(retryButton);
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['k8s', 'list', '/api/v1/pods'] });
+  });
+
+  it('go home button navigates to root on error state', () => {
+    setMockWatch({
+      data: [],
+      isLoading: false,
+      error: new Error('Not found'),
+    });
+
+    renderTable('v1/pods');
+
+    const goHomeButton = screen.getByText('Go Home');
+    fireEvent.click(goHomeButton);
+
+    expect(navigateMock).toHaveBeenCalledWith('/');
   });
 
   it('renders correct resource kind from gvrKey', () => {


### PR DESCRIPTION
## Summary
- TableView error state: icon, message, suggestion, Retry button, Go Home button
- CommandBar namespace fetch: replaced bare useEffect+fetch with useQuery (loading spinner, error state, retry, 60s staleTime)

## Test plan
- [ ] Disconnect proxy — TableView shows error with Retry button
- [ ] Click Retry — re-fetches data
- [ ] Namespace dropdown shows spinner while loading
- [ ] `npx vitest --run` — all 1671 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)