### PR TITLE
fix: accessibility — WCAG compliance, terminology, text sizes

### DIFF
--- a/src/kubeview/components/CommandPalette.tsx
+++ b/src/kubeview/components/CommandPalette.tsx
@@ -487,7 +487,7 @@ function renderGroups(
     const group = item.type === 'recent' ? 'FAVORITES' :
                   item.type === 'resource' ? 'RESOURCES' :
                   item.type === 'action' ? 'ACTIONS' :
-                  item.type === 'ai' ? 'PULSE AI' : 'PAGES';
+                  item.type === 'ai' ? 'PULSE AI' : 'VIEWS';
 
     if (!grouped.has(group)) {
       grouped.set(group, []);

--- a/src/kubeview/components/TabBar.tsx
+++ b/src/kubeview/components/TabBar.tsx
@@ -152,7 +152,7 @@ export function TabBar() {
   }
 
   return (
-    <div className="flex h-9 items-center gap-0.5 border-b border-slate-700 bg-slate-800 px-2 overflow-x-auto hide-scrollbar">
+    <div className="flex h-9 items-center gap-0.5 border-b border-slate-700 bg-slate-800 px-2 overflow-x-auto hide-scrollbar" role="tablist">
       {tabs.map((tab, tabIndex) => {
         const Icon = getIcon(tab.icon);
         const isActive = tab.id === activeTabId;
@@ -162,6 +162,7 @@ export function TabBar() {
           <div
             key={tab.id}
             role="tab"
+            aria-selected={isActive}
             draggable={!tab.pinned}
             onDragStart={() => setDraggedIdx(tabIndex)}
             onDragOver={(e) => { e.preventDefault(); setDragOverIdx(tabIndex); }}
@@ -223,6 +224,7 @@ export function TabBar() {
               <button
                 onClick={(e) => { e.stopPropagation(); unpinTab(tab.id); }}
                 className="rounded p-0.5 opacity-0 transition-opacity hover:bg-slate-600 group-hover:opacity-100 text-blue-400"
+                aria-label="Unpin tab"
                 title="Unpin tab"
               >
                 <PinOff className="h-3 w-3" />
@@ -231,6 +233,7 @@ export function TabBar() {
               <button
                 onClick={(e) => { e.stopPropagation(); pinTab(tab.id); }}
                 className="rounded p-0.5 opacity-0 transition-opacity hover:bg-slate-600 group-hover:opacity-100"
+                aria-label="Pin tab"
                 title="Pin tab"
               >
                 <Pin className="h-3 w-3" />
@@ -242,6 +245,7 @@ export function TabBar() {
               <button
                 onClick={(e) => handleTabClose(e, tab.id)}
                 className="rounded p-0.5 opacity-0 transition-opacity hover:bg-slate-600 group-hover:opacity-100"
+                aria-label="Close tab"
               >
                 <X className="h-3 w-3" />
               </button>

--- a/src/kubeview/components/__tests__/TabBar.render.test.tsx
+++ b/src/kubeview/components/__tests__/TabBar.render.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { TabBar } from '../TabBar';
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+
+vi.mock('../../store/uiStore', () => ({
+  useUIStore: Object.assign(
+    (selector: any) => {
+      const state = {
+        tabs: [
+          { id: '1', title: 'Workloads', path: '/workloads', pinned: true, closable: false },
+          { id: '2', title: 'Pods', path: '/r/v1~pods', pinned: false, closable: true },
+        ],
+        activeTabId: '1',
+        setActiveTab: vi.fn(),
+        closeTab: vi.fn(),
+        reorderTabs: vi.fn(),
+        pinTab: vi.fn(),
+        unpinTab: vi.fn(),
+        openCommandPalette: vi.fn(),
+        addTab: vi.fn(),
+        _pendingNavigate: null,
+      };
+      return selector(state);
+    },
+    { setState: vi.fn(), getState: vi.fn() },
+  ),
+}));
+
+describe('TabBar rendering', () => {
+  it('renders a tablist container with role="tablist"', () => {
+    render(
+      <MemoryRouter>
+        <TabBar />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole('tablist')).toBeTruthy();
+  });
+
+  it('renders tabs with aria-selected reflecting active state', () => {
+    render(
+      <MemoryRouter>
+        <TabBar />
+      </MemoryRouter>,
+    );
+    const tabs = screen.getAllByRole('tab');
+    expect(tabs.length).toBeGreaterThanOrEqual(2);
+    // First tab is active
+    expect(tabs[0].getAttribute('aria-selected')).toBe('true');
+    // Second tab is not active
+    expect(tabs[1].getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('close buttons have aria-label', () => {
+    render(
+      <MemoryRouter>
+        <TabBar />
+      </MemoryRouter>,
+    );
+    const closeBtns = screen.getAllByLabelText('Close tab');
+    expect(closeBtns.length).toBeGreaterThan(0);
+  });
+
+  it('pin buttons have aria-label', () => {
+    render(
+      <MemoryRouter>
+        <TabBar />
+      </MemoryRouter>,
+    );
+    const pinBtns = screen.getAllByLabelText('Pin tab');
+    expect(pinBtns.length).toBeGreaterThan(0);
+  });
+});

--- a/src/kubeview/components/agent/AgentComponentRenderer.tsx
+++ b/src/kubeview/components/agent/AgentComponentRenderer.tsx
@@ -237,14 +237,14 @@ function AgentChart({ spec }: { spec: ChartSpec }) {
       )}
       <svg viewBox={`0 0 ${width} ${height}`} className="w-full" style={{ maxHeight: height }}>
         {/* Y-axis labels */}
-        <text x={padding.left - 4} y={padding.top + 4} className="text-[9px] fill-slate-500" textAnchor="end">
+        <text x={padding.left - 4} y={padding.top + 4} className="text-xs fill-slate-500" textAnchor="end">
           {maxVal.toFixed(1)}
         </text>
-        <text x={padding.left - 4} y={height - padding.bottom} className="text-[9px] fill-slate-500" textAnchor="end">
+        <text x={padding.left - 4} y={height - padding.bottom} className="text-xs fill-slate-500" textAnchor="end">
           {minVal.toFixed(1)}
         </text>
         {spec.yAxisLabel && (
-          <text x={8} y={height / 2} className="text-[8px] fill-slate-500" textAnchor="middle" transform={`rotate(-90, 8, ${height / 2})`}>
+          <text x={8} y={height / 2} className="text-xs fill-slate-500" textAnchor="middle" transform={`rotate(-90, 8, ${height / 2})`}>
             {spec.yAxisLabel}
           </text>
         )}

--- a/src/kubeview/components/agent/ConfirmationCard.tsx
+++ b/src/kubeview/components/agent/ConfirmationCard.tsx
@@ -236,7 +236,7 @@ export function ConfirmationCard({ confirm, onConfirm }: ConfirmationCardProps) 
               aria-label="Approve operation (Y)"
             >
               <CheckCircle className="h-3.5 w-3.5" aria-hidden="true" />
-              Approve <kbd className="ml-1 text-[10px] opacity-60 bg-green-900 px-1 rounded">Y</kbd>
+              Approve <kbd className="ml-1 text-xs opacity-60 bg-green-900 px-1 rounded">Y</kbd>
             </button>
             {!showSimulation && (
               <button
@@ -254,7 +254,7 @@ export function ConfirmationCard({ confirm, onConfirm }: ConfirmationCardProps) 
               aria-label="Deny operation (N)"
             >
               <XCircle className="h-3.5 w-3.5" aria-hidden="true" />
-              Deny <kbd className="ml-1 text-[10px] opacity-60 bg-red-900 px-1 rounded">N</kbd>
+              Deny <kbd className="ml-1 text-xs opacity-60 bg-red-900 px-1 rounded">N</kbd>
             </button>
           </div>
           )}

--- a/src/kubeview/components/agent/MessageBubble.tsx
+++ b/src/kubeview/components/agent/MessageBubble.tsx
@@ -145,7 +145,7 @@ export const MessageBubble = memo(function MessageBubble({ message, mode }: { me
           <RichContent content={message.content} components={message.components} />
         )}
         <div className="flex items-center justify-between mt-1.5 pt-1 border-t border-slate-700/50">
-          <span className="text-[10px] text-slate-500 flex items-center gap-1">
+          <span className="text-xs text-slate-500 flex items-center gap-1">
             <Clock className="h-2.5 w-2.5" aria-hidden="true" />
             {timeStr}
           </span>

--- a/src/kubeview/components/feedback/ConfirmDialog.tsx
+++ b/src/kubeview/components/feedback/ConfirmDialog.tsx
@@ -95,6 +95,7 @@ export function ConfirmDialog({
         ref={dialogRef}
         className="w-full max-w-md rounded-lg bg-slate-800 p-6 shadow-xl"
         role="dialog"
+        aria-modal="true"
         aria-labelledby="dialog-title"
         aria-describedby="dialog-description"
       >

--- a/src/kubeview/views/DetailView.tsx
+++ b/src/kubeview/views/DetailView.tsx
@@ -702,7 +702,7 @@ export default function DetailView({ gvrKey, namespace, name }: DetailViewProps)
                           <span className="text-xs text-slate-400 font-mono flex-shrink-0 w-48 truncate" title={key}>{key}</span>
                           <span className="text-xs text-slate-200 font-mono flex-1">{value}</span>
                           <button onClick={() => { navigator.clipboard.writeText(`${key}=${value}`); addToast({ type: 'success', title: 'Label copied' }); }}
-                            className="opacity-0 group-hover:opacity-100 p-0.5 rounded text-slate-500 hover:text-slate-300 transition-opacity" title="Copy label">
+                            className="opacity-0 group-hover:opacity-100 focus:opacity-100 p-0.5 rounded text-slate-500 hover:text-slate-300 transition-opacity" title="Copy label">
                             <Copy className="w-3 h-3" />
                           </button>
                         </div>
@@ -752,7 +752,7 @@ export default function DetailView({ gvrKey, namespace, name }: DetailViewProps)
                           <span className="text-xs text-slate-400 font-mono flex-shrink-0 w-48 truncate" title={key}>{key}</span>
                           <span className="text-xs text-slate-200 font-mono flex-1">{value}</span>
                           <button onClick={() => { navigator.clipboard.writeText(`${key}=${value}`); addToast({ type: 'success', title: 'Label copied' }); }}
-                            className="opacity-0 group-hover:opacity-100 p-0.5 rounded text-slate-500 hover:text-slate-300 transition-opacity" title="Copy label">
+                            className="opacity-0 group-hover:opacity-100 focus:opacity-100 p-0.5 rounded text-slate-500 hover:text-slate-300 transition-opacity" title="Copy label">
                             <Copy className="w-3 h-3" />
                           </button>
                         </div>
@@ -887,7 +887,7 @@ export default function DetailView({ gvrKey, namespace, name }: DetailViewProps)
                       <span className="text-xs text-slate-200 font-mono flex-1">{value}</span>
                       <button
                         onClick={() => copyToClipboard(`${key}=${value}`, 'Label copied')}
-                        className="opacity-0 group-hover:opacity-100 p-0.5 rounded text-slate-500 hover:text-slate-300 transition-opacity"
+                        className="opacity-0 group-hover:opacity-100 focus:opacity-100 p-0.5 rounded text-slate-500 hover:text-slate-300 transition-opacity"
                         title="Copy label"
                       >
                         <Copy className="w-3 h-3" />
@@ -916,7 +916,7 @@ export default function DetailView({ gvrKey, namespace, name }: DetailViewProps)
                           </span>
                           <button
                             onClick={() => { navigator.clipboard.writeText(`${key}: ${value}`); addToast({ type: 'success', title: 'Annotation copied' }); }}
-                            className="opacity-0 group-hover:opacity-100 p-0.5 rounded text-slate-500 hover:text-slate-300 transition-opacity flex-shrink-0"
+                            className="opacity-0 group-hover:opacity-100 focus:opacity-100 p-0.5 rounded text-slate-500 hover:text-slate-300 transition-opacity flex-shrink-0"
                           >
                             <Copy className="w-3 h-3" />
                           </button>

--- a/src/kubeview/views/TableView.tsx
+++ b/src/kubeview/views/TableView.tsx
@@ -589,6 +589,7 @@ export default function TableView({ gvrKey, namespace: namespaceProp }: TableVie
                 value={searchInput}
                 onChange={(e) => setSearchInput(e.target.value)}
                 placeholder="Search..."
+                aria-label="Search resources"
                 className="pl-9 pr-3 py-1.5 text-sm bg-slate-900 border border-slate-700 rounded text-slate-200 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent w-64"
               />
             </div>
@@ -928,7 +929,7 @@ export default function TableView({ gvrKey, namespace: namespaceProp }: TableVie
                 }}
                 className="w-full px-3 py-1.5 text-xs bg-blue-600 hover:bg-blue-500 text-white rounded transition-colors"
               >
-                Open Detail Page →
+                Open Detail View →
               </button>
             </div>
           </div>

--- a/src/kubeview/views/pulse/ReportTab.tsx
+++ b/src/kubeview/views/pulse/ReportTab.tsx
@@ -811,7 +811,7 @@ export function ReportTab({ nodes, allPods, deployments, pvcs, operators, go }: 
                   <button key={i} onClick={() => go(ev.path, ev.name)}
                     className="w-full flex items-center gap-2 text-xs text-left hover:bg-slate-800/50 px-2 py-1.5 rounded transition-colors group">
                     <span className="text-slate-500 w-10 shrink-0 text-right font-mono">{ev.ago}</span>
-                    <span className={cn('px-1 py-0.5 rounded text-[10px] font-medium shrink-0',
+                    <span className={cn('px-1 py-0.5 rounded text-xs font-medium shrink-0',
                       ev.reason === 'Killing' || ev.reason === 'Unhealthy' || ev.reason === 'BackOff' ? 'bg-red-900/40 text-red-300' :
                       ev.reason === 'Pulled' || ev.reason === 'Created' || ev.reason === 'Started' || ev.reason === 'Scheduled' ? 'bg-green-900/40 text-green-300' :
                       'bg-slate-800 text-slate-400'


### PR DESCRIPTION
## Summary
- TabBar: added `role="tablist"`, `aria-selected`, `aria-label` on buttons
- ConfirmDialog: added `aria-modal="true"`
- Terminology: "PAGES" → "VIEWS", "Open Detail Page" → "Open Detail View"
- Sub-12px text: all `text-[10px]`/`text-[9px]`/`text-[8px]` → `text-xs`
- Copy buttons: added `focus:opacity-100` for keyboard users
- TableView search: added `aria-label="Search resources"`

## Test plan
- [ ] Screen reader: TabBar announces tabs with selection state
- [ ] Keyboard: copy buttons visible on focus
- [ ] `npx vitest --run` — all 1673 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)