### PR TITLE
feat: Trust Level 4 (Autonomous) + protocol v2 support

### DIFF
--- a/src/kubeview/engine/agentClient.ts
+++ b/src/kubeview/engine/agentClient.ts
@@ -1,7 +1,7 @@
 /**
  * Agent WebSocket client — connects to the Pulse Agent API server.
  *
- * Protocol Version: 1 (see API_CONTRACT.md for full specification)
+ * Supported Protocol Versions: 1, 2 (see API_CONTRACT.md for full specification)
  *
  * Handles streaming text, thinking, tool use events, and confirmation
  * requests over a persistent WebSocket connection.
@@ -9,7 +9,7 @@
 
 import type { ComponentSpec } from './agentComponents';
 
-export type AgentMode = 'sre' | 'security';
+export type AgentMode = 'sre' | 'security' | 'monitor';
 
 export interface AgentMessage {
   id: string;
@@ -44,12 +44,16 @@ export type AgentEvent =
   | { type: 'error'; message: string }
   | { type: 'cleared' }
   | { type: 'connected' }
-  | { type: 'disconnected' };
+  | { type: 'disconnected' }
+  | { type: 'finding'; id: string; severity: string; category: string; title: string; summary: string; resources: Array<{ kind: string; name: string; namespace?: string }>; autoFixable: boolean; runbookId?: string; timestamp: number }
+  | { type: 'action_report'; id: string; findingId: string; tool: string; status: string; beforeState?: string; afterState?: string; error?: string; timestamp: number }
+  | { type: 'prediction'; id: string; category: string; title: string; detail: string; eta: string; confidence: number; resources: Array<{ kind: string; name: string; namespace?: string }>; recommendedAction?: string; timestamp: number }
+  | { type: 'monitor_status'; activeWatches: string[]; lastScan: number; findingsCount: number; nextScan: number };
 
 type EventHandler = (event: AgentEvent) => void;
 
 const AGENT_BASE = '/api/agent';
-const EXPECTED_PROTOCOL = '1';
+const SUPPORTED_PROTOCOLS = ['1', '2'];
 const RECONNECT_DELAY = 3000;
 const MAX_RECONNECT_ATTEMPTS = 5;
 
@@ -86,15 +90,16 @@ export class AgentClient {
   }
 
   /** Check agent version compatibility before connecting. */
