### PR TITLE
feat: GitOps store + sanitizeForGitOps foundation

### DIFF
--- a/src/kubeview/__tests__/gitops-sanitize-store.test.ts
+++ b/src/kubeview/__tests__/gitops-sanitize-store.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { sanitizeForGitOps } from '../engine/yamlUtils';
+import { useGitOpsSetupStore } from '../store/gitopsSetupStore';
+
+describe('sanitizeForGitOps', () => {
+  it('strips status, resourceVersion, uid, managedFields, ownerReferences', () => {
+    const resource = {
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: {
+        name: 'my-config',
+        namespace: 'default',
+        resourceVersion: '12345',
+        uid: 'abc-123',
+        creationTimestamp: '2024-01-01T00:00:00Z',
+        generation: 3,
+        selfLink: '/api/v1/namespaces/default/configmaps/my-config',
+        managedFields: [{ manager: 'kubectl' }],
+        ownerReferences: [{ kind: 'Deployment', name: 'my-deploy' }],
+      },
+      data: { key: 'value' },
+      status: { phase: 'Active' },
+    };
+
+    const result = sanitizeForGitOps(resource);
+
+    expect(result.status).toBeUndefined();
+    expect(result.metadata).toBeDefined();
+    const meta = result.metadata as Record<string, unknown>;
+    expect(meta.resourceVersion).toBeUndefined();
+    expect(meta.uid).toBeUndefined();
+    expect(meta.creationTimestamp).toBeUndefined();
+    expect(meta.generation).toBeUndefined();
+    expect(meta.selfLink).toBeUndefined();
+    expect(meta.managedFields).toBeUndefined();
+    expect(meta.ownerReferences).toBeUndefined();
+    // Preserved fields
+    expect(meta.name).toBe('my-config');
+    expect(meta.namespace).toBe('default');
+    expect((result as Record<string, unknown>).data).toEqual({ key: 'value' });
+  });
+
+  it('redacts Secret data and adds annotation', () => {
+    const secret = {
+      apiVersion: 'v1',
+      kind: 'Secret',
+      metadata: { name: 'my-secret', namespace: 'default' },
+      data: { password: 'c2VjcmV0', username: 'dXNlcg==' },
+      stringData: { token: 'plaintext' },
+    };
+
+    const result = sanitizeForGitOps(secret);
+
+    expect(result.data).toEqual({});
+    expect(result.stringData).toBeUndefined();
+    const meta = result.metadata as Record<string, unknown>;
+    const annotations = meta.annotations as Record<string, string>;
+    expect(annotations['openshiftpulse.io/secret-data']).toBe('redacted');
+  });
+
+  it('removes noisy annotations and pv.kubernetes.io/* annotations', () => {
+    const resource = {
+      apiVersion: 'v1',
+      kind: 'PersistentVolumeClaim',
+      metadata: {
+        name: 'my-pvc',
+        annotations: {
+          'kubectl.kubernetes.io/last-applied-configuration': '{}',
+          'openshift.io/generated-by': 'OpenShiftWebConsole',
+          'deployment.kubernetes.io/revision': '3',
+          'pv.kubernetes.io/bind-completed': 'yes',
+          'pv.kubernetes.io/bound-by-controller': 'yes',
+          'my-custom/annotation': 'keep-me',
+        },
+      },
+    };
+
+    const result = sanitizeForGitOps(resource);
+    const meta = result.metadata as Record<string, unknown>;
+    const annotations = meta.annotations as Record<string, string>;
+
+    expect(annotations['kubectl.kubernetes.io/last-applied-configuration']).toBeUndefined();
+    expect(annotations['openshift.io/generated-by']).toBeUndefined();
+    expect(annotations['deployment.kubernetes.io/revision']).toBeUndefined();
+    expect(annotations['pv.kubernetes.io/bind-completed']).toBeUndefined();
+    expect(annotations['pv.kubernetes.io/bound-by-controller']).toBeUndefined();
+    expect(annotations['my-custom/annotation']).toBe('keep-me');
+  });
+
+  it('removes empty annotations object', () => {
+    const resource = {
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: {
+        name: 'test',
+        annotations: {
+          'kubectl.kubernetes.io/last-applied-configuration': '{}',
+        },
+      },
+    };
+
+    const result = sanitizeForGitOps(resource);
+    const meta = result.metadata as Record<string, unknown>;
+    expect(meta.annotations).toBeUndefined();
+  });
+
+  it('does not mutate the original resource', () => {
+    const resource = {
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: { name: 'test', uid: 'abc' },
+      status: { phase: 'Active' },
+    };
+
+    sanitizeForGitOps(resource);
+
+    expect(resource.status).toEqual({ phase: 'Active' });
+    expect(resource.metadata.uid).toBe('abc');
+  });
+});
+
+describe('useGitOpsSetupStore — new fields', () => {
+  beforeEach(() => {
+    useGitOpsSetupStore.setState({
+      selectedCategories: ['cluster-config', 'operators'],
+      selectedNamespaces: [],
+      clusterName: '',
+      exportProgress: null,
+      exportMode: 'pull-request',
+    });
+  });
+
+  it('has correct defaults for new fields', () => {
+    const state = useGitOpsSetupStore.getState();
+    expect(state.selectedCategories).toEqual(['cluster-config', 'operators']);
+    expect(state.selectedNamespaces).toEqual([]);
+    expect(state.clusterName).toBe('');
+    expect(state.exportProgress).toBeNull();
+    expect(state.exportMode).toBe('pull-request');
+  });
+
+  it('setSelectedCategories updates categories', () => {
+    useGitOpsSetupStore.getState().setSelectedCategories(['networking', 'rbac']);
+    expect(useGitOpsSetupStore.getState().selectedCategories).toEqual(['networking', 'rbac']);
+  });
+
+  it('setSelectedNamespaces updates namespaces', () => {
+    useGitOpsSetupStore.getState().setSelectedNamespaces(['default', 'kube-system']);
+    expect(useGitOpsSetupStore.getState().selectedNamespaces).toEqual(['default', 'kube-system']);
+  });
+
+  it('setClusterName updates cluster name', () => {
+    useGitOpsSetupStore.getState().setClusterName('prod-east');
+    expect(useGitOpsSetupStore.getState().clusterName).toBe('prod-east');
+  });
+
+  it('setExportProgress updates progress', () => {
+    const progress = { category: 'operators', totalFiles: 10, committedFiles: 3, errors: [] };
+    useGitOpsSetupStore.getState().setExportProgress(progress);
+    expect(useGitOpsSetupStore.getState().exportProgress).toEqual(progress);
+
+    useGitOpsSetupStore.getState().setExportProgress(null);
+    expect(useGitOpsSetupStore.getState().exportProgress).toBeNull();
+  });
+
+  it('setExportMode updates mode', () => {
+    useGitOpsSetupStore.getState().setExportMode('direct-commit');
+    expect(useGitOpsSetupStore.getState().exportMode).toBe('direct-commit');
+  });
+
+  it('WizardStep type includes select-resources and export', () => {
+    useGitOpsSetupStore.getState().setStep('select-resources');
+    expect(useGitOpsSetupStore.getState().currentStep).toBe('select-resources');
+
+    useGitOpsSetupStore.getState().setStep('export');
+    expect(useGitOpsSetupStore.getState().currentStep).toBe('export');
+  });
+});

