### PR TITLE
feat: monitor client, store, and fix history foundation

### DIFF
--- a/src/kubeview/engine/__tests__/fixHistory.test.ts
+++ b/src/kubeview/engine/__tests__/fixHistory.test.ts
@@ -1,0 +1,178 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  fetchFixHistory,
+  fetchActionDetail,
+  requestRollback,
+} from '../fixHistory';
+
+const mockAction = {
+  id: 'a1',
+  findingId: 'f1',
+  timestamp: 1000,
+  category: 'memory',
+  tool: 'scale_deployment',
+  input: { replicas: 3 },
+  status: 'completed',
+  beforeState: '1 replica',
+  afterState: '3 replicas',
+  reasoning: 'OOM risk detected',
+  durationMs: 500,
+  rollbackAvailable: true,
+  resources: [{ kind: 'Deployment', name: 'web', namespace: 'default' }],
+};
+
+describe('fixHistory', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('fetchFixHistory', () => {
+    it('fetches with no params', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              actions: [mockAction],
+              total: 1,
+              page: 1,
+              pageSize: 20,
+            }),
+        }),
+      );
+
+      const result = await fetchFixHistory();
+      expect(fetch).toHaveBeenCalledWith('/api/agent/fix-history');
+      expect(result.actions).toHaveLength(1);
+      expect(result.total).toBe(1);
+    });
+
+    it('builds query string from filters', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () =>
+            Promise.resolve({ actions: [], total: 0, page: 2, pageSize: 20 }),
+        }),
+      );
+
+      await fetchFixHistory({
+        page: 2,
+        filters: { category: 'memory', status: 'completed', search: 'oom' },
+      });
+
+      const url = (fetch as any).mock.calls[0][0] as string;
+      expect(url).toContain('page=2');
+      expect(url).toContain('category=memory');
+      expect(url).toContain('status=completed');
+      expect(url).toContain('search=oom');
+    });
+
+    it('includes since filter', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () =>
+            Promise.resolve({ actions: [], total: 0, page: 1, pageSize: 20 }),
+        }),
+      );
+
+      await fetchFixHistory({ filters: { since: 1700000000 } });
+      const url = (fetch as any).mock.calls[0][0] as string;
+      expect(url).toContain('since=1700000000');
+    });
+
+    it('throws on non-ok response', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 500,
+          statusText: 'Internal Server Error',
+        }),
+      );
+
+      await expect(fetchFixHistory()).rejects.toThrow(
+        'Failed to fetch fix history: 500 Internal Server Error',
+      );
+    });
+  });
+
+  describe('fetchActionDetail', () => {
+    it('fetches action by id', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve(mockAction),
+        }),
+      );
+
+      const result = await fetchActionDetail('a1');
+      expect(fetch).toHaveBeenCalledWith('/api/agent/fix-history/a1');
+      expect(result.id).toBe('a1');
+    });
+
+    it('encodes id in URL', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve(mockAction),
+        }),
+      );
+
+      await fetchActionDetail('a/b');
+      expect(fetch).toHaveBeenCalledWith('/api/agent/fix-history/a%2Fb');
+    });
+
+    it('throws on non-ok response', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 404,
+          statusText: 'Not Found',
+        }),
+      );
+
+      await expect(fetchActionDetail('x')).rejects.toThrow(
+        'Failed to fetch action detail: 404 Not Found',
+      );
+    });
+  });
+
+  describe('requestRollback', () => {
+    it('sends POST to rollback endpoint', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({ ok: true }),
+      );
+
+      await requestRollback('a1');
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/agent/fix-history/a1/rollback',
+        { method: 'POST' },
+      );
+    });
+
+    it('throws on non-ok response', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 409,
+          statusText: 'Conflict',
+        }),
+      );
+
+      await expect(requestRollback('a1')).rejects.toThrow(
+        'Failed to request rollback: 409 Conflict',
+      );
+    });
+  });
+});

