### PR TITLE
feat: app-of-apps pattern + enhanced verification for cluster-as-code

### DIFF
--- a/src/kubeview/__tests__/gitops-setup-wizard-steps.test.tsx
+++ b/src/kubeview/__tests__/gitops-setup-wizard-steps.test.tsx
@@ -1,0 +1,241 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { CreateApplicationStep } from '../views/argocd/steps/CreateApplicationStep';
+import { VerificationStep } from '../views/argocd/steps/VerificationStep';
+
+// --- Mocks ---
+
+const mockSetExportSummary = vi.fn();
+const mockMarkComplete = vi.fn();
+let mockSelectedCategories: string[] = [];
+let mockSelectedNamespaces: string[] = [];
+let mockExportSummary: {
+  resourceCount: number;
+  categories: string[];
+  namespaces: string[];
+  prUrl?: string;
+  clusterName: string;
+} | null = null;
+
+vi.mock('../store/gitopsSetupStore', () => ({
+  useGitOpsSetupStore: (selector: (s: Record<string, unknown>) => unknown) => {
+    const state = {
+      markStepComplete: mockMarkComplete,
+      selectedCategories: mockSelectedCategories,
+      selectedNamespaces: mockSelectedNamespaces,
+      setExportSummary: mockSetExportSummary,
+      exportSummary: mockExportSummary,
+      setStep: vi.fn(),
+    };
+    return selector(state);
+  },
+}));
+
+vi.mock('../store/argoCDStore', () => ({
+  useArgoCDStore: (selector: (s: Record<string, unknown>) => unknown) => {
+    const state = {
+      namespace: 'openshift-gitops',
+      available: true,
+      applications: [
+        { metadata: { name: 'test-app', namespace: 'openshift-gitops' } },
+      ],
+    };
+    return selector(state);
+  },
+}));
+
+vi.mock('../hooks/useGitOpsConfig', () => ({
+  useGitOpsConfig: () => ({
+    config: {
+      provider: 'github',
+      repoUrl: 'https://github.com/org/repo',
+      baseBranch: 'main',
+      token: 'test-token',
+    },
+    isConfigured: true,
+    isLoading: false,
+  }),
+}));
+
+vi.mock('../hooks/useNavigateTab', () => ({
+  useNavigateTab: () => vi.fn(),
+}));
+
+vi.mock('../engine/gitProvider', () => ({
+  createGitProvider: () => ({
+    createBranch: vi.fn().mockResolvedValue(undefined),
+    getFileContent: vi.fn().mockResolvedValue(null),
+    createOrUpdateFile: vi.fn().mockResolvedValue(undefined),
+    commitMultipleFiles: vi.fn().mockResolvedValue(undefined),
+    createPullRequest: vi.fn().mockResolvedValue({ url: 'https://github.com/org/repo/pull/42', number: 42 }),
+  }),
+}));
+
+vi.mock('../engine/query', () => ({
+  k8sCreate: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('../engine/errorToast', () => ({
+  showErrorToast: vi.fn(),
+}));
+
+function renderWithQuery(ui: React.ReactElement) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>{ui}</QueryClientProvider>,
+  );
+}
+
+describe('CreateApplicationStep', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSelectedCategories = [];
+    mockSelectedNamespaces = [];
+    mockExportSummary = null;
+  });
+
+  afterEach(cleanup);
+
+  it('renders single-app mode when no categories selected', () => {
+    mockSelectedCategories = [];
+    renderWithQuery(<CreateApplicationStep onComplete={vi.fn()} />);
+
+    expect(screen.getAllByText('Create ArgoCD Application').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Create Application').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Application Name').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Path').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Destination Namespace').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders app-of-apps mode when categories are selected', () => {
+    mockSelectedCategories = ['deployments', 'services'];
+    mockSelectedNamespaces = ['default', 'production'];
+    renderWithQuery(<CreateApplicationStep onComplete={vi.fn()} />);
+
+    expect(screen.getAllByText('Create App-of-Apps').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('App-of-Apps Pattern').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Cluster Name').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Child Applications').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('generates correct number of child apps (categories x namespaces)', () => {
+    mockSelectedCategories = ['deployments', 'services'];
+    mockSelectedNamespaces = ['default', 'production'];
+    renderWithQuery(<CreateApplicationStep onComplete={vi.fn()} />);
+
+    // 2 categories x 2 namespaces = 4 child apps
+    const buttons = screen.getAllByText(/Create App-of-Apps.*\d+ apps/);
+    expect(buttons.length).toBeGreaterThanOrEqual(1);
+    expect(buttons[0].textContent).toContain('4 apps');
+  });
+
+  it('shows YAML preview toggle', () => {
+    renderWithQuery(<CreateApplicationStep onComplete={vi.fn()} />);
+    expect(screen.getAllByText('Preview YAML').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows auto sync toggle in both modes', () => {
+    mockSelectedCategories = ['deployments'];
+    renderWithQuery(<CreateApplicationStep onComplete={vi.fn()} />);
+    expect(screen.getAllByText('Auto Sync').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('defaults to single namespace when none selected for app-of-apps', () => {
+    mockSelectedCategories = ['deployments'];
+    mockSelectedNamespaces = [];
+    renderWithQuery(<CreateApplicationStep onComplete={vi.fn()} />);
+
+    // 1 category x 1 default namespace = 1 app
+    const buttons = screen.getAllByText(/Create App-of-Apps.*\d+ apps/);
+    expect(buttons.length).toBeGreaterThanOrEqual(1);
+    expect(buttons[0].textContent).toContain('1 apps');
+  });
+});
+
+describe('VerificationStep', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSelectedCategories = [];
+    mockSelectedNamespaces = [];
+    mockExportSummary = null;
+  });
+
+  afterEach(cleanup);
+
+  it('renders basic verification summary', () => {
+    renderWithQuery(<VerificationStep onClose={vi.fn()} />);
+
+    expect(screen.getAllByText('GitOps Setup Complete').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('OpenShift GitOps installed').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('test-app').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows View in Git link when repo is configured', () => {
+    renderWithQuery(<VerificationStep onClose={vi.fn()} />);
+
+    const links = screen.getAllByText('View in Git');
+    expect(links.length).toBeGreaterThanOrEqual(1);
+    expect(links[0].closest('a')?.getAttribute('href')).toBe('https://github.com/org/repo');
+  });
+
+  it('shows export summary when present', () => {
+    mockExportSummary = {
+      resourceCount: 4,
+      categories: ['deployments', 'services'],
+      namespaces: ['default', 'production'],
+      prUrl: 'https://github.com/org/repo/pull/42',
+      clusterName: 'my-cluster',
+    };
+    renderWithQuery(<VerificationStep onClose={vi.fn()} />);
+
+    expect(screen.getAllByText('Export Summary').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('my-cluster').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('4').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('deployments, services').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('default, production').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows PR link in export summary', () => {
+    mockExportSummary = {
+      resourceCount: 2,
+      categories: ['deployments'],
+      namespaces: ['default'],
+      prUrl: 'https://github.com/org/repo/pull/42',
+      clusterName: 'test-cluster',
+    };
+    renderWithQuery(<VerificationStep onClose={vi.fn()} />);
+
+    const prLinks = screen.getAllByText('View Pull Request');
+    expect(prLinks.length).toBeGreaterThanOrEqual(1);
+    expect(prLinks[0].closest('a')?.getAttribute('href')).toBe('https://github.com/org/repo/pull/42');
+  });
+
+  it('shows Re-export Cluster button when export summary present', () => {
+    mockExportSummary = {
+      resourceCount: 2,
+      categories: ['deployments'],
+      namespaces: ['default'],
+      clusterName: 'test-cluster',
+    };
+    renderWithQuery(<VerificationStep onClose={vi.fn()} />);
+
+    expect(screen.getAllByText('Re-export Cluster').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('does not show Re-export or export summary without export data', () => {
+    mockExportSummary = null;
+    renderWithQuery(<VerificationStep onClose={vi.fn()} />);
+
+    expect(screen.queryByText('Export Summary')).toBeNull();
+    expect(screen.queryByText('Re-export Cluster')).toBeNull();
+  });
+
+  it('shows Create Another Application button', () => {
+    renderWithQuery(<VerificationStep onClose={vi.fn()} />);
+    expect(screen.getAllByText('Create Another Application').length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/kubeview/engine/gitProvider.ts
+++ b/src/kubeview/engine/gitProvider.ts
@@ -3,10 +3,16 @@
  * across GitHub, GitLab, and Bitbucket via their REST APIs.
  */
 
+export interface FileCommit {
+  path: string;
+  content: string;
+}
+
 export interface GitProvider {
   createBranch(baseBranch: string, newBranch: string): Promise<void>;
   getFileContent(branch: string, path: string): Promise<{ content: string; sha: string } | null>;
   createOrUpdateFile(branch: string, path: string, content: string, message: string, fileSha?: string): Promise<void>;
+  commitMultipleFiles(branch: string, files: FileCommit[], message: string): Promise<void>;
   createPullRequest(title: string, body: string, head: string, base: string): Promise<{ url: string; number: number }>;
 }
 
@@ -131,6 +137,58 @@ class GitHubProvider implements GitProvider {
     if (!res.ok) throw new Error(`Failed to update file: ${res.status}`);
   }
 
+  async commitMultipleFiles(branch: string, files: FileCommit[], message: string): Promise<void> {
+    // Get the latest commit SHA on the branch
+    const refRes = await fetch(`${this.apiBase}/git/ref/heads/${branch}`, { headers: this.headers });
+    if (!refRes.ok) throw new Error(`Failed to get branch ref: ${refRes.status}`);
+    const refData = await refRes.json();
+    const latestCommitSha = refData.object.sha;
+
+    // Get the tree SHA of that commit
+    const commitRes = await fetch(`${this.apiBase}/git/commits/${latestCommitSha}`, { headers: this.headers });
+    if (!commitRes.ok) throw new Error(`Failed to get commit: ${commitRes.status}`);
+    const commitData = await commitRes.json();
+    const baseTreeSha = commitData.tree.sha;
+
+    // Create blobs for each file and build tree entries
+    const tree = await Promise.all(files.map(async (f) => {
+      const blobRes = await fetch(`${this.apiBase}/git/blobs`, {
+        method: 'POST',
+        headers: this.headers,
+        body: JSON.stringify({ content: f.content, encoding: 'utf-8' }),
+      });
+      if (!blobRes.ok) throw new Error(`Failed to create blob for ${f.path}: ${blobRes.status}`);
+      const blobData = await blobRes.json();
+      return { path: f.path, mode: '100644' as const, type: 'blob' as const, sha: blobData.sha };
+    }));
+
+    // Create a new tree
+    const treeRes = await fetch(`${this.apiBase}/git/trees`, {
+      method: 'POST',
+      headers: this.headers,
+      body: JSON.stringify({ base_tree: baseTreeSha, tree }),
+    });
+    if (!treeRes.ok) throw new Error(`Failed to create tree: ${treeRes.status}`);
+    const treeData = await treeRes.json();
+
+    // Create the commit
+    const newCommitRes = await fetch(`${this.apiBase}/git/commits`, {
+      method: 'POST',
+      headers: this.headers,
+      body: JSON.stringify({ message, tree: treeData.sha, parents: [latestCommitSha] }),
+    });
+    if (!newCommitRes.ok) throw new Error(`Failed to create commit: ${newCommitRes.status}`);
+    const newCommitData = await newCommitRes.json();
+
+    // Update the branch ref
+    const updateRes = await fetch(`${this.apiBase}/git/refs/heads/${branch}`, {
+      method: 'PATCH',
+      headers: this.headers,
+      body: JSON.stringify({ sha: newCommitData.sha }),
+    });
+    if (!updateRes.ok) throw new Error(`Failed to update branch ref: ${updateRes.status}`);
+  }
+
   async createPullRequest(title: string, body: string, head: string, base: string): Promise<{ url: string; number: number }> {
     const res = await fetch(`${this.apiBase}/pulls`, {
       method: 'POST',
@@ -189,6 +247,20 @@ class GitLabProvider implements GitProvider {
       body: JSON.stringify({ branch, content, commit_message: message, encoding: 'text' }),
     });
     if (!res.ok) throw new Error(`Failed to update file: ${res.status}`);
+  }
+
+  async commitMultipleFiles(branch: string, files: FileCommit[], message: string): Promise<void> {
+    const actions = files.map((f) => ({
+      action: 'create' as const,
+      file_path: f.path,
+      content: f.content,
+    }));
+    const res = await fetch(`${this.apiBase}/repository/commits`, {
+      method: 'POST',
+      headers: this.headers,
+      body: JSON.stringify({ branch, commit_message: message, actions }),
+    });
+    if (!res.ok) throw new Error(`Failed to commit files: ${res.status}`);
   }
 
   async createPullRequest(title: string, body: string, head: string, base: string): Promise<{ url: string; number: number }> {
@@ -258,6 +330,22 @@ class BitbucketProvider implements GitProvider {
       body: formData,
     });
     if (!res.ok) throw new Error(`Failed to update file: ${res.status}`);
+  }
+
+  async commitMultipleFiles(branch: string, files: FileCommit[], message: string): Promise<void> {
+    const formData = new FormData();
+    for (const f of files) {
+      formData.append(f.path, new Blob([f.content]));
+    }
+    formData.append('message', message);
+    formData.append('branch', branch);
+
+    const res = await fetch(`${this.apiBase}/src`, {
+      method: 'POST',
+      headers: { Authorization: this.headers.Authorization },
+      body: formData,
+    });
+    if (!res.ok) throw new Error(`Failed to commit files: ${res.status}`);
   }
 
   async createPullRequest(title: string, body: string, head: string, base: string): Promise<{ url: string; number: number }> {

--- a/src/kubeview/store/gitopsSetupStore.ts
+++ b/src/kubeview/store/gitopsSetupStore.ts
@@ -5,6 +5,14 @@ import { k8sGet } from '../engine/query';
 
 export type WizardStep = 'operator' | 'git-config' | 'first-app' | 'done';
 
+export interface ExportSummary {
+  resourceCount: number;
+  categories: string[];
+  namespaces: string[];
+  prUrl?: string;
+  clusterName: string;
+}
+
 interface GitOpsSetupState {
   wizardOpen: boolean;
   currentStep: WizardStep;
@@ -14,11 +22,21 @@ interface GitOpsSetupState {
   operatorPhase: 'idle' | 'creating' | 'pending' | 'installing' | 'succeeded' | 'failed';
   operatorError: string | null;
 
+  /** Categories selected for app-of-apps export (e.g. 'deployments', 'services') */
+  selectedCategories: string[];
+  /** Namespaces to export for app-of-apps pattern */
+  selectedNamespaces: string[];
+  /** Summary of the last export */
+  exportSummary: ExportSummary | null;
+
   openWizard: (resumeAt?: WizardStep) => void;
   closeWizard: () => void;
   setStep: (step: WizardStep) => void;
   markStepComplete: (step: WizardStep) => void;
   setOperatorPhase: (phase: GitOpsSetupState['operatorPhase'], error?: string) => void;
+  setSelectedCategories: (categories: string[]) => void;
+  setSelectedNamespaces: (namespaces: string[]) => void;
+  setExportSummary: (summary: ExportSummary) => void;
   detectCompletedSteps: () => Promise<void>;
 }
 
@@ -31,6 +49,10 @@ export const useGitOpsSetupStore = create<GitOpsSetupState>()(
       dismissed: false,
       operatorPhase: 'idle',
       operatorError: null,
+
+      selectedCategories: [],
+      selectedNamespaces: [],
+      exportSummary: null,
 
       openWizard: (resumeAt) => {
         const step = resumeAt || get().currentStep;
@@ -50,6 +72,10 @@ export const useGitOpsSetupStore = create<GitOpsSetupState>()(
 
       setOperatorPhase: (phase, error) =>
         set({ operatorPhase: phase, operatorError: error || null }),
+
+      setSelectedCategories: (categories) => set({ selectedCategories: categories }),
+      setSelectedNamespaces: (namespaces) => set({ selectedNamespaces: namespaces }),
+      setExportSummary: (summary) => set({ exportSummary: summary }),
 
       detectCompletedSteps: async () => {
         const completed: WizardStep[] = [];

--- a/src/kubeview/views/argocd/steps/CreateApplicationStep.tsx
+++ b/src/kubeview/views/argocd/steps/CreateApplicationStep.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useMemo } from 'react';
-import { Loader2, Code2, FileCode, ToggleLeft, ToggleRight } from 'lucide-react';
+import { Loader2, Code2, FileCode, ToggleLeft, ToggleRight, Layers, AppWindow } from 'lucide-react';
 import { useGitOpsConfig } from '../../../hooks/useGitOpsConfig';
 import { useArgoCDStore } from '../../../store/argoCDStore';
 import { useGitOpsSetupStore } from '../../../store/gitopsSetupStore';
 import { k8sCreate } from '../../../engine/query';
+import { createGitProvider, type FileCommit } from '../../../engine/gitProvider';
 import { showErrorToast } from '../../../engine/errorToast';
 import { cn } from '@/lib/utils';
 
@@ -12,6 +13,7 @@ interface Props {
 }
 
 const NAME_REGEX = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+const INPUT_CLASS = 'w-full px-3 py-2 text-sm bg-slate-800 border border-slate-700 rounded text-slate-200 placeholder-slate-600 focus:border-violet-500 outline-none';
 
 function buildApplicationYAML(opts: {
   name: string;
@@ -92,12 +94,42 @@ function toYAMLString(obj: unknown, indent = 0): string {
   return String(obj);
 }
 
+function buildChildAppYAML(opts: {
+  category: string;
+  namespace: string;
+  clusterName: string;
+  repoURL: string;
+  targetRevision: string;
+  argoNamespace: string;
+  autoSync: boolean;
+}): { name: string; filePath: string; yaml: object } {
+  const name = `${opts.clusterName}-${opts.category}-${opts.namespace}`;
+  const filePath = `clusters/${opts.clusterName}/apps/${opts.category}-${opts.namespace}.yaml`;
+  const yaml = buildApplicationYAML({
+    name,
+    namespace: opts.argoNamespace,
+    repoURL: opts.repoURL,
+    path: `clusters/${opts.clusterName}/${opts.category}/${opts.namespace}`,
+    targetRevision: opts.targetRevision,
+    destNamespace: opts.namespace,
+    autoSync: opts.autoSync,
+    createNamespace: true,
+  });
+  return { name, filePath, yaml };
+}
+
 export function CreateApplicationStep({ onComplete }: Props) {
-  const { config } = useGitOpsConfig();
+  const { config, isConfigured } = useGitOpsConfig();
   const argoNamespace = useArgoCDStore((s) => s.namespace) || 'openshift-gitops';
   const markComplete = useGitOpsSetupStore((s) => s.markStepComplete);
+  const selectedCategories = useGitOpsSetupStore((s) => s.selectedCategories);
+  const selectedNamespaces = useGitOpsSetupStore((s) => s.selectedNamespaces);
+  const setExportSummary = useGitOpsSetupStore((s) => s.setExportSummary);
+
+  const isAppOfApps = selectedCategories.length > 0;
 
   const [name, setName] = useState('my-app');
+  const [clusterName, setClusterName] = useState('my-cluster');
   const [repoURL, setRepoURL] = useState(config?.repoUrl || '');
   const [path, setPath] = useState('manifests');
   const [targetRevision, setTargetRevision] = useState('HEAD');
@@ -107,42 +139,144 @@ export function CreateApplicationStep({ onComplete }: Props) {
   const [showYAML, setShowYAML] = useState(false);
   const [creating, setCreating] = useState(false);
 
-  // Pre-fill repo URL when config loads
   React.useEffect(() => {
     if (config?.repoUrl && !repoURL) {
       setRepoURL(config.repoUrl);
     }
   }, [config]);
 
-  const nameValid = NAME_REGEX.test(name);
-  const formValid = nameValid && repoURL.length > 0 && path.length > 0 && targetRevision.length > 0 && destNamespace.length > 0;
+  const nameValid = NAME_REGEX.test(isAppOfApps ? clusterName : name);
+  const formValid = isAppOfApps
+    ? nameValid && repoURL.length > 0 && targetRevision.length > 0
+    : nameValid && repoURL.length > 0 && path.length > 0 && targetRevision.length > 0 && destNamespace.length > 0;
 
   const applicationObj = useMemo(
     () =>
-      buildApplicationYAML({
-        name,
-        namespace: argoNamespace,
-        repoURL,
-        path,
-        targetRevision,
-        destNamespace,
-        autoSync,
-        createNamespace,
-      }),
-    [name, argoNamespace, repoURL, path, targetRevision, destNamespace, autoSync, createNamespace],
+      isAppOfApps
+        ? null
+        : buildApplicationYAML({
+            name,
+            namespace: argoNamespace,
+            repoURL,
+            path,
+            targetRevision,
+            destNamespace,
+            autoSync,
+            createNamespace,
+          }),
+    [isAppOfApps, name, argoNamespace, repoURL, path, targetRevision, destNamespace, autoSync, createNamespace],
   );
 
-  const yamlPreview = useMemo(() => toYAMLString(applicationObj), [applicationObj]);
+  const namespaces = useMemo(
+    () => (selectedNamespaces.length > 0 ? selectedNamespaces : ['default']),
+    [selectedNamespaces],
+  );
+
+  const childApps = useMemo(() => {
+    if (!isAppOfApps) return [];
+    return selectedCategories.flatMap((category) =>
+      namespaces.map((ns) =>
+        buildChildAppYAML({
+          category,
+          namespace: ns,
+          clusterName,
+          repoURL,
+          targetRevision,
+          argoNamespace,
+          autoSync,
+        }),
+      ),
+    );
+  }, [isAppOfApps, selectedCategories, namespaces, clusterName, repoURL, targetRevision, argoNamespace, autoSync]);
+
+  const rootAppObj = useMemo(() => {
+    if (!isAppOfApps) return null;
+    return buildApplicationYAML({
+      name: `${clusterName}-root`,
+      namespace: argoNamespace,
+      repoURL,
+      path: `clusters/${clusterName}/apps`,
+      targetRevision,
+      destNamespace: argoNamespace,
+      autoSync,
+      createNamespace: false,
+    });
+  }, [isAppOfApps, clusterName, argoNamespace, repoURL, targetRevision, autoSync]);
+
+  const yamlPreview = useMemo(() => {
+    if (isAppOfApps && rootAppObj) {
+      const rootYaml = toYAMLString(rootAppObj);
+      const childPreviews = childApps.slice(0, 3).map((c) =>
+        `# ${c.filePath}\n${toYAMLString(c.yaml)}`
+      );
+      const more = childApps.length > 3 ? `\n# ... and ${childApps.length - 3} more child apps` : '';
+      return `# Root Application\n${rootYaml}\n\n---\n${childPreviews.join('\n---\n')}${more}`;
+    }
+    return applicationObj ? toYAMLString(applicationObj) : '';
+  }, [isAppOfApps, rootAppObj, childApps, applicationObj]);
 
   const handleCreate = async () => {
     if (!formValid) return;
     setCreating(true);
     try {
-      await k8sCreate(
-        `/apis/argoproj.io/v1alpha1/namespaces/${argoNamespace}/applications`,
-        applicationObj,
-      );
-      // Reload applications in the ArgoCD store
+      if (isAppOfApps && rootAppObj) {
+        if (!isConfigured || !config) {
+          throw new Error('Git provider not configured. Go to Admin → GitOps to set up your repository.');
+        }
+
+        const provider = createGitProvider(config);
+        const branchName = `pulse/app-of-apps-${clusterName}-${Date.now()}`;
+
+        await provider.createBranch(config.baseBranch, branchName);
+
+        const files: FileCommit[] = childApps.map((c) => ({
+          path: c.filePath,
+          content: toYAMLString(c.yaml),
+        }));
+        await provider.commitMultipleFiles(
+          branchName,
+          files,
+          `Add app-of-apps structure for cluster ${clusterName} via OpenShift Pulse`,
+        );
+
+        const pr = await provider.createPullRequest(
+          `[Pulse] App-of-apps for ${clusterName}`,
+          [
+            `## App-of-Apps Export`,
+            ``,
+            `Exported **${childApps.length}** child applications for cluster \`${clusterName}\`.`,
+            ``,
+            `### Categories`,
+            ...selectedCategories.map((c) => `- ${c}`),
+            ``,
+            `### Namespaces`,
+            ...namespaces.map((ns) => `- ${ns}`),
+            ``,
+            `> Merge this PR, then the root Application will sync all child apps via ArgoCD.`,
+          ].join('\n'),
+          branchName,
+          config.baseBranch,
+        );
+
+        await k8sCreate(
+          `/apis/argoproj.io/v1alpha1/namespaces/${argoNamespace}/applications`,
+          rootAppObj,
+        );
+
+        setExportSummary({
+          resourceCount: childApps.length,
+          categories: [...selectedCategories],
+          namespaces: [...namespaces],
+          prUrl: pr.url,
+          clusterName,
+        });
+      } else if (applicationObj) {
+        await k8sCreate(
+          `/apis/argoproj.io/v1alpha1/namespaces/${argoNamespace}/applications`,
+          applicationObj,
+        );
+      }
+
       await useArgoCDStore.getState().loadApplications();
       markComplete('first-app');
       onComplete();
@@ -155,32 +289,59 @@ export function CreateApplicationStep({ onComplete }: Props) {
   return (
     <div className="space-y-6">
       <div>
-        <h3 className="text-lg font-medium text-slate-100">Create ArgoCD Application</h3>
+        <h3 className="text-lg font-medium text-slate-100">
+          {isAppOfApps ? 'Create App-of-Apps' : 'Create ArgoCD Application'}
+        </h3>
         <p className="text-sm text-slate-400 mt-1">
-          Define an Application that ArgoCD will sync from your Git repository to the cluster.
+          {isAppOfApps ? (
+            <>
+              Export <span className="text-violet-300 font-medium">{selectedCategories.length}</span> categories
+              across <span className="text-violet-300 font-medium">{namespaces.length}</span> namespace{namespaces.length !== 1 ? 's' : ''} as
+              an app-of-apps pattern. A root Application manages child apps per category and namespace.
+            </>
+          ) : (
+            'Define an Application that ArgoCD will sync from your Git repository to the cluster.'
+          )}
         </p>
       </div>
 
+      {isAppOfApps && (
+        <div className="flex items-start gap-3 p-3 bg-violet-950/30 border border-violet-800/40 rounded-lg">
+          <Layers className="w-5 h-5 text-violet-400 mt-0.5 shrink-0" />
+          <div className="text-xs text-slate-300 space-y-1">
+            <p className="font-medium text-violet-200">App-of-Apps Pattern</p>
+            <p>
+              {childApps.length} child application{childApps.length !== 1 ? 's' : ''} will be committed to Git.
+              A root Application pointing to <code className="text-violet-300">clusters/{clusterName}/apps</code> will
+              be created in the cluster.
+            </p>
+          </div>
+        </div>
+      )}
+
       <div className="space-y-4">
-        {/* Application Name */}
         <div>
-          <label className="text-xs text-slate-400 block mb-1">Application Name</label>
+          <label className="text-xs text-slate-400 block mb-1">
+            {isAppOfApps ? 'Cluster Name' : 'Application Name'}
+          </label>
           <input
             type="text"
-            value={name}
-            onChange={(e) => setName(e.target.value.toLowerCase())}
-            placeholder="my-app"
+            value={isAppOfApps ? clusterName : name}
+            onChange={(e) => {
+              const val = e.target.value.toLowerCase();
+              isAppOfApps ? setClusterName(val) : setName(val);
+            }}
+            placeholder={isAppOfApps ? 'my-cluster' : 'my-app'}
             className={cn(
               'w-full px-3 py-2 text-sm bg-slate-800 border rounded text-slate-200 placeholder-slate-600 focus:border-violet-500 outline-none',
-              name && !nameValid ? 'border-red-500' : 'border-slate-700',
+              (isAppOfApps ? clusterName : name) && !nameValid ? 'border-red-500' : 'border-slate-700',
             )}
           />
-          {name && !nameValid && (
+          {(isAppOfApps ? clusterName : name) && !nameValid && (
             <p className="text-xs text-red-400 mt-1">Must be lowercase alphanumeric with hyphens only</p>
           )}
         </div>
 
-        {/* Git Repository URL */}
         <div>
           <label className="text-xs text-slate-400 block mb-1">Git Repository URL</label>
           <input
@@ -188,48 +349,83 @@ export function CreateApplicationStep({ onComplete }: Props) {
             value={repoURL}
             onChange={(e) => setRepoURL(e.target.value)}
             placeholder="https://github.com/org/repo"
-            className="w-full px-3 py-2 text-sm bg-slate-800 border border-slate-700 rounded text-slate-200 placeholder-slate-600 focus:border-violet-500 outline-none"
+            className={INPUT_CLASS}
           />
         </div>
 
-        <div className="grid grid-cols-2 gap-4">
-          {/* Path */}
-          <div>
-            <label className="text-xs text-slate-400 block mb-1">Path</label>
-            <input
-              type="text"
-              value={path}
-              onChange={(e) => setPath(e.target.value)}
-              placeholder="manifests"
-              className="w-full px-3 py-2 text-sm bg-slate-800 border border-slate-700 rounded text-slate-200 placeholder-slate-600 focus:border-violet-500 outline-none"
-            />
-          </div>
-          {/* Target Revision */}
-          <div>
-            <label className="text-xs text-slate-400 block mb-1">Target Revision</label>
-            <input
-              type="text"
-              value={targetRevision}
-              onChange={(e) => setTargetRevision(e.target.value)}
-              placeholder="HEAD"
-              className="w-full px-3 py-2 text-sm bg-slate-800 border border-slate-700 rounded text-slate-200 placeholder-slate-600 focus:border-violet-500 outline-none"
-            />
-          </div>
-        </div>
+        {isAppOfApps ? (
+          <>
+            <div>
+              <label className="text-xs text-slate-400 block mb-1">Target Revision</label>
+              <input
+                type="text"
+                value={targetRevision}
+                onChange={(e) => setTargetRevision(e.target.value)}
+                placeholder="HEAD"
+                className={INPUT_CLASS}
+              />
+            </div>
 
-        {/* Destination Namespace */}
-        <div>
-          <label className="text-xs text-slate-400 block mb-1">Destination Namespace</label>
-          <input
-            type="text"
-            value={destNamespace}
-            onChange={(e) => setDestNamespace(e.target.value)}
-            placeholder="default"
-            className="w-full px-3 py-2 text-sm bg-slate-800 border border-slate-700 rounded text-slate-200 placeholder-slate-600 focus:border-violet-500 outline-none"
-          />
-        </div>
+            <div>
+              <label className="text-xs text-slate-400 block mb-2">Child Applications</label>
+              <div className="bg-slate-800 border border-slate-700 rounded-lg divide-y divide-slate-700 max-h-40 overflow-y-auto">
+                {childApps.map((child) => (
+                  <div key={child.name} className="flex items-center gap-2 px-3 py-2 text-xs">
+                    <AppWindow className="w-3.5 h-3.5 text-violet-400 shrink-0" />
+                    <span className="text-slate-200 font-mono truncate">{child.name}</span>
+                    <span className="text-slate-500 ml-auto truncate">{child.filePath}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="text-xs text-slate-400 block mb-1">Path</label>
+                <input
+                  type="text"
+                  value={path}
+                  onChange={(e) => setPath(e.target.value)}
+                  placeholder="manifests"
+                  className={INPUT_CLASS}
+                />
+              </div>
+              <div>
+                <label className="text-xs text-slate-400 block mb-1">Target Revision</label>
+                <input
+                  type="text"
+                  value={targetRevision}
+                  onChange={(e) => setTargetRevision(e.target.value)}
+                  placeholder="HEAD"
+                  className={INPUT_CLASS}
+                />
+              </div>
+            </div>
 
-        {/* Sync Policy */}
+            <div>
+              <label className="text-xs text-slate-400 block mb-1">Destination Namespace</label>
+              <input
+                type="text"
+                value={destNamespace}
+                onChange={(e) => setDestNamespace(e.target.value)}
+                placeholder="default"
+                className={INPUT_CLASS}
+              />
+            </div>
+
+            <label className="flex items-center gap-2 text-sm text-slate-300 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={createNamespace}
+                onChange={(e) => setCreateNamespace(e.target.checked)}
+                className="rounded border-slate-600 bg-slate-800 text-violet-600 focus:ring-violet-500"
+              />
+              Create namespace if it doesn't exist
+            </label>
+          </>
+        )}
         <div className="flex items-center justify-between">
           <div>
             <p className="text-sm text-slate-200">Auto Sync</p>
@@ -243,17 +439,6 @@ export function CreateApplicationStep({ onComplete }: Props) {
             )}
           </button>
         </div>
-
-        {/* Create Namespace */}
-        <label className="flex items-center gap-2 text-sm text-slate-300 cursor-pointer">
-          <input
-            type="checkbox"
-            checked={createNamespace}
-            onChange={(e) => setCreateNamespace(e.target.checked)}
-            className="rounded border-slate-600 bg-slate-800 text-violet-600 focus:ring-violet-500"
-          />
-          Create namespace if it doesn't exist
-        </label>
       </div>
 
       {/* YAML Preview Toggle */}
@@ -283,7 +468,7 @@ export function CreateApplicationStep({ onComplete }: Props) {
         className="px-6 py-3 bg-violet-600 hover:bg-violet-500 text-white rounded-lg text-sm font-medium transition-colors disabled:opacity-50 flex items-center gap-2"
       >
         {creating ? <Loader2 className="w-4 h-4 animate-spin" /> : null}
-        Create Application
+        {isAppOfApps ? `Create App-of-Apps (${childApps.length} apps)` : 'Create Application'}
       </button>
     </div>
   );

--- a/src/kubeview/views/argocd/steps/VerificationStep.tsx
+++ b/src/kubeview/views/argocd/steps/VerificationStep.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CheckCircle2, ArrowRight, Plus, X } from 'lucide-react';
+import { CheckCircle2, ArrowRight, Plus, X, ExternalLink, GitBranch, Layers, RefreshCw } from 'lucide-react';
 import { useArgoCDStore } from '../../../store/argoCDStore';
 import { useGitOpsConfig } from '../../../hooks/useGitOpsConfig';
 import { useGitOpsSetupStore } from '../../../store/gitopsSetupStore';
@@ -10,14 +10,21 @@ interface Props {
   onClose: () => void;
 }
 
+const SECONDARY_BTN = 'w-full px-4 py-3 bg-slate-800 hover:bg-slate-700 text-slate-200 rounded-lg text-sm font-medium transition-colors flex items-center justify-center gap-2';
+
 export function VerificationStep({ onClose }: Props) {
   const go = useNavigateTab();
   const argoAvailable = useArgoCDStore((s) => s.available);
   const applications = useArgoCDStore((s) => s.applications);
   const { config } = useGitOpsConfig();
   const setStep = useGitOpsSetupStore((s) => s.setStep);
+  const exportSummary = useGitOpsSetupStore((s) => s.exportSummary);
 
   const latestApp = applications.length > 0 ? applications[applications.length - 1] : null;
+
+  const gitBrowseUrl = config?.repoUrl
+    ? config.repoUrl.replace(/\.git$/, '')
+    : null;
 
   return (
     <div className="space-y-6">
@@ -27,7 +34,6 @@ export function VerificationStep({ onClose }: Props) {
         <p className="text-sm text-slate-400 mt-2">Your cluster is ready for GitOps workflows.</p>
       </div>
 
-      {/* Summary */}
       <div className="bg-slate-900 border border-slate-700 rounded-lg divide-y divide-slate-800">
         <div className="flex items-center justify-between px-4 py-3">
           <span className="text-sm text-slate-400">Operator</span>
@@ -49,7 +55,46 @@ export function VerificationStep({ onClose }: Props) {
         </div>
       </div>
 
-      {/* Action buttons */}
+      {exportSummary && (
+        <div className="bg-slate-900 border border-violet-800/40 rounded-lg p-4 space-y-3">
+          <div className="flex items-center gap-2 text-sm font-medium text-violet-200">
+            <Layers className="w-4 h-4 text-violet-400" />
+            Export Summary
+          </div>
+          <div className="grid grid-cols-2 gap-3 text-xs">
+            <div>
+              <span className="text-slate-500">Cluster</span>
+              <p className="text-slate-200 font-mono">{exportSummary.clusterName}</p>
+            </div>
+            <div>
+              <span className="text-slate-500">Child Apps</span>
+              <p className="text-slate-200">{exportSummary.resourceCount}</p>
+            </div>
+            <div>
+              <span className="text-slate-500">Categories</span>
+              <p className="text-slate-200">{exportSummary.categories.join(', ')}</p>
+            </div>
+            <div>
+              <span className="text-slate-500">Namespaces</span>
+              <p className="text-slate-200">{exportSummary.namespaces.join(', ')}</p>
+            </div>
+          </div>
+
+          {exportSummary.prUrl && (
+            <a
+              href={exportSummary.prUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-violet-600 hover:bg-violet-500 text-white text-xs rounded transition-colors"
+            >
+              <GitBranch className="w-3.5 h-3.5" />
+              View Pull Request
+              <ExternalLink className="w-3 h-3" />
+            </a>
+          )}
+        </div>
+      )}
+
       <div className="flex flex-col gap-2">
         <button
           onClick={() => {
@@ -61,13 +106,26 @@ export function VerificationStep({ onClose }: Props) {
           Go to GitOps Dashboard
           <ArrowRight className="w-4 h-4" />
         </button>
-        <button
-          onClick={() => setStep('first-app')}
-          className="w-full px-4 py-3 bg-slate-800 hover:bg-slate-700 text-slate-200 rounded-lg text-sm font-medium transition-colors flex items-center justify-center gap-2"
-        >
+
+        {gitBrowseUrl && (
+          <a href={gitBrowseUrl} target="_blank" rel="noopener noreferrer" className={SECONDARY_BTN}>
+            <ExternalLink className="w-4 h-4" />
+            View in Git
+          </a>
+        )}
+
+        <button onClick={() => setStep('first-app')} className={SECONDARY_BTN}>
           <Plus className="w-4 h-4" />
           Create Another Application
         </button>
+
+        {exportSummary && (
+          <button onClick={() => setStep('first-app')} className={SECONDARY_BTN}>
+            <RefreshCw className="w-4 h-4" />
+            Re-export Cluster
+          </button>
+        )}
+
         <button
           onClick={onClose}
           className="w-full px-4 py-3 text-slate-400 hover:text-slate-200 rounded-lg text-sm transition-colors flex items-center justify-center gap-2"


### PR DESCRIPTION
## Summary
- CreateApplicationStep: dual-mode — app-of-apps when categories selected, single-app otherwise
- Generates root Application + child app YAMLs per category/namespace
- Commits child app manifests to git via `commitMultipleFiles`
- VerificationStep: export summary, PR link, "View in Git", "Re-export" button
- 13 new tests

## Test plan
- [ ] GitOps wizard with categories → app-of-apps mode shows child apps
- [ ] GitOps wizard without categories → single-app mode unchanged
- [ ] Verification shows export summary and PR link
- [ ] `npx vitest --run` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)