### PR TITLE
feat: export engine + SelectResourcesStep for cluster-as-code wizard

### DIFF
--- a/src/kubeview/engine/__tests__/gitopsExport.test.ts
+++ b/src/kubeview/engine/__tests__/gitopsExport.test.ts
@@ -1,0 +1,311 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  RESOURCE_CATEGORIES,
+  isUserNamespace,
+  sanitizeResource,
+  exportClusterToGit,
+  type ExportEvent,
+  type ExportOptions,
+} from '../gitopsExport';
+import type { K8sResource } from '../renderers/index';
+
+// Mock query module
+vi.mock('../query', () => ({
+  k8sList: vi.fn().mockResolvedValue([]),
+}));
+
+// Mock gitProvider module
+vi.mock('../gitProvider', () => ({
+  createGitProvider: vi.fn(),
+}));
+
+import { k8sList } from '../query';
+import { createGitProvider } from '../gitProvider';
+
+const mockK8sList = vi.mocked(k8sList);
+const mockCreateGitProvider = vi.mocked(createGitProvider);
+
+describe('RESOURCE_CATEGORIES', () => {
+  it('has 4 categories', () => {
+    expect(RESOURCE_CATEGORIES).toHaveLength(4);
+  });
+
+  it('includes workloads, networking, config, and storage', () => {
+    const ids = RESOURCE_CATEGORIES.map((c) => c.id);
+    expect(ids).toEqual(['workloads', 'networking', 'config', 'storage']);
+  });
+
+  it('each category has at least one resource', () => {
+    for (const cat of RESOURCE_CATEGORIES) {
+      expect(cat.resources.length).toBeGreaterThan(0);
+      expect(cat.label).toBeTruthy();
+      expect(cat.description).toBeTruthy();
+    }
+  });
+
+  it('each resource has kind, apiPath, and namespaced flag', () => {
+    for (const cat of RESOURCE_CATEGORIES) {
+      for (const res of cat.resources) {
+        expect(res.kind).toBeTruthy();
+        expect(res.apiPath).toMatch(/^\//);
+        expect(typeof res.namespaced).toBe('boolean');
+      }
+    }
+  });
+
+  it('workloads category has deployments, statefulsets, daemonsets, cronjobs', () => {
+    const workloads = RESOURCE_CATEGORIES.find((c) => c.id === 'workloads')!;
+    const kinds = workloads.resources.map((r) => r.kind);
+    expect(kinds).toContain('Deployment');
+    expect(kinds).toContain('StatefulSet');
+    expect(kinds).toContain('DaemonSet');
+    expect(kinds).toContain('CronJob');
+  });
+
+  it('storage category includes a non-namespaced resource (StorageClass)', () => {
+    const storage = RESOURCE_CATEGORIES.find((c) => c.id === 'storage')!;
+    const sc = storage.resources.find((r) => r.kind === 'StorageClass');
+    expect(sc).toBeDefined();
+    expect(sc!.namespaced).toBe(false);
+  });
+});
+
+describe('isUserNamespace', () => {
+  it('returns true for user namespaces', () => {
+    expect(isUserNamespace('my-app')).toBe(true);
+    expect(isUserNamespace('production')).toBe(true);
+    expect(isUserNamespace('team-frontend')).toBe(true);
+  });
+
+  it('returns false for openshift- prefixed namespaces', () => {
+    expect(isUserNamespace('openshift-operators')).toBe(false);
+    expect(isUserNamespace('openshift-monitoring')).toBe(false);
+    expect(isUserNamespace('openshift-console')).toBe(false);
+  });
+
+  it('returns false for kube- prefixed namespaces', () => {
+    expect(isUserNamespace('kube-system')).toBe(false);
+    expect(isUserNamespace('kube-public')).toBe(false);
+    expect(isUserNamespace('kube-node-lease')).toBe(false);
+  });
+
+  it('returns false for default namespace', () => {
+    expect(isUserNamespace('default')).toBe(false);
+  });
+
+  it('returns false for openshift namespace', () => {
+    expect(isUserNamespace('openshift')).toBe(false);
+  });
+
+  it('returns true for namespaces starting with "kube" but not "kube-"', () => {
+    expect(isUserNamespace('kubeedge')).toBe(true);
+  });
+});
+
+describe('sanitizeResource', () => {
+  const baseResource: K8sResource = {
+    apiVersion: 'apps/v1',
+    kind: 'Deployment',
+    metadata: {
+      name: 'my-app',
+      namespace: 'production',
+      uid: 'abc-123',
+      resourceVersion: '12345',
+      creationTimestamp: '2026-01-01T00:00:00Z',
+      labels: { app: 'my-app' },
+      annotations: {
+        'app.kubernetes.io/name': 'my-app',
+        'kubectl.kubernetes.io/last-applied-configuration': '{}',
+        'deployment.kubernetes.io/revision': '3',
+      },
+      ownerReferences: [
+        { apiVersion: 'v1', kind: 'ReplicaSet', name: 'my-app-abc', uid: 'ref-123' },
+      ],
+    },
+    spec: { replicas: 2 },
+    status: { readyReplicas: 2 },
+  };
+
+  it('strips uid, resourceVersion, creationTimestamp', () => {
+    const clean = sanitizeResource(baseResource);
+    expect(clean.metadata.uid).toBeUndefined();
+    expect(clean.metadata.resourceVersion).toBeUndefined();
+    expect(clean.metadata.creationTimestamp).toBeUndefined();
+  });
+
+  it('strips status', () => {
+    const clean = sanitizeResource(baseResource);
+    expect(clean.status).toBeUndefined();
+  });
+
+  it('strips ownerReferences', () => {
+    const clean = sanitizeResource(baseResource);
+    expect(clean.metadata.ownerReferences).toBeUndefined();
+  });
+
+  it('strips kubectl/deployment runtime annotations but keeps user annotations', () => {
+    const clean = sanitizeResource(baseResource);
+    expect(clean.metadata.annotations).toBeDefined();
+    expect(clean.metadata.annotations!['app.kubernetes.io/name']).toBe('my-app');
+    expect(clean.metadata.annotations!['kubectl.kubernetes.io/last-applied-configuration']).toBeUndefined();
+    expect(clean.metadata.annotations!['deployment.kubernetes.io/revision']).toBeUndefined();
+  });
+
+  it('removes annotations key entirely when all annotations are stripped', () => {
+    const resource: K8sResource = {
+      ...baseResource,
+      metadata: {
+        ...baseResource.metadata,
+        annotations: {
+          'kubectl.kubernetes.io/last-applied-configuration': '{}',
+        },
+      },
+    };
+    const clean = sanitizeResource(resource);
+    expect(clean.metadata.annotations).toBeUndefined();
+  });
+
+  it('preserves name, namespace, labels, and spec', () => {
+    const clean = sanitizeResource(baseResource);
+    expect(clean.metadata.name).toBe('my-app');
+    expect(clean.metadata.namespace).toBe('production');
+    expect(clean.metadata.labels).toEqual({ app: 'my-app' });
+    expect(clean.spec).toEqual({ replicas: 2 });
+  });
+
+  it('does not mutate the original resource', () => {
+    const original = structuredClone(baseResource);
+    sanitizeResource(baseResource);
+    expect(baseResource).toEqual(original);
+  });
+});
+
+describe('exportClusterToGit', () => {
+  const mockProvider = {
+    createBranch: vi.fn().mockResolvedValue(undefined),
+    getFileContent: vi.fn().mockResolvedValue(null),
+    createOrUpdateFile: vi.fn().mockResolvedValue(undefined),
+    createPullRequest: vi.fn().mockResolvedValue({ url: 'https://github.com/org/repo/pull/1', number: 1 }),
+  };
+
+  const baseOptions: ExportOptions = {
+    config: {
+      provider: 'github',
+      repoUrl: 'https://github.com/org/repo',
+      baseBranch: 'main',
+      token: 'test-token',
+    },
+    clusterName: 'test-cluster',
+    categoryIds: ['workloads'],
+    namespaces: ['production'],
+    exportMode: 'pr',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateGitProvider.mockReturnValue(mockProvider as any);
+    mockK8sList.mockResolvedValue([]);
+  });
+
+  async function collectEvents(options: ExportOptions): Promise<ExportEvent[]> {
+    const events: ExportEvent[] = [];
+    for await (const event of exportClusterToGit(options)) {
+      events.push(event);
+    }
+    return events;
+  }
+
+  it('yields start event with correct category count', async () => {
+    const events = await collectEvents(baseOptions);
+    expect(events[0]).toEqual({ type: 'start', totalCategories: 1 });
+  });
+
+  it('yields category-start, category-fetched, category-committed for each category', async () => {
+    const events = await collectEvents(baseOptions);
+    const types = events.map((e) => e.type);
+    expect(types).toContain('category-start');
+    expect(types).toContain('category-fetched');
+    expect(types).toContain('category-committed');
+  });
+
+  it('yields complete event at the end', async () => {
+    const events = await collectEvents(baseOptions);
+    const last = events[events.length - 1];
+    expect(last.type).toBe('complete');
+  });
+
+  it('creates a branch in PR mode', async () => {
+    await collectEvents(baseOptions);
+    expect(mockProvider.createBranch).toHaveBeenCalledWith('main', expect.stringContaining('cluster-export/test-cluster/'));
+  });
+
+  it('does not create a branch in direct mode', async () => {
+    await collectEvents({ ...baseOptions, exportMode: 'direct' });
+    expect(mockProvider.createBranch).not.toHaveBeenCalled();
+  });
+
+  it('commits resources and creates a PR in PR mode', async () => {
+    const deployment: K8sResource = {
+      apiVersion: 'apps/v1',
+      kind: 'Deployment',
+      metadata: { name: 'web', namespace: 'production', uid: 'x', resourceVersion: '1', creationTimestamp: '2026-01-01T00:00:00Z' },
+      spec: { replicas: 1 },
+      status: { readyReplicas: 1 },
+    };
+    mockK8sList.mockResolvedValueOnce([deployment]);
+
+    const events = await collectEvents(baseOptions);
+    expect(mockProvider.createOrUpdateFile).toHaveBeenCalled();
+    expect(mockProvider.createPullRequest).toHaveBeenCalled();
+
+    const completeEvent = events.find((e) => e.type === 'complete');
+    expect(completeEvent).toEqual({ type: 'complete', totalResources: 1 });
+  });
+
+  it('skips resources from system namespaces', async () => {
+    const systemDeploy: K8sResource = {
+      apiVersion: 'apps/v1',
+      kind: 'Deployment',
+      metadata: { name: 'operator', namespace: 'openshift-operators' },
+    };
+    const userDeploy: K8sResource = {
+      apiVersion: 'apps/v1',
+      kind: 'Deployment',
+      metadata: { name: 'web', namespace: 'production' },
+    };
+    mockK8sList.mockResolvedValueOnce([systemDeploy, userDeploy]);
+
+    await collectEvents(baseOptions);
+    // Only the user deploy should be committed
+    expect(mockProvider.createOrUpdateFile).toHaveBeenCalledTimes(1);
+    expect(mockProvider.createOrUpdateFile).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining('production'),
+      expect.any(String),
+      expect.any(String),
+      undefined,
+    );
+  });
+
+  it('yields error event if git provider creation fails', async () => {
+    mockCreateGitProvider.mockImplementation(() => {
+      throw new Error('Invalid repository URL');
+    });
+
+    const events = await collectEvents(baseOptions);
+    expect(events).toContainEqual({ type: 'error', error: 'Invalid repository URL' });
+  });
+
+  it('yields error event if branch creation fails', async () => {
+    mockProvider.createBranch.mockRejectedValueOnce(new Error('Branch exists'));
+
+    const events = await collectEvents(baseOptions);
+    expect(events).toContainEqual({
+      type: 'error',
+      error: 'Failed to create branch: Branch exists',
+    });
+  });
+});