--- a/src/kubeview/engine/__tests__/monitorClient.test.ts
+++ b/src/kubeview/engine/__tests__/monitorClient.test.ts
@@ -1,0 +1,208 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MonitorClient } from '../monitorClient';
+
+// Mock WebSocket
+class MockWebSocket {
+  static OPEN = 1;
+  static CONNECTING = 0;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  readyState = MockWebSocket.OPEN;
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  sent: string[] = [];
+
+  constructor(public url: string) {
+    setTimeout(() => this.onopen?.(), 0);
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.();
+  }
+}
+
+vi.stubGlobal('WebSocket', MockWebSocket);
+
+describe('MonitorClient', () => {
+  let client: MonitorClient;
+
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    client = new MonitorClient();
+  });
+
+  afterEach(() => {
+    client.disconnect();
+    vi.useRealTimers();
+  });
+
+  it('creates in disconnected state', () => {
+    expect(client.connected).toBe(false);
+  });
+
+  it('connects and emits connected event', async () => {
+    const events: string[] = [];
+    client.on((e) => events.push(e.type));
+    client.connect();
+    await vi.advanceTimersByTimeAsync(10);
+    expect(events).toContain('connected');
+    expect(client.connected).toBe(true);
+  });
+
+  it('sends subscribe_monitor on connect', async () => {
+    client.connect('supervised', ['memory', 'cpu']);
+    await vi.advanceTimersByTimeAsync(10);
+    const ws = (client as any).ws as MockWebSocket;
+    expect(ws.sent).toHaveLength(1);
+    const parsed = JSON.parse(ws.sent[0]);
+    expect(parsed.type).toBe('subscribe_monitor');
+    expect(parsed.trustLevel).toBe('supervised');
+    expect(parsed.autoFixCategories).toEqual(['memory', 'cpu']);
+  });
+
+  it('emits finding events from WebSocket messages', async () => {
+    const events: any[] = [];
+    client.on((e) => events.push(e));
+    client.connect();
+    await vi.advanceTimersByTimeAsync(10);
+
+    const ws = (client as any).ws as MockWebSocket;
+    ws.onmessage?.({
+      data: JSON.stringify({
+        type: 'finding',
+        id: 'f1',
+        severity: 'critical',
+        category: 'memory',
+        title: 'OOM Risk',
+        summary: 'Pod nearing memory limit',
+        resources: [{ kind: 'Pod', name: 'web-1', namespace: 'default' }],
+        autoFixable: true,
+        timestamp: Date.now(),
+      }),
+    });
+
+    const finding = events.find((e) => e.type === 'finding');
+    expect(finding).toBeDefined();
+    expect(finding.id).toBe('f1');
+    expect(finding.severity).toBe('critical');
+  });
+
+  it('emits disconnected on close', async () => {
+    const events: string[] = [];
+    client.on((e) => events.push(e.type));
+    client.connect();
+    await vi.advanceTimersByTimeAsync(10);
+
+    client.disconnect();
+    expect(events).toContain('disconnected');
+    expect(client.connected).toBe(false);
+  });
+
+  it('approveAction sends JSON message', async () => {
+    client.connect();
+    await vi.advanceTimersByTimeAsync(10);
+    client.approveAction('action-1');
+    const ws = (client as any).ws as MockWebSocket;
+    // sent[0] is subscribe_monitor, sent[1] is approve
+    const parsed = JSON.parse(ws.sent[1]);
+    expect(parsed.type).toBe('approve_action');
+    expect(parsed.actionId).toBe('action-1');
+  });
+
+  it('rejectAction sends JSON message', async () => {
+    client.connect();
+    await vi.advanceTimersByTimeAsync(10);
+    client.rejectAction('action-2');
+    const ws = (client as any).ws as MockWebSocket;
+    const parsed = JSON.parse(ws.sent[1]);
+    expect(parsed.type).toBe('reject_action');
+    expect(parsed.actionId).toBe('action-2');
+  });
+
+  it('requestFixHistory sends JSON message', async () => {
+    client.connect();
+    await vi.advanceTimersByTimeAsync(10);
+    client.requestFixHistory({ category: 'memory' }, 2);
+    const ws = (client as any).ws as MockWebSocket;
+    const parsed = JSON.parse(ws.sent[1]);
+    expect(parsed.type).toBe('request_fix_history');
+    expect(parsed.filters).toEqual({ category: 'memory' });
+    expect(parsed.page).toBe(2);
+  });
+
+  it('emits error when sending without connection', () => {
+    const events: any[] = [];
+    client.on((e) => events.push(e));
+    client.approveAction('x');
+    expect(events).toContainEqual({
+      type: 'error',
+      message: 'Not connected to monitor',
+    });
+  });
+
+  it('unsubscribe removes handler', async () => {
+    const events: string[] = [];
+    const unsub = client.on((e) => events.push(e.type));
+    client.connect();
+    await vi.advanceTimersByTimeAsync(10);
+
+    unsub();
+    const ws = (client as any).ws as MockWebSocket;
+    ws.onmessage?.({
+      data: JSON.stringify({ type: 'finding', id: 'f2' }),
+    });
+
+    // Only connected event, no finding
+    expect(events).toEqual(['connected']);
+  });
+
+  it('schedules reconnect on unexpected close', async () => {
+    client.connect();
+    await vi.advanceTimersByTimeAsync(10);
+
+    // Simulate unexpected close (not user-initiated)
+    const ws = (client as any).ws as MockWebSocket;
+    ws.onclose?.();
+
+    // Should schedule reconnect — advance past base delay + jitter
+    expect((client as any).reconnectTimer).not.toBeNull();
+  });
+
+  it('does not reconnect after user disconnect', async () => {
+    client.connect();
+    await vi.advanceTimersByTimeAsync(10);
+
+    client.disconnect();
+    expect((client as any).reconnectTimer).toBeNull();
+  });
+
+  it('reconnects immediately when tab becomes visible', async () => {
+    client.connect();
+    await vi.advanceTimersByTimeAsync(10);
+    expect(client.connected).toBe(true);
+
+    // Simulate unexpected close — schedules a reconnect timer
+    (client as any)._connected = false;
+    (client as any).ws = null;
+
+    // Simulate tab becoming visible — should trigger reconnect
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'visible',
+      writable: true,
+      configurable: true,
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+    await vi.advanceTimersByTimeAsync(10);
+
+    // Should be connected again after visibility-triggered reconnect
+    expect(client.connected).toBe(true);
+  });
+});

