### PR TITLE
feat: Last Updated timestamps on Pulse, Workloads, Compute views

### DIFF
--- a/src/kubeview/components/primitives/LastUpdated.tsx
+++ b/src/kubeview/components/primitives/LastUpdated.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { RefreshCw } from 'lucide-react';
+import { useQueryClient } from '@tanstack/react-query';
+import { cn } from '@/lib/utils';
+
+export function formatTimeAgo(timestamp: number): string {
+  const seconds = Math.floor((Date.now() - timestamp) / 1000);
+  if (seconds < 5) return 'just now';
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ago`;
+}
+
+interface LastUpdatedProps {
+  timestamp: number;
+  className?: string;
+}
+
+/** Returns the earliest non-zero dataUpdatedAt from a set of queries, or 0 if none have data. */
+export function earliestDataUpdatedAt(queries: Array<{ dataUpdatedAt: number }>): number {
+  const timestamps = queries.map((q) => q.dataUpdatedAt).filter((t) => t > 0);
+  return timestamps.length > 0 ? Math.min(...timestamps) : 0;
+}
+
+export function LastUpdated({ timestamp, className }: LastUpdatedProps) {
+  const queryClient = useQueryClient();
+  const [, setTick] = React.useState(0);
+
+  React.useEffect(() => {
+    const interval = setInterval(() => setTick((t) => t + 1), 10_000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const handleRefresh = () => {
+    queryClient.invalidateQueries({ queryKey: ['k8s'] });
+  };
+
+  if (!timestamp) return null;
+
+  return (
+    <div className={cn('flex items-center gap-1.5 text-xs text-slate-500', className)}>
+      <span data-testid="last-updated-text">Updated {formatTimeAgo(timestamp)}</span>
+      <button
+        onClick={handleRefresh}
+        className="p-0.5 rounded hover:bg-slate-800 hover:text-slate-300 transition-colors"
+        title="Refresh data"
+        data-testid="refresh-button"
+      >
+        <RefreshCw className="w-3 h-3" />
+      </button>
+    </div>
+  );
+}

--- a/src/kubeview/components/primitives/__tests__/LastUpdated.test.tsx
+++ b/src/kubeview/components/primitives/__tests__/LastUpdated.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { LastUpdated, formatTimeAgo, earliestDataUpdatedAt } from '../LastUpdated';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe('formatTimeAgo', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-26T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns "just now" for timestamps within 5 seconds', () => {
+    expect(formatTimeAgo(Date.now() - 2000)).toBe('just now');
+  });
+
+  it('returns seconds ago for timestamps within a minute', () => {
+    expect(formatTimeAgo(Date.now() - 30_000)).toBe('30s ago');
+  });
+
+  it('returns minutes ago for timestamps within an hour', () => {
+    expect(formatTimeAgo(Date.now() - 120_000)).toBe('2m ago');
+  });
+
+  it('returns hours ago for timestamps over an hour', () => {
+    expect(formatTimeAgo(Date.now() - 7_200_000)).toBe('2h ago');
+  });
+});
+
+describe('earliestDataUpdatedAt', () => {
+  it('returns 0 when all queries have dataUpdatedAt of 0', () => {
+    expect(earliestDataUpdatedAt([{ dataUpdatedAt: 0 }, { dataUpdatedAt: 0 }])).toBe(0);
+  });
+
+  it('returns 0 for an empty array', () => {
+    expect(earliestDataUpdatedAt([])).toBe(0);
+  });
+
+  it('returns the earliest non-zero timestamp', () => {
+    expect(earliestDataUpdatedAt([
+      { dataUpdatedAt: 1000 },
+      { dataUpdatedAt: 500 },
+      { dataUpdatedAt: 2000 },
+    ])).toBe(500);
+  });
+
+  it('ignores zero timestamps', () => {
+    expect(earliestDataUpdatedAt([
+      { dataUpdatedAt: 0 },
+      { dataUpdatedAt: 1500 },
+      { dataUpdatedAt: 0 },
+    ])).toBe(1500);
+  });
+});
+
+describe('LastUpdated', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-26T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('renders nothing when timestamp is 0', () => {
+    const { container } = render(<LastUpdated timestamp={0} />, {
+      wrapper: createWrapper(),
+    });
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders the time-ago text', () => {
+    render(<LastUpdated timestamp={Date.now() - 15_000} />, {
+      wrapper: createWrapper(),
+    });
+    expect(screen.getByTestId('last-updated-text').textContent).toBe('Updated 15s ago');
+  });
+
+  it('renders a refresh button', () => {
+    render(<LastUpdated timestamp={Date.now() - 5000} />, {
+      wrapper: createWrapper(),
+    });
+    const btn = screen.getByTestId('refresh-button');
+    expect(btn).toBeDefined();
+    expect(btn.getAttribute('title')).toBe('Refresh data');
+  });
+
+  it('invalidates k8s queries when refresh is clicked', () => {
+    const queryClient = new QueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <LastUpdated timestamp={Date.now() - 10_000} />
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(screen.getByTestId('refresh-button'));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['k8s'] });
+  });
+
+  it('auto-refreshes the display every 10 seconds', () => {
+    const initialTime = Date.now();
+    render(<LastUpdated timestamp={initialTime - 10_000} />, {
+      wrapper: createWrapper(),
+    });
+    expect(screen.getByTestId('last-updated-text').textContent).toBe('Updated 10s ago');
+
+    // advanceTimersByTime also advances Date.now() with fake timers
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(screen.getByTestId('last-updated-text').textContent).toBe('Updated 20s ago');
+  });
+});

--- a/src/kubeview/views/ComputeView.tsx
+++ b/src/kubeview/views/ComputeView.tsx
@@ -16,6 +16,7 @@ import { getNodeStatus } from '../engine/renderers/statusUtils';
 import { parseResourceValue, formatBytes, formatCpu } from '../engine/formatting';
 import { useNavigateTab } from '../hooks/useNavigateTab';
 import { useK8sListWatch } from '../hooks/useK8sListWatch';
+import { LastUpdated, earliestDataUpdatedAt } from '../components/primitives/LastUpdated';
 import { useClusterStore } from '../store/clusterStore';
 import { Card } from '../components/primitives/Card';
 import { CapacityTab } from './compute/CapacityTab';
@@ -74,8 +75,12 @@ export default function ComputeView() {
   const [computeTab, setComputeTab] = React.useState<'overview' | 'capacity'>(urlTab === 'capacity' ? 'capacity' : 'overview');
   const isHyperShift = useClusterStore((s) => s.isHyperShift);
 
-  const { data: nodes = [] } = useK8sListWatch({ apiPath: '/api/v1/nodes' });
-  const { data: pods = [] } = useK8sListWatch({ apiPath: '/api/v1/pods' });
+  const nodesQuery = useK8sListWatch({ apiPath: '/api/v1/nodes' });
+  const podsQuery = useK8sListWatch({ apiPath: '/api/v1/pods' });
+  const nodes = nodesQuery.data ?? [];
+  const pods = podsQuery.data ?? [];
+
+  const dataUpdatedAt = earliestDataUpdatedAt([nodesQuery, podsQuery]);
 
   const { data: machines = [] } = useQuery<K8sResource[]>({
     queryKey: ['k8s', 'list', '/apis/machine.openshift.io/v1beta1/machines'],
@@ -249,7 +254,10 @@ export default function ComputeView() {
       <div className="max-w-7xl mx-auto space-y-6">
         <div>
           <h1 className="text-2xl font-bold text-slate-100 flex items-center gap-2"><Server className="w-6 h-6 text-blue-500" /> Compute</h1>
-          <p className="text-sm text-slate-400 mt-1">Cluster capacity, node health, and resource utilization</p>
+          <div className="flex items-center gap-3 mt-1">
+            <p className="text-sm text-slate-400">Cluster capacity, node health, and resource utilization</p>
+            <LastUpdated timestamp={dataUpdatedAt} />
+          </div>
         </div>
 
         {/* Tabs */}

--- a/src/kubeview/views/PulseView.tsx
+++ b/src/kubeview/views/PulseView.tsx
@@ -5,6 +5,7 @@ import { useUIStore } from '../store/uiStore';
 import { useFleetStore } from '../store/fleetStore';
 import { useNavigateTab } from '../hooks/useNavigateTab';
 import { useK8sListWatch } from '../hooks/useK8sListWatch';
+import { LastUpdated, earliestDataUpdatedAt } from '../components/primitives/LastUpdated';
 import { ReportTab } from './pulse/ReportTab';
 import { FleetReportTab } from './pulse/FleetReportTab';
 import { AIOnboarding } from '../components/agent/AIOnboarding';
@@ -15,11 +16,22 @@ export default function PulseView() {
   const fleetMode = useFleetStore((s) => s.fleetMode);
 
   const nsFilter = selectedNamespace !== '*' ? selectedNamespace : undefined;
-  const { data: nodes = [], isLoading: nodesLoading } = useK8sListWatch({ apiPath: '/api/v1/nodes' });
-  const { data: pods = [], isLoading: podsLoading } = useK8sListWatch({ apiPath: '/api/v1/pods', namespace: nsFilter });
-  const { data: deployments = [], isLoading: deploysLoading } = useK8sListWatch({ apiPath: '/apis/apps/v1/deployments', namespace: nsFilter });
-  const { data: pvcs = [] } = useK8sListWatch({ apiPath: '/api/v1/persistentvolumeclaims', namespace: nsFilter });
-  const { data: operators = [] } = useK8sListWatch({ apiPath: '/apis/config.openshift.io/v1/clusteroperators' });
+  const nodesQuery = useK8sListWatch({ apiPath: '/api/v1/nodes' });
+  const podsQuery = useK8sListWatch({ apiPath: '/api/v1/pods', namespace: nsFilter });
+  const deploysQuery = useK8sListWatch({ apiPath: '/apis/apps/v1/deployments', namespace: nsFilter });
+  const pvcsQuery = useK8sListWatch({ apiPath: '/api/v1/persistentvolumeclaims', namespace: nsFilter });
+  const operatorsQuery = useK8sListWatch({ apiPath: '/apis/config.openshift.io/v1/clusteroperators' });
+
+  const nodes = nodesQuery.data ?? [];
+  const pods = podsQuery.data ?? [];
+  const deployments = deploysQuery.data ?? [];
+  const pvcs = pvcsQuery.data ?? [];
+  const operators = operatorsQuery.data ?? [];
+  const nodesLoading = nodesQuery.isLoading;
+  const podsLoading = podsQuery.isLoading;
+  const deploysLoading = deploysQuery.isLoading;
+
+  const dataUpdatedAt = earliestDataUpdatedAt([nodesQuery, podsQuery, deploysQuery, pvcsQuery, operatorsQuery]);
 
   const isLoading = nodesLoading || podsLoading || deploysLoading;
 
@@ -31,10 +43,13 @@ export default function PulseView() {
             <HeartPulse className="w-6 h-6 text-blue-500" />
             Cluster Pulse
           </h1>
-          <p className="text-sm text-slate-400 mt-1">
-            Daily briefing — control plane, capacity, workload health, and next steps
-            {selectedNamespace !== '*' && <span className="text-blue-400 ml-1">· {selectedNamespace}</span>}
-          </p>
+          <div className="flex items-center gap-3 mt-1">
+            <p className="text-sm text-slate-400">
+              Daily briefing — control plane, capacity, workload health, and next steps
+              {selectedNamespace !== '*' && <span className="text-blue-400 ml-1">· {selectedNamespace}</span>}
+            </p>
+            <LastUpdated timestamp={dataUpdatedAt} />
+          </div>
         </div>
 
         <AIOnboarding compact className="mb-2" />

--- a/src/kubeview/views/WorkloadsView.tsx
+++ b/src/kubeview/views/WorkloadsView.tsx
@@ -12,6 +12,7 @@ import { getDeploymentStatus, getPodStatus } from '../engine/renderers/statusUti
 import { useUIStore } from '../store/uiStore';
 import { useNavigateTab } from '../hooks/useNavigateTab';
 import { useK8sListWatch } from '../hooks/useK8sListWatch';
+import { LastUpdated, earliestDataUpdatedAt } from '../components/primitives/LastUpdated';
 import { MetricCard } from '../components/metrics/Sparkline';
 import { MetricGrid } from '../components/primitives/MetricGrid';
 import { CHART_COLORS } from '../engine/colors';
@@ -44,14 +45,25 @@ export default function WorkloadsView() {
   const nsFilter = selectedNamespace !== '*' ? selectedNamespace : undefined;
   const safeNs = nsFilter ? sanitizePromQL(nsFilter) : '';
 
-  const { data: deployments = [] } = useK8sListWatch<Deployment>({ apiPath: '/apis/apps/v1/deployments', namespace: nsFilter });
-  const { data: statefulsets = [] } = useK8sListWatch<StatefulSet>({ apiPath: '/apis/apps/v1/statefulsets', namespace: nsFilter });
-  const { data: daemonsets = [] } = useK8sListWatch<DaemonSet>({ apiPath: '/apis/apps/v1/daemonsets', namespace: nsFilter });
-  const { data: pods = [] } = useK8sListWatch<Pod>({ apiPath: '/api/v1/pods', namespace: nsFilter });
-  const { data: jobs = [] } = useK8sListWatch<Job>({ apiPath: '/apis/batch/v1/jobs', namespace: nsFilter });
-  const { data: cronjobs = [] } = useK8sListWatch<CronJob>({ apiPath: '/apis/batch/v1/cronjobs', namespace: nsFilter });
-  const { data: replicasets = [] } = useK8sListWatch<ReplicaSet>({ apiPath: '/apis/apps/v1/replicasets', namespace: nsFilter });
-  const { data: pdbs = [] } = useK8sListWatch<PodDisruptionBudget>({ apiPath: '/apis/policy/v1/poddisruptionbudgets', namespace: nsFilter });
+  const deploymentsQuery = useK8sListWatch<Deployment>({ apiPath: '/apis/apps/v1/deployments', namespace: nsFilter });
+  const statefulsetsQuery = useK8sListWatch<StatefulSet>({ apiPath: '/apis/apps/v1/statefulsets', namespace: nsFilter });
+  const daemonsetsQuery = useK8sListWatch<DaemonSet>({ apiPath: '/apis/apps/v1/daemonsets', namespace: nsFilter });
+  const podsQuery = useK8sListWatch<Pod>({ apiPath: '/api/v1/pods', namespace: nsFilter });
+  const jobsQuery = useK8sListWatch<Job>({ apiPath: '/apis/batch/v1/jobs', namespace: nsFilter });
+  const cronjobsQuery = useK8sListWatch<CronJob>({ apiPath: '/apis/batch/v1/cronjobs', namespace: nsFilter });
+  const replicasetsQuery = useK8sListWatch<ReplicaSet>({ apiPath: '/apis/apps/v1/replicasets', namespace: nsFilter });
+  const pdbsQuery = useK8sListWatch<PodDisruptionBudget>({ apiPath: '/apis/policy/v1/poddisruptionbudgets', namespace: nsFilter });
+
+  const deployments = deploymentsQuery.data ?? [];
+  const statefulsets = statefulsetsQuery.data ?? [];
+  const daemonsets = daemonsetsQuery.data ?? [];
+  const pods = podsQuery.data ?? [];
+  const jobs = jobsQuery.data ?? [];
+  const cronjobs = cronjobsQuery.data ?? [];
+  const replicasets = replicasetsQuery.data ?? [];
+  const pdbs = pdbsQuery.data ?? [];
+
+  const dataUpdatedAt = earliestDataUpdatedAt([deploymentsQuery, podsQuery, statefulsetsQuery, daemonsetsQuery, jobsQuery, cronjobsQuery]);
 
   // Pod status breakdown
   const podStats = React.useMemo(() => {
@@ -129,10 +141,13 @@ export default function WorkloadsView() {
             <h1 className="text-2xl font-bold text-slate-100 flex items-center gap-2">
               <Package className="w-6 h-6 text-blue-500" /> Workloads
             </h1>
-            <p className="text-sm text-slate-400 mt-1">
-              Deployments, StatefulSets, DaemonSets, Jobs, and Pods
-              {nsFilter && <span className="text-blue-400 ml-1">in {nsFilter}</span>}
-            </p>
+            <div className="flex items-center gap-3 mt-1">
+              <p className="text-sm text-slate-400">
+                Deployments, StatefulSets, DaemonSets, Jobs, and Pods
+                {nsFilter && <span className="text-blue-400 ml-1">in {nsFilter}</span>}
+              </p>
+              <LastUpdated timestamp={dataUpdatedAt} />
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- New `LastUpdated` component with time-ago display, 10s auto-refresh, refresh button
- Added to PulseView, WorkloadsView, ComputeView headers
- Shared `earliestDataUpdatedAt` helper for multi-query views
- Builds trust during incidents — users see data freshness at a glance

## Test plan
- [ ] Open PulseView — verify "Last updated: Xs ago" in header
- [ ] Click refresh button — data re-fetches, timestamp resets
- [ ] Wait 10s — timestamp auto-updates
- [ ] `npx vitest --run` — all 1682 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)