-  async checkVersion(): Promise<{ compatible: boolean; error?: string }> {
+  async checkVersion(): Promise<{ compatible: boolean; protocol?: string; error?: string }> {
     try {
       const res = await fetch(`${AGENT_BASE}/version`);
-      if (!res.ok) return { compatible: true }; // Old agent without /version — allow
+      if (!res.ok) return { compatible: true, protocol: '1' }; // Old agent without /version — allow
       const data = await res.json();
-      if (data.protocol !== EXPECTED_PROTOCOL) {
-        return { compatible: false, error: `Agent protocol v${data.protocol} does not match UI (expected v${EXPECTED_PROTOCOL}). Redeploy the agent.` };
+      const protocol = String(data.protocol);
+      if (!SUPPORTED_PROTOCOLS.includes(protocol)) {
+        return { compatible: false, error: `Agent protocol v${protocol} is not supported by this UI (supported: v${SUPPORTED_PROTOCOLS.join(', v')}). Redeploy the agent.` };
       }
-      return { compatible: true };
+      return { compatible: true, protocol };
     } catch {
       return { compatible: false, error: 'Cannot reach agent API. Is the pulse-agent pod running?' };
     }

--- a/src/kubeview/store/__tests__/trustStore.test.ts
+++ b/src/kubeview/store/__tests__/trustStore.test.ts
@@ -1,12 +1,12 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach } from 'vitest';
 import { act, renderHook } from '@testing-library/react';
-import { useTrustStore } from '../trustStore';
+import { useTrustStore, TRUST_LABELS, TRUST_DESCRIPTIONS } from '../trustStore';
 
 describe('trustStore', () => {
   beforeEach(() => {
     act(() => {
-      useTrustStore.setState({ trustLevel: 1, history: [] });
+      useTrustStore.setState({ trustLevel: 1, history: [], autoFixCategories: [] });
     });
   });
 
@@ -82,9 +82,9 @@ describe('trustStore', () => {
     expect(elig.consecutiveApprovals).toBe(0);
   });
 
-  it('does not upgrade past level 3', () => {
+  it('does not upgrade past level 4', () => {
     const { result } = renderHook(() => useTrustStore());
-    act(() => result.current.setTrustLevel(3));
+    act(() => result.current.setTrustLevel(4));
 
     act(() => {
       for (let i = 0; i < 15; i++) {
@@ -94,7 +94,7 @@ describe('trustStore', () => {
 
     const elig = result.current.getUpgradeEligibility();
     expect(elig.eligible).toBe(false);
-    expect(elig.nextLevel).toBe(3);
+    expect(elig.nextLevel).toBe(4);
   });
 
   it('trims history to 100 records', () => {
@@ -118,5 +118,57 @@ describe('trustStore', () => {
     });
 
     expect(result.current.history).toHaveLength(0);
+  });
+
+  it('has level 4 label and description', () => {
+    expect(TRUST_LABELS[4]).toBe('Autonomous');
+    expect(TRUST_DESCRIPTIONS[4]).toBe('Agent auto-fixes known issues from runbooks. All actions are logged and reversible.');
+  });
+
+  it('manages autoFixCategories state', () => {
+    const { result } = renderHook(() => useTrustStore());
+    expect(result.current.autoFixCategories).toEqual([]);
+
+    act(() => {
+      result.current.setAutoFixCategories(['pod-restart', 'certificate-renewal']);
+    });
+
+    expect(result.current.autoFixCategories).toEqual(['pod-restart', 'certificate-renewal']);
+  });
+
+  it('shouldAutoApprove returns true for all risk levels at level 4', () => {
+    const { result } = renderHook(() => useTrustStore());
+    act(() => result.current.setTrustLevel(4));
+
+    expect(result.current.shouldAutoApprove('scale_deployment', 'LOW')).toBe(true);
+    expect(result.current.shouldAutoApprove('delete_pod', 'MEDIUM')).toBe(true);
+    expect(result.current.shouldAutoApprove('drain_node', 'HIGH')).toBe(true);
+  });
+
+  it('upgrade eligibility from level 3 to 4', () => {
+    const { result } = renderHook(() => useTrustStore());
+    act(() => result.current.setTrustLevel(3));
+
+    act(() => {
+      for (let i = 0; i < 10; i++) {
+        result.current.recordConfirmation({ tool: 'scale_deployment', approved: true, timestamp: Date.now() + i, riskLevel: 'LOW' });
+      }
+    });
+
+    const elig = result.current.getUpgradeEligibility();
+    expect(elig.eligible).toBe(true);
+    expect(elig.currentLevel).toBe(3);
+    expect(elig.nextLevel).toBe(4);
+  });
+
+  it('persists autoFixCategories', () => {
+    const { result } = renderHook(() => useTrustStore());
+    act(() => {
+      result.current.setAutoFixCategories(['pod-restart']);
+    });
+
+    // Verify the partialize includes autoFixCategories by checking state
+    const state = useTrustStore.getState();
+    expect(state.autoFixCategories).toEqual(['pod-restart']);
   });
 });

--- a/src/kubeview/store/trustStore.ts
+++ b/src/kubeview/store/trustStore.ts
@@ -2,22 +2,24 @@
  * Trust Store — tracks agent confirmation history and progressive trust levels.
  *
  * Trust levels:
- *   0 OBSERVE  — Agent explains, no action buttons
- *   1 CONFIRM  — All actions require confirmation (default)
- *   2 BATCH    — LOW risk auto-approved
- *   3 BOUNDED  — LOW + MEDIUM auto-approved, only HIGH requires confirmation
+ *   0 OBSERVE     — Agent explains, no action buttons
+ *   1 CONFIRM     — All actions require confirmation (default)
+ *   2 BATCH       — LOW risk auto-approved
+ *   3 BOUNDED     — LOW + MEDIUM auto-approved, only HIGH requires confirmation
+ *   4 AUTONOMOUS  — Agent auto-fixes known issues from runbooks (all actions logged & reversible)
  */
 
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-export type TrustLevel = 0 | 1 | 2 | 3;
+export type TrustLevel = 0 | 1 | 2 | 3 | 4;
 
 export const TRUST_LABELS: Record<TrustLevel, string> = {
   0: 'Observe',
   1: 'Confirm',
   2: 'Batch',
   3: 'Bounded',
+  4: 'Autonomous',
 };
 
 export const TRUST_DESCRIPTIONS: Record<TrustLevel, string> = {
@@ -25,6 +27,7 @@ export const TRUST_DESCRIPTIONS: Record<TrustLevel, string> = {
   1: 'Every action requires your explicit approval.',
   2: 'Low-risk actions auto-approved. Medium and high require confirmation.',
   3: 'Low and medium auto-approved. Only high-risk actions require confirmation.',
+  4: 'Agent auto-fixes known issues from runbooks. All actions are logged and reversible.',
 };
 
 export interface ConfirmationRecord {
@@ -41,9 +44,11 @@ const MAX_HISTORY = 100;
 interface TrustState {
   trustLevel: TrustLevel;
   history: ConfirmationRecord[];
+  autoFixCategories: string[];
 
   recordConfirmation: (record: Omit<ConfirmationRecord, 'id'>) => void;
   setTrustLevel: (level: TrustLevel) => void;
+  setAutoFixCategories: (categories: string[]) => void;
   shouldAutoApprove: (tool: string, riskLevel: string) => boolean;
   getUpgradeEligibility: () => {
     eligible: boolean;
@@ -69,6 +74,7 @@ export const useTrustStore = create<TrustState>()(
     (set, get) => ({
       trustLevel: 1 as TrustLevel,
       history: [],
+      autoFixCategories: [],
 
       recordConfirmation: (record) => {
         const entry: ConfirmationRecord = {
@@ -84,23 +90,28 @@ export const useTrustStore = create<TrustState>()(
         set({ trustLevel: level });
       },
 
+      setAutoFixCategories: (categories) => {
+        set({ autoFixCategories: categories });
+      },
+
       shouldAutoApprove: (_tool: string, riskLevel: string) => {
         const { trustLevel } = get();
         if (trustLevel === 0) return false; // observe mode — no actions
         if (trustLevel === 1) return false; // all confirm
         if (trustLevel === 2) return riskLevel === 'LOW';
         if (trustLevel === 3) return riskLevel === 'LOW' || riskLevel === 'MEDIUM';
+        if (trustLevel === 4) return true;
         return false;
       },
 
       getUpgradeEligibility: () => {
         const { trustLevel, history } = get();
         const consecutive = countConsecutiveApprovals(history);
-        const nextLevel = Math.min(trustLevel + 1, 3) as TrustLevel;
+        const nextLevel = Math.min(trustLevel + 1, 4) as TrustLevel;
         const approvalsNeeded = Math.max(0, UPGRADE_THRESHOLD - consecutive);
 
         return {
-          eligible: trustLevel < 3 && consecutive >= UPGRADE_THRESHOLD,
+          eligible: trustLevel < 4 && consecutive >= UPGRADE_THRESHOLD,
           currentLevel: trustLevel,
           nextLevel,
           consecutiveApprovals: consecutive,
@@ -117,6 +128,7 @@ export const useTrustStore = create<TrustState>()(
       partialize: (state) => ({
         trustLevel: state.trustLevel,
         history: state.history.slice(-MAX_HISTORY),
+        autoFixCategories: state.autoFixCategories,
       }),
     },
   ),


### PR DESCRIPTION
## Summary
- Add Trust Level 4 (Autonomous) to trustStore — agent auto-fixes known issues from runbooks
- Add autoFixCategories state field for future category-gated autonomous actions
- Update agentClient to support both protocol v1 and v2, add monitor agent mode, and new event types
- Update upgrade eligibility max level from 3 to 4

## Test plan
- [x] 16 trustStore tests pass (5 new)
- [x] Full suite: 1784 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)