--- a/src/kubeview/engine/fixHistory.ts
+++ b/src/kubeview/engine/fixHistory.ts
@@ -1,0 +1,85 @@
+/**
+ * Fix History — types and REST helpers for querying the agent's
+ * autonomous action history. Used by the monitor store and fix history UI.
+ */
+
+import type { ResourceRef } from './monitorClient';
+
+// ---- Types ----
+
+export interface ActionRecord {
+  id: string;
+  findingId: string;
+  timestamp: number;
+  category: string;
+  tool: string;
+  input: Record<string, unknown>;
+  status: 'proposed' | 'executing' | 'completed' | 'failed' | 'rolled_back';
+  beforeState: string;
+  afterState: string;
+  error?: string;
+  reasoning: string;
+  durationMs: number;
+  rollbackAvailable: boolean;
+  rollbackAction?: { tool: string; input: Record<string, unknown> };
+  resources: ResourceRef[];
+}
+
+export interface FixHistoryFilters {
+  since?: number;
+  category?: string;
+  status?: string;
+  search?: string;
+}
+
+export interface FixHistoryResponse {
+  actions: ActionRecord[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+// ---- REST helpers ----
+
+const AGENT_BASE = '/api/agent';
+
+/** Fetch paginated fix history with optional filters. */
+export async function fetchFixHistory(params?: {
+  page?: number;
+  filters?: FixHistoryFilters;
+}): Promise<FixHistoryResponse> {
+  const query = new URLSearchParams();
+  if (params?.page) query.set('page', String(params.page));
+  if (params?.filters?.since) query.set('since', String(params.filters.since));
+  if (params?.filters?.category) query.set('category', params.filters.category);
+  if (params?.filters?.status) query.set('status', params.filters.status);
+  if (params?.filters?.search) query.set('search', params.filters.search);
+
+  const qs = query.toString();
+  const url = `${AGENT_BASE}/fix-history${qs ? `?${qs}` : ''}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch fix history: ${res.status} ${res.statusText}`);
+  }
+  return res.json();
+}
+
+/** Fetch details for a single action record. */
+export async function fetchActionDetail(id: string): Promise<ActionRecord> {
+  const res = await fetch(`${AGENT_BASE}/fix-history/${encodeURIComponent(id)}`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch action detail: ${res.status} ${res.statusText}`);
+  }
+  return res.json();
+}
+
+/** Request a rollback for a completed action. */
+export async function requestRollback(actionId: string): Promise<void> {
+  const res = await fetch(
+    `${AGENT_BASE}/fix-history/${encodeURIComponent(actionId)}/rollback`,
+    { method: 'POST' },
+  );
+  if (!res.ok) {
+    throw new Error(`Failed to request rollback: ${res.status} ${res.statusText}`);
+  }
+}

--- a/src/kubeview/engine/monitorClient.ts
+++ b/src/kubeview/engine/monitorClient.ts
@@ -1,0 +1,257 @@
+/**
+ * Monitor WebSocket client — connects to the Pulse Agent monitor channel.
+ *
+ * Unlike the interactive AgentClient, this is a background connection that
+ * receives autonomous findings, predictions, and action reports from the
+ * 24/7 SRE agent. It uses infinite reconnect with exponential backoff and
+ * reduces polling frequency when the tab is hidden.
+ */
+
+// ---- Types ----
+
+export interface ResourceRef {
+  kind: string;
+  name: string;
+  namespace?: string;
+}
+
+export interface Finding {
+  id: string;
+  severity: 'critical' | 'warning' | 'info';
+  category: string;
+  title: string;
+  summary: string;
+  resources: ResourceRef[];
+  autoFixable: boolean;
+  runbookId?: string;
+  timestamp: number;
+}
+
+export interface ActionReport {
+  id: string;
+  findingId: string;
+  tool: string;
+  input: Record<string, unknown>;
+  status: 'proposed' | 'executing' | 'completed' | 'failed' | 'rolled_back';
+  beforeState?: string;
+  afterState?: string;
+  error?: string;
+  timestamp: number;
+  reasoning?: string;
+  durationMs?: number;
+}
+
+export interface Prediction {
+  id: string;
+  category: string;
+  title: string;
+  detail: string;
+  eta: string;
+  confidence: number;
+  resources: ResourceRef[];
+  recommendedAction?: string;
+  timestamp: number;
+}
+
+export interface MonitorStatus {
+  activeWatches: string[];
+  lastScan: number;
+  findingsCount: number;
+  nextScan: number;
+}
+
+export type MonitorEvent =
+  | ({ type: 'finding' } & Finding)
+  | ({ type: 'action_report' } & ActionReport)
+  | ({ type: 'prediction' } & Prediction)
+  | ({ type: 'monitor_status' } & MonitorStatus)
+  | { type: 'connected' }
+  | { type: 'disconnected' }
+  | { type: 'error'; message: string };
+
+type EventHandler = (event: MonitorEvent) => void;
+
+const MONITOR_ENDPOINT = '/api/agent/ws/monitor';
+const BASE_RECONNECT_DELAY = 1000;
+const MAX_RECONNECT_DELAY = 30_000;
+const HIDDEN_RECONNECT_DELAY = 60_000;
+
+export class MonitorClient {
+  private ws: WebSocket | null = null;
+  private handlers: Set<EventHandler> = new Set();
+  private reconnectAttempts = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private _connected = false;
+  private _disconnectedByUser = false;
+  private trustLevel = 'observe';
+  private autoFixCategories: string[] = [];
+  private visibilityHandler: (() => void) | null = null;
+
+  get connected(): boolean {
+    return this._connected;
+  }
+
+  /** Subscribe to monitor events. Returns unsubscribe function. */
+  on(handler: EventHandler): () => void {
+    this.handlers.add(handler);
+    return () => this.handlers.delete(handler);
+  }
+
+  private emit(event: MonitorEvent) {
+    for (const handler of this.handlers) {
+      try {
+        handler(event);
+      } catch (e) {
+        console.error('Monitor event handler error:', e);
+      }
+    }
+  }
+
+  /** Connect to the monitor WebSocket channel. */
+  connect(trustLevel = 'observe', autoFixCategories: string[] = []) {
+    this._disconnectedByUser = false;
+    this.trustLevel = trustLevel;
+    this.autoFixCategories = autoFixCategories;
+
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const url = `${protocol}//${window.location.host}${MONITOR_ENDPOINT}`;
+
+    this.ws = new WebSocket(url);
+
+    this.ws.onopen = () => {
+      this._connected = true;
+      this.reconnectAttempts = 0;
+      this.emit({ type: 'connected' });
+
+      // Send subscription message with trust level and auto-fix categories
+      this.ws?.send(
+        JSON.stringify({
+          type: 'subscribe_monitor',
+          trustLevel: this.trustLevel,
+          autoFixCategories: this.autoFixCategories,
+        }),
+      );
+    };
+
+    this.ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data) as MonitorEvent;
+        this.emit(data);
+      } catch {
+        console.error('Failed to parse monitor message:', event.data);
+      }
+    };
+
+    this.ws.onclose = () => {
+      this._connected = false;
+      this.emit({ type: 'disconnected' });
+      if (!this._disconnectedByUser) {
+        this.scheduleReconnect();
+      }
+    };
+
+    this.ws.onerror = () => {
+      // onclose will fire after onerror
+    };
+
+    // Set up visibility change listener
+    if (!this.visibilityHandler) {
+      this.visibilityHandler = () => this.handleVisibilityChange();
+      document.addEventListener('visibilitychange', this.visibilityHandler);
+    }
+  }
+
+  private scheduleReconnect() {
+    if (this._disconnectedByUser) return;
+    if (this.reconnectTimer) return;
+
+    // Check if tab is hidden — use longer delay
+    const isHidden = document.visibilityState === 'hidden';
+    const delay = isHidden
+      ? HIDDEN_RECONNECT_DELAY
+      : Math.min(
+          BASE_RECONNECT_DELAY * Math.pow(2, this.reconnectAttempts),
+          MAX_RECONNECT_DELAY,
+        );
+
+    // Add jitter (up to 20% of delay)
+    const jitter = Math.random() * delay * 0.2;
+
+    this.reconnectAttempts++;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      if (!this._disconnectedByUser) {
+        this.connect(this.trustLevel, this.autoFixCategories);
+      }
+    }, delay + jitter);
+  }
+
+  private handleVisibilityChange() {
+    if (this._disconnectedByUser) return;
+
+    if (document.visibilityState === 'visible') {
+      // Tab became visible — reconnect immediately if disconnected
+      if (!this._connected) {
+        if (this.reconnectTimer) {
+          clearTimeout(this.reconnectTimer);
+          this.reconnectTimer = null;
+        }
+        this.reconnectAttempts = 0;
+        this.connect(this.trustLevel, this.autoFixCategories);
+      }
+    }
+    // When hidden, scheduleReconnect already uses HIDDEN_RECONNECT_DELAY
+  }
+
+  /** Disconnect and stop reconnecting. */
+  disconnect() {
+    this._disconnectedByUser = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.visibilityHandler) {
+      document.removeEventListener('visibilitychange', this.visibilityHandler);
+      this.visibilityHandler = null;
+    }
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+    this._connected = false;
+  }
+
+  /** Approve a proposed action. */
+  approveAction(actionId: string) {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      this.emit({ type: 'error', message: 'Not connected to monitor' });
+      return;
+    }
+    this.ws.send(JSON.stringify({ type: 'approve_action', actionId }));
+  }
+
+  /** Reject a proposed action. */
+  rejectAction(actionId: string) {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      this.emit({ type: 'error', message: 'Not connected to monitor' });
+      return;
+    }
+    this.ws.send(JSON.stringify({ type: 'reject_action', actionId }));
+  }
+
+  /** Request fix history with optional filters and pagination. */
+  requestFixHistory(filters?: Record<string, unknown>, page?: number) {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      this.emit({ type: 'error', message: 'Not connected to monitor' });
+      return;
+    }
+    this.ws.send(
+      JSON.stringify({ type: 'request_fix_history', filters, page }),
+    );
+  }
+}