--- a/src/kubeview/engine/yamlUtils.ts
+++ b/src/kubeview/engine/yamlUtils.ts
@@ -66,6 +66,47 @@ export function jsonToYaml(obj: unknown, indent: number = 0): string {
 }
 
 /**
+ * Sanitize a K8s resource for GitOps export — strips runtime fields, redacts secrets
+ */
+export function sanitizeForGitOps(resource: Record<string, unknown>): Record<string, unknown> {
+  const clean = JSON.parse(JSON.stringify(resource));
+
+  delete clean.status;
+
+  if (clean.metadata) {
+    delete clean.metadata.resourceVersion;
+    delete clean.metadata.uid;
+    delete clean.metadata.creationTimestamp;
+    delete clean.metadata.generation;
+    delete clean.metadata.selfLink;
+    delete clean.metadata.managedFields;
+    delete clean.metadata.ownerReferences;
+
+    if (clean.metadata.annotations) {
+      const noisy = [
+        'kubectl.kubernetes.io/last-applied-configuration',
+        'openshift.io/generated-by',
+        'deployment.kubernetes.io/revision',
+      ];
+      for (const key of noisy) delete clean.metadata.annotations[key];
+      for (const key of Object.keys(clean.metadata.annotations)) {
+        if (key.startsWith('pv.kubernetes.io/')) delete clean.metadata.annotations[key];
+      }
+      if (Object.keys(clean.metadata.annotations).length === 0) delete clean.metadata.annotations;
+    }
+  }
+
+  if (clean.kind === 'Secret') {
+    clean.data = {};
+    delete clean.stringData;
+    if (!clean.metadata.annotations) clean.metadata.annotations = {};
+    clean.metadata.annotations['openshiftpulse.io/secret-data'] = 'redacted';
+  }
+
+  return clean;
+}
+
+/**
  * Convert a K8s resource to clean YAML (removes managed fields and other noise)
  */
 export function resourceToYaml(resource: Record<string, unknown>): string {

--- a/src/kubeview/store/gitopsSetupStore.ts
+++ b/src/kubeview/store/gitopsSetupStore.ts
@@ -3,7 +3,14 @@ import { persist } from 'zustand/middleware';
 import { useArgoCDStore } from './argoCDStore';
 import { k8sGet } from '../engine/query';
 
-export type WizardStep = 'operator' | 'git-config' | 'first-app' | 'done';
+export type WizardStep = 'operator' | 'git-config' | 'first-app' | 'select-resources' | 'export' | 'done';
+
+interface ExportProgress {
+  category: string;
+  totalFiles: number;
+  committedFiles: number;
+  errors: string[];
+}
 
 interface GitOpsSetupState {
   wizardOpen: boolean;
@@ -14,11 +21,22 @@ interface GitOpsSetupState {
   operatorPhase: 'idle' | 'creating' | 'pending' | 'installing' | 'succeeded' | 'failed';
   operatorError: string | null;
 
+  selectedCategories: string[];
+  selectedNamespaces: string[];
+  clusterName: string;
+  exportProgress: ExportProgress | null;
+  exportMode: 'direct-commit' | 'pull-request';
+
   openWizard: (resumeAt?: WizardStep) => void;
   closeWizard: () => void;
   setStep: (step: WizardStep) => void;
   markStepComplete: (step: WizardStep) => void;
   setOperatorPhase: (phase: GitOpsSetupState['operatorPhase'], error?: string) => void;
+  setSelectedCategories: (categories: string[]) => void;
+  setSelectedNamespaces: (namespaces: string[]) => void;
+  setClusterName: (name: string) => void;
+  setExportProgress: (progress: ExportProgress | null) => void;
+  setExportMode: (mode: 'direct-commit' | 'pull-request') => void;
   detectCompletedSteps: () => Promise<void>;
 }
 
@@ -31,6 +49,12 @@ export const useGitOpsSetupStore = create<GitOpsSetupState>()(
       dismissed: false,
       operatorPhase: 'idle',
       operatorError: null,
+
+      selectedCategories: ['cluster-config', 'operators'],
+      selectedNamespaces: [],
+      clusterName: '',
+      exportProgress: null,
+      exportMode: 'pull-request',
 
       openWizard: (resumeAt) => {
         const step = resumeAt || get().currentStep;
@@ -50,6 +74,12 @@ export const useGitOpsSetupStore = create<GitOpsSetupState>()(
 
       setOperatorPhase: (phase, error) =>
         set({ operatorPhase: phase, operatorError: error || null }),
+
+      setSelectedCategories: (categories) => set({ selectedCategories: categories }),
+      setSelectedNamespaces: (namespaces) => set({ selectedNamespaces: namespaces }),
+      setClusterName: (name) => set({ clusterName: name }),
+      setExportProgress: (progress) => set({ exportProgress: progress }),
+      setExportMode: (mode) => set({ exportMode: mode }),
 
       detectCompletedSteps: async () => {
         const completed: WizardStep[] = [];
@@ -88,6 +118,10 @@ export const useGitOpsSetupStore = create<GitOpsSetupState>()(
       partialize: (state) => ({
         completedSteps: state.completedSteps,
         dismissed: state.dismissed,
+        selectedCategories: state.selectedCategories,
+        selectedNamespaces: state.selectedNamespaces,
+        clusterName: state.clusterName,
+        exportMode: state.exportMode,
       }),
     },
   ),


### PR DESCRIPTION
## Summary
- Extended gitopsSetupStore with select-resources/export steps, category/namespace/cluster selections
- Added `sanitizeForGitOps()` to yamlUtils — strips runtime fields, redacts Secret data
- 12 new tests covering sanitization and store state

## Test plan
- [ ] `npx vitest --run` — all 1719 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)