--- a/src/kubeview/engine/gitopsExport.ts
+++ b/src/kubeview/engine/gitopsExport.ts
@@ -1,0 +1,268 @@
+/**
+ * gitopsExport — exports cluster resources to a Git repo as YAML manifests.
+ *
+ * Defines resource categories, fetches them from the K8s API, sanitizes
+ * runtime fields, and commits each category as a batch via the GitProvider.
+ */
+
+import { k8sList } from './query';
+import type { K8sResource } from './renderers/index';
+import type { GitProvider, GitOpsConfig } from './gitProvider';
+import { createGitProvider } from './gitProvider';
+
+// ── System namespace filter ──
+
+const SYSTEM_NS_PREFIXES = ['openshift-', 'kube-'];
+const SYSTEM_NS_EXACT = ['default', 'openshift'];
+
+export function isUserNamespace(ns: string): boolean {
+  if (SYSTEM_NS_EXACT.includes(ns)) return false;
+  return !SYSTEM_NS_PREFIXES.some((p) => ns.startsWith(p));
+}
+
+// ── Resource category registry ──
+
+export interface ResourceDef {
+  kind: string;
+  apiPath: string;
+  namespaced: boolean;
+}
+
+export interface ResourceCategory {
+  id: string;
+  label: string;
+  description: string;
+  resources: ResourceDef[];
+}
+
+export const RESOURCE_CATEGORIES: ResourceCategory[] = [
+  {
+    id: 'workloads',
+    label: 'Workloads',
+    description: 'Deployments, StatefulSets, DaemonSets, CronJobs',
+    resources: [
+      { kind: 'Deployment', apiPath: '/apis/apps/v1/deployments', namespaced: true },
+      { kind: 'StatefulSet', apiPath: '/apis/apps/v1/statefulsets', namespaced: true },
+      { kind: 'DaemonSet', apiPath: '/apis/apps/v1/daemonsets', namespaced: true },
+      { kind: 'CronJob', apiPath: '/apis/batch/v1/cronjobs', namespaced: true },
+    ],
+  },
+  {
+    id: 'networking',
+    label: 'Networking',
+    description: 'Services, Ingresses, NetworkPolicies, Routes',
+    resources: [
+      { kind: 'Service', apiPath: '/api/v1/services', namespaced: true },
+      { kind: 'Ingress', apiPath: '/apis/networking.k8s.io/v1/ingresses', namespaced: true },
+      { kind: 'NetworkPolicy', apiPath: '/apis/networking.k8s.io/v1/networkpolicies', namespaced: true },
+      { kind: 'Route', apiPath: '/apis/route.openshift.io/v1/routes', namespaced: true },
+    ],
+  },
+  {
+    id: 'config',
+    label: 'Configuration',
+    description: 'ConfigMaps, Secrets, ServiceAccounts, RBAC',
+    resources: [
+      { kind: 'ConfigMap', apiPath: '/api/v1/configmaps', namespaced: true },
+      { kind: 'Secret', apiPath: '/api/v1/secrets', namespaced: true },
+      { kind: 'ServiceAccount', apiPath: '/api/v1/serviceaccounts', namespaced: true },
+      { kind: 'Role', apiPath: '/apis/rbac.authorization.k8s.io/v1/roles', namespaced: true },
+      { kind: 'RoleBinding', apiPath: '/apis/rbac.authorization.k8s.io/v1/rolebindings', namespaced: true },
+    ],
+  },
+  {
+    id: 'storage',
+    label: 'Storage',
+    description: 'PersistentVolumeClaims, StorageClasses',
+    resources: [
+      { kind: 'PersistentVolumeClaim', apiPath: '/api/v1/persistentvolumeclaims', namespaced: true },
+      { kind: 'StorageClass', apiPath: '/apis/storage.k8s.io/v1/storageclasses', namespaced: false },
+    ],
+  },
+];
+
+// ── Sanitization ──
+
+/** Fields to strip from exported resources (runtime/cluster-managed) */
+const METADATA_STRIP_FIELDS = [
+  'resourceVersion',
+  'uid',
+  'creationTimestamp',
+  'generation',
+  'managedFields',
+  'selfLink',
+  'deletionTimestamp',
+  'deletionGracePeriodSeconds',
+];
+
+const ANNOTATION_STRIP_PREFIXES = [
+  'kubectl.kubernetes.io/',
+  'deployment.kubernetes.io/',
+  'kubernetes.io/change-cause',
+];
+
+export function sanitizeResource(resource: K8sResource): K8sResource {
+  const clean = structuredClone(resource);
+
+  // Strip runtime metadata fields
+  for (const field of METADATA_STRIP_FIELDS) {
+    delete (clean.metadata as Record<string, unknown>)[field];
+  }
+
+  // Strip ownerReferences (managed by controllers)
+  delete clean.metadata.ownerReferences;
+
+  // Strip runtime annotations
+  if (clean.metadata.annotations) {
+    for (const key of Object.keys(clean.metadata.annotations)) {
+      if (ANNOTATION_STRIP_PREFIXES.some((p) => key.startsWith(p))) {
+        delete clean.metadata.annotations[key];
+      }
+    }
+    if (Object.keys(clean.metadata.annotations).length === 0) {
+      delete clean.metadata.annotations;
+    }
+  }
+
+  // Strip status (runtime state)
+  delete clean.status;
+
+  return clean;
+}
+
+// ── Export progress events ──
+
+export type ExportEvent =
+  | { type: 'start'; totalCategories: number }
+  | { type: 'category-start'; categoryId: string; label: string }
+  | { type: 'category-fetched'; categoryId: string; resourceCount: number }
+  | { type: 'category-committed'; categoryId: string }
+  | { type: 'category-error'; categoryId: string; error: string }
+  | { type: 'complete'; totalResources: number }
+  | { type: 'error'; error: string };
+
+// ── Export options ──
+
+export interface ExportOptions {
+  config: GitOpsConfig;
+  clusterName: string;
+  categoryIds: string[];
+  namespaces: string[];
+  exportMode: 'pr' | 'direct';
+  branchName?: string;
+}
+
+/** Convert a resource to a simple YAML-like string (JSON with 2-space indent for commits) */
+function resourceToJson(resource: K8sResource): string {
+  return JSON.stringify(resource, null, 2);
+}
+
+/**
+ * Export selected cluster resources to a Git repository.
+ * Yields progress events for UI feedback.
+ */
+export async function* exportClusterToGit(
+  options: ExportOptions,
+): AsyncGenerator<ExportEvent> {
+  const { config, clusterName, categoryIds, namespaces, exportMode } = options;
+  const categories = RESOURCE_CATEGORIES.filter((c) => categoryIds.includes(c.id));
+
+  yield { type: 'start', totalCategories: categories.length };
+
+  let provider: GitProvider;
+  try {
+    provider = createGitProvider(config);
+  } catch (err) {
+    yield { type: 'error', error: err instanceof Error ? err.message : 'Failed to create git provider' };
+    return;
+  }
+
+  const branchName = options.branchName || `cluster-export/${clusterName}/${Date.now()}`;
+  const pathPrefix = config.pathPrefix ? config.pathPrefix.replace(/\/$/, '') : '';
+  const basePath = pathPrefix ? `${pathPrefix}/${clusterName}` : clusterName;
+
+  // Create branch for PR mode
+  if (exportMode === 'pr') {
+    try {
+      await provider.createBranch(config.baseBranch, branchName);
+    } catch (err) {
+      yield { type: 'error', error: `Failed to create branch: ${err instanceof Error ? err.message : String(err)}` };
+      return;
+    }
+  }
+
+  const targetBranch = exportMode === 'pr' ? branchName : config.baseBranch;
+  let totalResources = 0;
+
+  for (const category of categories) {
+    yield { type: 'category-start', categoryId: category.id, label: category.label };
+
+    try {
+      let categoryResourceCount = 0;
+
+      for (const resDef of category.resources) {
+        const fetchNamespaces = resDef.namespaced ? namespaces : ['_cluster_'];
+
+        for (const ns of fetchNamespaces) {
+          try {
+            const items = await k8sList<K8sResource>(
+              resDef.apiPath,
+              resDef.namespaced ? ns : undefined,
+            );
+
+            // Filter out system namespace resources for namespaced resources
+            const filtered = resDef.namespaced
+              ? items.filter((r) => r.metadata.namespace && isUserNamespace(r.metadata.namespace))
+              : items;
+
+            for (const resource of filtered) {
+              const sanitized = sanitizeResource(resource);
+              const nsDir = sanitized.metadata.namespace || '_cluster';
+              const filePath = `${basePath}/${category.id}/${nsDir}/${resDef.kind}-${sanitized.metadata.name}.json`;
+              const content = resourceToJson(sanitized);
+
+              const existing = await provider.getFileContent(targetBranch, filePath);
+              await provider.createOrUpdateFile(
+                targetBranch,
+                filePath,
+                content,
+                `Export ${resDef.kind}/${sanitized.metadata.name} from ${clusterName}`,
+                existing?.sha,
+              );
+              categoryResourceCount++;
+            }
+          } catch {
+            // Skip resources that fail (e.g. Routes on non-OpenShift clusters)
+          }
+        }
+      }
+
+      totalResources += categoryResourceCount;
+      yield { type: 'category-fetched', categoryId: category.id, resourceCount: categoryResourceCount };
+      yield { type: 'category-committed', categoryId: category.id };
+    } catch (err) {
+      yield {
+        type: 'category-error',
+        categoryId: category.id,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  // Create PR if needed
+  if (exportMode === 'pr' && totalResources > 0) {
+    try {
+      await provider.createPullRequest(
+        `Export cluster resources: ${clusterName}`,
+        `Exported ${totalResources} resources from cluster \`${clusterName}\` across ${categories.length} categories.\n\nCategories: ${categories.map((c) => c.label).join(', ')}`,
+        branchName,
+        config.baseBranch,
+      );
+    } catch (err) {
+      yield { type: 'error', error: `Failed to create PR: ${err instanceof Error ? err.message : String(err)}` };
+      return;
+    }
+  }
+
+  yield { type: 'complete', totalResources };
+}

--- a/src/kubeview/store/gitopsSetupStore.ts
+++ b/src/kubeview/store/gitopsSetupStore.ts
@@ -3,7 +3,14 @@ import { persist } from 'zustand/middleware';
 import { useArgoCDStore } from './argoCDStore';
 import { k8sGet } from '../engine/query';
 
-export type WizardStep = 'operator' | 'git-config' | 'first-app' | 'done';
+export type WizardStep = 'operator' | 'git-config' | 'select-resources' | 'first-app' | 'done';
+
+interface ExportSelections {
+  clusterName: string;
+  categoryIds: string[];
+  namespaces: string[];
+  exportMode: 'pr' | 'direct';
+}
 
 interface GitOpsSetupState {
   wizardOpen: boolean;
@@ -14,11 +21,14 @@ interface GitOpsSetupState {
   operatorPhase: 'idle' | 'creating' | 'pending' | 'installing' | 'succeeded' | 'failed';
   operatorError: string | null;
 
+  exportSelections: ExportSelections;
+
   openWizard: (resumeAt?: WizardStep) => void;
   closeWizard: () => void;
   setStep: (step: WizardStep) => void;
   markStepComplete: (step: WizardStep) => void;
   setOperatorPhase: (phase: GitOpsSetupState['operatorPhase'], error?: string) => void;
+  setExportSelections: (selections: Partial<ExportSelections>) => void;
   detectCompletedSteps: () => Promise<void>;
 }
 
@@ -31,6 +41,13 @@ export const useGitOpsSetupStore = create<GitOpsSetupState>()(
       dismissed: false,
       operatorPhase: 'idle',
       operatorError: null,
+
+      exportSelections: {
+        clusterName: '',
+        categoryIds: ['workloads', 'networking', 'config', 'storage'],
+        namespaces: [],
+        exportMode: 'pr',
+      },
 
       openWizard: (resumeAt) => {
         const step = resumeAt || get().currentStep;
@@ -51,6 +68,11 @@ export const useGitOpsSetupStore = create<GitOpsSetupState>()(
       setOperatorPhase: (phase, error) =>
         set({ operatorPhase: phase, operatorError: error || null }),
 
+      setExportSelections: (selections) =>
+        set((state) => ({
+          exportSelections: { ...state.exportSelections, ...selections },
+        })),
+
       detectCompletedSteps: async () => {
         const completed: WizardStep[] = [];
         let resumeStep: WizardStep = 'operator';
@@ -69,18 +91,19 @@ export const useGitOpsSetupStore = create<GitOpsSetupState>()(
         try {
           await k8sGet('/api/v1/namespaces/openshiftpulse/secrets/openshiftpulse-gitops-config');
           completed.push('git-config');
-          resumeStep = 'first-app';
+          resumeStep = 'select-resources';
         } catch {
           // Not configured
         }
 
         // Check if apps exist
         if (useArgoCDStore.getState().applications.length > 0) {
+          completed.push('select-resources');
           completed.push('first-app');
           resumeStep = 'done';
         }
 
-        set({ completedSteps: completed, currentStep: completed.length === 3 ? 'done' : resumeStep });
+        set({ completedSteps: completed, currentStep: completed.length === 4 ? 'done' : resumeStep });
       },
     }),
     {

--- a/src/kubeview/views/argocd/GitOpsSetupWizard.tsx
+++ b/src/kubeview/views/argocd/GitOpsSetupWizard.tsx
@@ -8,6 +8,7 @@ import { X, CheckCircle2, ArrowRight, Circle } from 'lucide-react';
 import { useGitOpsSetupStore, type WizardStep } from '../../store/gitopsSetupStore';
 import { OperatorInstallStep } from './steps/OperatorInstallStep';
 import { GitProviderStep } from './steps/GitProviderStep';
+import { SelectResourcesStep } from './steps/SelectResourcesStep';
 import { CreateApplicationStep } from './steps/CreateApplicationStep';
 import { VerificationStep } from './steps/VerificationStep';
 import { cn } from '@/lib/utils';
@@ -15,6 +16,7 @@ import { cn } from '@/lib/utils';
 const STEPS: { id: WizardStep; label: string; description: string }[] = [
   { id: 'operator', label: 'Install Operator', description: 'OpenShift GitOps (ArgoCD)' },
   { id: 'git-config', label: 'Configure Git', description: 'Repository, token, branch' },
+  { id: 'select-resources', label: 'Select Resources', description: 'Choose what to export' },
   { id: 'first-app', label: 'Create Application', description: 'First ArgoCD app' },
   { id: 'done', label: 'Verification', description: 'Confirm everything works' },
 ];
@@ -40,10 +42,9 @@ export function GitOpsSetupWizard() {
   );
 
   const advanceToNext = useCallback(() => {
-    const stepOrder: WizardStep[] = ['operator', 'git-config', 'first-app', 'done'];
-    const currentIdx = stepOrder.indexOf(currentStep);
-    if (currentIdx < stepOrder.length - 1) {
-      setStep(stepOrder[currentIdx + 1]);
+    const currentIdx = STEPS.findIndex((s) => s.id === currentStep);
+    if (currentIdx < STEPS.length - 1) {
+      setStep(STEPS[currentIdx + 1].id);
     }
   }, [currentStep, setStep]);
 
@@ -120,6 +121,7 @@ export function GitOpsSetupWizard() {
           <div className="flex-1 overflow-auto p-6">
             {currentStep === 'operator' && <OperatorInstallStep onComplete={advanceToNext} />}
             {currentStep === 'git-config' && <GitProviderStep onComplete={advanceToNext} />}
+            {currentStep === 'select-resources' && <SelectResourcesStep onComplete={advanceToNext} />}
             {currentStep === 'first-app' && <CreateApplicationStep onComplete={advanceToNext} />}
             {currentStep === 'done' && (
               <VerificationStep onClose={closeWizard} />

--- a/src/kubeview/views/argocd/steps/SelectResourcesStep.tsx
+++ b/src/kubeview/views/argocd/steps/SelectResourcesStep.tsx
@@ -1,0 +1,256 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import { Package, Search, ArrowRight, GitPullRequest, GitCommit, Loader2 } from 'lucide-react';
+import { useGitOpsSetupStore } from '../../../store/gitopsSetupStore';
+import { useClusterStore } from '../../../store/clusterStore';
+import { k8sList, k8sGet } from '../../../engine/query';
+import { RESOURCE_CATEGORIES, isUserNamespace } from '../../../engine/gitopsExport';
+import type { K8sResource } from '../../../engine/renderers/index';
+import { cn } from '@/lib/utils';
+
+interface Props {
+  onComplete: () => void;
+}
+
+export function SelectResourcesStep({ onComplete }: Props) {
+  const { exportSelections, setExportSelections, markStepComplete } = useGitOpsSetupStore();
+  const clusterVersion = useClusterStore((s) => s.clusterVersion);
+
+  const [clusterName, setClusterName] = useState(exportSelections.clusterName || '');
+  const [categoryIds, setCategoryIds] = useState<string[]>(exportSelections.categoryIds);
+  const [selectedNamespaces, setSelectedNamespaces] = useState<string[]>(exportSelections.namespaces);
+  const [exportMode, setExportMode] = useState<'pr' | 'direct'>(exportSelections.exportMode);
+  const [nsSearch, setNsSearch] = useState('');
+  const [allNamespaces, setAllNamespaces] = useState<string[]>([]);
+  const [loadingNs, setLoadingNs] = useState(true);
+
+  // Auto-detect cluster name from ClusterVersion
+  useEffect(() => {
+    if (clusterName) return;
+    (async () => {
+      try {
+        const cv = await k8sGet<K8sResource>('/apis/config.openshift.io/v1/clusterversions/version');
+        const id = cv.spec?.clusterID as string;
+        if (id) setClusterName(id.slice(0, 8));
+      } catch {
+        // Fall back to cluster version string
+        if (clusterVersion) {
+          setClusterName(`ocp-${clusterVersion.replace(/\./g, '-')}`);
+        }
+      }
+    })();
+  }, [clusterName, clusterVersion]);
+
+  // Fetch namespaces
+  useEffect(() => {
+    (async () => {
+      setLoadingNs(true);
+      try {
+        const nsList = await k8sList<K8sResource>('/api/v1/namespaces');
+        const userNs = nsList
+          .map((ns) => ns.metadata.name)
+          .filter(isUserNamespace)
+          .sort();
+        setAllNamespaces(userNs);
+        // Pre-select all if none selected
+        if (selectedNamespaces.length === 0) {
+          setSelectedNamespaces(userNs);
+        }
+      } catch {
+        setAllNamespaces([]);
+      }
+      setLoadingNs(false);
+    })();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const filteredNamespaces = useMemo(() => {
+    if (!nsSearch) return allNamespaces;
+    const lower = nsSearch.toLowerCase();
+    return allNamespaces.filter((ns) => ns.toLowerCase().includes(lower));
+  }, [allNamespaces, nsSearch]);
+
+  const toggleCategory = (id: string) => {
+    setCategoryIds((prev) =>
+      prev.includes(id) ? prev.filter((c) => c !== id) : [...prev, id],
+    );
+  };
+
+  const toggleNamespace = (ns: string) => {
+    setSelectedNamespaces((prev) =>
+      prev.includes(ns) ? prev.filter((n) => n !== ns) : [...prev, ns],
+    );
+  };
+
+  const selectAllNamespaces = () => setSelectedNamespaces([...allNamespaces]);
+  const clearAllNamespaces = () => setSelectedNamespaces([]);
+
+  const canContinue = clusterName.trim() && categoryIds.length > 0 && selectedNamespaces.length > 0;
+
+  const handleContinue = () => {
+    setExportSelections({
+      clusterName: clusterName.trim(),
+      categoryIds,
+      namespaces: selectedNamespaces,
+      exportMode,
+    });
+    markStepComplete('select-resources');
+    onComplete();
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-lg font-medium text-slate-100">Select Resources to Export</h3>
+        <p className="text-sm text-slate-400 mt-1">
+          Choose which cluster resources to export to your Git repository.
+        </p>
+      </div>
+
+      {/* Cluster name */}
+      <div>
+        <label className="text-xs text-slate-400 block mb-1">Cluster Name</label>
+        <input
+          type="text"
+          value={clusterName}
+          onChange={(e) => setClusterName(e.target.value)}
+          placeholder="my-cluster"
+          className="w-full px-3 py-2 text-sm bg-slate-800 border border-slate-700 rounded text-slate-200 placeholder-slate-600 focus:border-violet-500 outline-none"
+        />
+        <p className="text-xs text-slate-500 mt-1">Used as the folder name in your Git repository.</p>
+      </div>
+
+      {/* Resource categories */}
+      <div>
+        <label className="text-xs text-slate-400 block mb-2">Resource Categories</label>
+        <div className="grid grid-cols-2 gap-3">
+          {RESOURCE_CATEGORIES.map((cat) => {
+            const selected = categoryIds.includes(cat.id);
+            return (
+              <button
+                key={cat.id}
+                onClick={() => toggleCategory(cat.id)}
+                className={cn(
+                  'p-3 rounded-lg border text-left transition-colors',
+                  selected
+                    ? 'border-violet-500 bg-violet-500/10'
+                    : 'border-slate-700 bg-slate-800/50 hover:border-slate-600',
+                )}
+              >
+                <div className="flex items-center gap-2 mb-1">
+                  <input
+                    type="checkbox"
+                    checked={selected}
+                    readOnly
+                    className="accent-violet-500"
+                  />
+                  <Package className="w-4 h-4 text-slate-400" />
+                  <span className="text-sm font-medium text-slate-200">{cat.label}</span>
+                </div>
+                <p className="text-xs text-slate-500 ml-6">
+                  {cat.description}
+                </p>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Namespace picker */}
+      <div>
+        <div className="flex items-center justify-between mb-2">
+          <label className="text-xs text-slate-400">
+            Namespaces ({selectedNamespaces.length} of {allNamespaces.length} selected)
+          </label>
+          <div className="flex gap-2">
+            <button onClick={selectAllNamespaces} className="text-xs text-blue-400 hover:text-blue-300">
+              Select all
+            </button>
+            <button onClick={clearAllNamespaces} className="text-xs text-slate-500 hover:text-slate-400">
+              Clear
+            </button>
+          </div>
+        </div>
+        <div className="relative mb-2">
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-slate-500" />
+          <input
+            type="text"
+            value={nsSearch}
+            onChange={(e) => setNsSearch(e.target.value)}
+            placeholder="Search namespaces..."
+            className="w-full pl-8 pr-3 py-1.5 text-sm bg-slate-800 border border-slate-700 rounded text-slate-200 placeholder-slate-600 focus:border-violet-500 outline-none"
+          />
+        </div>
+        <div className="max-h-40 overflow-y-auto border border-slate-700 rounded bg-slate-800/50 p-1.5 space-y-0.5">
+          {loadingNs ? (
+            <div className="flex items-center gap-2 p-2 text-sm text-slate-400">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              Loading namespaces...
+            </div>
+          ) : filteredNamespaces.length === 0 ? (
+            <p className="text-sm text-slate-500 p-2">No namespaces found</p>
+          ) : (
+            filteredNamespaces.map((ns) => (
+              <label
+                key={ns}
+                className="flex items-center gap-2 px-2 py-1 rounded hover:bg-slate-700/50 cursor-pointer"
+              >
+                <input
+                  type="checkbox"
+                  checked={selectedNamespaces.includes(ns)}
+                  onChange={() => toggleNamespace(ns)}
+                  className="accent-violet-500"
+                />
+                <span className="text-sm text-slate-300">{ns}</span>
+              </label>
+            ))
+          )}
+        </div>
+      </div>
+
+      {/* Export mode */}
+      <div>
+        <label className="text-xs text-slate-400 block mb-2">Export Mode</label>
+        <div className="flex gap-3">
+          <button
+            onClick={() => setExportMode('pr')}
+            className={cn(
+              'flex-1 flex items-center gap-2 p-3 rounded-lg border text-left transition-colors',
+              exportMode === 'pr'
+                ? 'border-violet-500 bg-violet-500/10'
+                : 'border-slate-700 bg-slate-800/50 hover:border-slate-600',
+            )}
+          >
+            <GitPullRequest className={cn('w-4 h-4', exportMode === 'pr' ? 'text-violet-400' : 'text-slate-500')} />
+            <div>
+              <div className="text-sm font-medium text-slate-200">Pull Request</div>
+              <div className="text-xs text-slate-500">Create a branch and open a PR for review</div>
+            </div>
+          </button>
+          <button
+            onClick={() => setExportMode('direct')}
+            className={cn(
+              'flex-1 flex items-center gap-2 p-3 rounded-lg border text-left transition-colors',
+              exportMode === 'direct'
+                ? 'border-violet-500 bg-violet-500/10'
+                : 'border-slate-700 bg-slate-800/50 hover:border-slate-600',
+            )}
+          >
+            <GitCommit className={cn('w-4 h-4', exportMode === 'direct' ? 'text-violet-400' : 'text-slate-500')} />
+            <div>
+              <div className="text-sm font-medium text-slate-200">Direct Commit</div>
+              <div className="text-xs text-slate-500">Commit directly to the base branch</div>
+            </div>
+          </button>
+        </div>
+      </div>
+
+      <button
+        onClick={handleContinue}
+        disabled={!canContinue}
+        className="px-6 py-3 bg-violet-600 hover:bg-violet-500 text-white rounded-lg text-sm font-medium transition-colors disabled:opacity-50 flex items-center gap-2"
+      >
+        <ArrowRight className="w-4 h-4" />
+        Continue
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Export engine with 4 categories (13 resource types), async generator with progress events
- SelectResourcesStep UI: cluster name auto-detect, category cards, searchable namespace picker
- `isUserNamespace()` filters system namespaces
- 28 new tests

## Test plan
- [ ] Open GitOps wizard — new "Select Resources" step appears
- [ ] Select categories and namespaces — stored in Zustand
- [ ] `npx vitest --run` — all 1735 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)