--- a/src/kubeview/store/__tests__/monitorStore.test.ts
+++ b/src/kubeview/store/__tests__/monitorStore.test.ts
@@ -1,0 +1,183 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock MonitorClient
+vi.mock('../../engine/monitorClient', () => {
+  return {
+    MonitorClient: class MockMonitorClient {
+      connected = false;
+      private handlers = new Set<(e: any) => void>();
+
+      on(handler: (e: any) => void) {
+        this.handlers.add(handler);
+        return () => this.handlers.delete(handler);
+      }
+
+      connect() {
+        this.connected = true;
+        this.emit({ type: 'connected' });
+      }
+
+      disconnect() {
+        this.connected = false;
+      }
+
+      approveAction() {}
+      rejectAction() {}
+      requestFixHistory() {}
+
+      private emit(event: any) {
+        for (const h of this.handlers) h(event);
+      }
+
+      // Test helper: simulate incoming event
+      _simulateEvent(event: any) {
+        this.emit(event);
+      }
+    },
+  };
+});
+
+// Mock fetchFixHistory
+vi.mock('../../engine/fixHistory', () => ({
+  fetchFixHistory: vi.fn().mockResolvedValue({
+    actions: [
+      {
+        id: 'a1',
+        findingId: 'f1',
+        timestamp: 1000,
+        category: 'memory',
+        tool: 'scale_deployment',
+        input: {},
+        status: 'completed',
+        beforeState: '1 replica',
+        afterState: '3 replicas',
+        reasoning: 'OOM risk',
+        durationMs: 500,
+        rollbackAvailable: true,
+        resources: [],
+      },
+    ],
+    total: 1,
+    page: 1,
+    pageSize: 20,
+  }),
+}));
+
+import { useMonitorStore } from '../monitorStore';
+
+describe('monitorStore', () => {
+  beforeEach(() => {
+    const { disconnect } = useMonitorStore.getState();
+    disconnect();
+    useMonitorStore.setState({
+      connected: false,
+      lastScanTime: 0,
+      nextScanTime: 0,
+      activeWatches: [],
+      findings: [],
+      dismissedFindingIds: [],
+      predictions: [],
+      pendingActions: [],
+      recentActions: [],
+      fixHistory: [],
+      fixHistoryTotal: 0,
+      fixHistoryPage: 1,
+      fixHistoryLoading: false,
+      monitorEnabled: true,
+      autoFixCategories: [],
+      unreadCount: 0,
+      notificationCenterOpen: false,
+    });
+  });
+
+  it('initializes with default state', () => {
+    const state = useMonitorStore.getState();
+    expect(state.connected).toBe(false);
+    expect(state.findings).toEqual([]);
+    expect(state.predictions).toEqual([]);
+    expect(state.monitorEnabled).toBe(true);
+    expect(state.unreadCount).toBe(0);
+  });
+
+  it('connect sets connected to true', () => {
+    useMonitorStore.getState().connect();
+    expect(useMonitorStore.getState().connected).toBe(true);
+  });
+
+  it('disconnect sets connected to false', () => {
+    useMonitorStore.getState().connect();
+    useMonitorStore.getState().disconnect();
+    expect(useMonitorStore.getState().connected).toBe(false);
+  });
+
+  it('dismissFinding removes finding and records id', () => {
+    useMonitorStore.setState({
+      findings: [
+        {
+          id: 'f1',
+          severity: 'warning',
+          category: 'cpu',
+          title: 'High CPU',
+          summary: 'CPU at 95%',
+          resources: [],
+          autoFixable: false,
+          timestamp: 1000,
+        },
+      ],
+    });
+
+    useMonitorStore.getState().dismissFinding('f1');
+    const state = useMonitorStore.getState();
+    expect(state.findings).toEqual([]);
+    expect(state.dismissedFindingIds).toContain('f1');
+  });
+
+  it('setMonitorEnabled toggles and connects/disconnects', () => {
+    useMonitorStore.getState().setMonitorEnabled(false);
+    expect(useMonitorStore.getState().monitorEnabled).toBe(false);
+    expect(useMonitorStore.getState().connected).toBe(false);
+
+    useMonitorStore.getState().setMonitorEnabled(true);
+    expect(useMonitorStore.getState().monitorEnabled).toBe(true);
+    expect(useMonitorStore.getState().connected).toBe(true);
+  });
+
+  it('setAutoFixCategories updates categories', () => {
+    useMonitorStore.getState().setAutoFixCategories(['memory', 'disk']);
+    expect(useMonitorStore.getState().autoFixCategories).toEqual([
+      'memory',
+      'disk',
+    ]);
+  });
+
+  it('markAllRead resets unread count', () => {
+    useMonitorStore.setState({ unreadCount: 5 });
+    useMonitorStore.getState().markAllRead();
+    expect(useMonitorStore.getState().unreadCount).toBe(0);
+  });
+
+  it('toggleNotificationCenter toggles open state and clears unread on open', () => {
+    useMonitorStore.setState({ unreadCount: 3, notificationCenterOpen: false });
+    useMonitorStore.getState().toggleNotificationCenter();
+    const state = useMonitorStore.getState();
+    expect(state.notificationCenterOpen).toBe(true);
+    expect(state.unreadCount).toBe(0);
+  });
+
+  it('toggleNotificationCenter preserves unread when closing', () => {
+    useMonitorStore.setState({ unreadCount: 3, notificationCenterOpen: true });
+    useMonitorStore.getState().toggleNotificationCenter();
+    const state = useMonitorStore.getState();
+    expect(state.notificationCenterOpen).toBe(false);
+    expect(state.unreadCount).toBe(3);
+  });
+
+  it('loadFixHistory fetches and updates state', async () => {
+    await useMonitorStore.getState().loadFixHistory();
+    const state = useMonitorStore.getState();
+    expect(state.fixHistory).toHaveLength(1);
+    expect(state.fixHistoryTotal).toBe(1);
+    expect(state.fixHistoryLoading).toBe(false);
+  });
+});

--- a/src/kubeview/store/monitorStore.ts
+++ b/src/kubeview/store/monitorStore.ts
@@ -1,0 +1,268 @@
+/**
+ * Monitor Store — manages state for the autonomous SRE agent monitor channel.
+ * Receives findings, predictions, and action reports over WebSocket.
+ * Persists user preferences and recent data to localStorage.
+ */
+
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import {
+  MonitorClient,
+  type MonitorEvent,
+  type Finding,
+  type ActionReport,
+  type Prediction,
+} from '../engine/monitorClient';
+import {
+  fetchFixHistory,
+  type ActionRecord,
+  type FixHistoryFilters,
+} from '../engine/fixHistory';
+
+const MAX_FINDINGS = 200;
+const MAX_PREDICTIONS = 50;
+const MAX_RECENT_ACTIONS = 50;
+
+interface MonitorState {
+  // Connection
+  connected: boolean;
+  lastScanTime: number;
+  nextScanTime: number;
+  activeWatches: string[];
+
+  // Data
+  findings: Finding[];
+  dismissedFindingIds: string[];
+  predictions: Prediction[];
+  pendingActions: ActionReport[];
+  recentActions: ActionReport[];
+
+  // Fix history (REST-loaded)
+  fixHistory: ActionRecord[];
+  fixHistoryTotal: number;
+  fixHistoryPage: number;
+  fixHistoryLoading: boolean;
+
+  // Preferences
+  monitorEnabled: boolean;
+  autoFixCategories: string[];
+
+  // UI
+  unreadCount: number;
+  notificationCenterOpen: boolean;
+
+  // Actions
+  connect: () => void;
+  disconnect: () => void;
+  dismissFinding: (id: string) => void;
+  approveAction: (actionId: string) => void;
+  rejectAction: (actionId: string) => void;
+  setMonitorEnabled: (enabled: boolean) => void;
+  setAutoFixCategories: (categories: string[]) => void;
+  loadFixHistory: (page?: number, filters?: FixHistoryFilters) => void;
+  markAllRead: () => void;
+  toggleNotificationCenter: () => void;
+}
+
+let client: MonitorClient | null = null;
+let unsubscribe: (() => void) | null = null;
+
+function capArray<T>(arr: T[], max: number): T[] {
+  return arr.length > max ? arr.slice(-max) : arr;
+}
+
+export const useMonitorStore = create<MonitorState>()(
+  persist(
+    (set, get) => ({
+      // Connection
+      connected: false,
+      lastScanTime: 0,
+      nextScanTime: 0,
+      activeWatches: [],
+
+      // Data
+      findings: [],
+      dismissedFindingIds: [],
+      predictions: [],
+      pendingActions: [],
+      recentActions: [],
+
+      // Fix history
+      fixHistory: [],
+      fixHistoryTotal: 0,
+      fixHistoryPage: 1,
+      fixHistoryLoading: false,
+
+      // Preferences
+      monitorEnabled: true,
+      autoFixCategories: [],
+
+      // UI
+      unreadCount: 0,
+      notificationCenterOpen: false,
+
+      connect: () => {
+        if (client && get().connected) return;
+        if (unsubscribe) unsubscribe();
+        if (client) client.disconnect();
+
+        client = new MonitorClient();
+
+        unsubscribe = client.on((event: MonitorEvent) => {
+          switch (event.type) {
+            case 'connected':
+              set({ connected: true });
+              break;
+
+            case 'disconnected':
+              set({ connected: false });
+              break;
+
+            case 'finding': {
+              const { type: _, ...finding } = event;
+              const dismissed = get().dismissedFindingIds;
+              if (dismissed.includes(finding.id)) break;
+              set((s) => ({
+                findings: capArray([...s.findings, finding], MAX_FINDINGS),
+                unreadCount: s.unreadCount + 1,
+              }));
+              break;
+            }
+
+            case 'action_report': {
+              const { type: _, ...report } = event;
+              if (report.status === 'proposed') {
+                set((s) => ({
+                  pendingActions: [...s.pendingActions, report],
+                  unreadCount: s.unreadCount + 1,
+                }));
+              } else {
+                // Move from pending to recent on status change
+                set((s) => ({
+                  pendingActions: s.pendingActions.filter(
+                    (a) => a.id !== report.id,
+                  ),
+                  recentActions: capArray(
+                    [...s.recentActions, report],
+                    MAX_RECENT_ACTIONS,
+                  ),
+                }));
+              }
+              break;
+            }
+
+            case 'prediction': {
+              const { type: _, ...prediction } = event;
+              set((s) => ({
+                predictions: capArray(
+                  [...s.predictions, prediction],
+                  MAX_PREDICTIONS,
+                ),
+                unreadCount: s.unreadCount + 1,
+              }));
+              break;
+            }
+
+            case 'monitor_status': {
+              set({
+                activeWatches: event.activeWatches,
+                lastScanTime: event.lastScan,
+                nextScanTime: event.nextScan,
+              });
+              break;
+            }
+
+            case 'error':
+              console.error('Monitor error:', event.message);
+              break;
+          }
+        });
+
+        const state = get();
+        client.connect('observe', state.autoFixCategories);
+      },
+
+      disconnect: () => {
+        if (unsubscribe) {
+          unsubscribe();
+          unsubscribe = null;
+        }
+        if (client) {
+          client.disconnect();
+          client = null;
+        }
+        set({ connected: false });
+      },
+
+      dismissFinding: (id) => {
+        set((s) => ({
+          findings: s.findings.filter((f) => f.id !== id),
+          dismissedFindingIds: [...s.dismissedFindingIds, id],
+        }));
+      },
+
+      approveAction: (actionId) => {
+        if (client) client.approveAction(actionId);
+      },
+
+      rejectAction: (actionId) => {
+        if (client) client.rejectAction(actionId);
+        set((s) => ({
+          pendingActions: s.pendingActions.filter((a) => a.id !== actionId),
+        }));
+      },
+
+      setMonitorEnabled: (enabled) => {
+        set({ monitorEnabled: enabled });
+        if (enabled) {
+          get().connect();
+        } else {
+          get().disconnect();
+        }
+      },
+
+      setAutoFixCategories: (categories) => {
+        set({ autoFixCategories: categories });
+      },
+
+      loadFixHistory: async (page = 1, filters?) => {
+        set({ fixHistoryLoading: true });
+        try {
+          const response = await fetchFixHistory({ page, filters });
+          set({
+            fixHistory: response.actions,
+            fixHistoryTotal: response.total,
+            fixHistoryPage: response.page,
+            fixHistoryLoading: false,
+          });
+        } catch (err) {
+          console.error('Failed to load fix history:', err);
+          set({ fixHistoryLoading: false });
+        }
+      },
+
+      markAllRead: () => {
+        set({ unreadCount: 0 });
+      },
+
+      toggleNotificationCenter: () => {
+        set((s) => ({
+          notificationCenterOpen: !s.notificationCenterOpen,
+          // Mark as read when opening
+          unreadCount: s.notificationCenterOpen ? s.unreadCount : 0,
+        }));
+      },
+    }),
+    {
+      name: 'openshiftpulse-monitor',
+      partialize: (state) => ({
+        monitorEnabled: state.monitorEnabled,
+        autoFixCategories: state.autoFixCategories,
+        dismissedFindingIds: state.dismissedFindingIds,
+        findings: state.findings.slice(-MAX_FINDINGS),
+        predictions: state.predictions.slice(-MAX_PREDICTIONS),
+        recentActions: state.recentActions.slice(-MAX_RECENT_ACTIONS),
+      }),
+    },
+  ),
+);


### PR DESCRIPTION
## Summary
- New `monitorClient.ts`: WebSocket client for `/ws/monitor` with infinite reconnect, visibility-aware delays, subscribe_monitor handshake
- New `monitorStore.ts`: Zustand + persist store for findings, predictions, actions, config (capped persistence)
- New `fixHistory.ts`: ActionRecord types and REST helpers for paginated fix history
- 32 new tests (monitorClient: 13, monitorStore: 10, fixHistory: 9)

## Test plan
- [x] All 1811 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)