### PR TITLE
fix: stop connecting to removed /ws/sre endpoint, causing "Pulse AI: Offline"

### DIFF
--- a/src/kubeview/components/agent/AmbientInsight.tsx
+++ b/src/kubeview/components/agent/AmbientInsight.tsx
@@ -122,7 +122,9 @@ export function AmbientInsight({
     setError('');
     setVisible(false);
 
-    const client = new AgentClient('sre');
+    // 'sre' mode was removed from the agent's WebSocket API (see pulse-agent#fcce7b0) —
+    // only 'auto' (/ws/agent) and 'monitor' (/ws/monitor) remain. Using 'sre' here 403s.
+    const client = new AgentClient('auto');
     clientRef.current = client;
 
     const collectedComponents: ComponentSpec[] = [];

--- a/src/kubeview/components/agent/NLFilterBar.tsx
+++ b/src/kubeview/components/agent/NLFilterBar.tsx
@@ -39,7 +39,9 @@ export function NLFilterBar({ resourceKind, columns, onFiltersApplied }: NLFilte
     setLoading(true);
     setError(null);
 
-    const client = new AgentClient('sre');
+    // 'sre' mode was removed from the agent's WebSocket API (see pulse-agent#fcce7b0) —
+    // only 'auto' (/ws/agent) and 'monitor' (/ws/monitor) remain. Using 'sre' here 403s.
+    const client = new AgentClient('auto');
     clientRef.current = client;
 
     let responseText = '';

--- a/src/kubeview/engine/__tests__/agentClient.test.ts
+++ b/src/kubeview/engine/__tests__/agentClient.test.ts
@@ -52,6 +52,19 @@ describe('AgentClient', () => {
     expect(client.connected).toBe(false);
   });
 
+  it('defaults to auto mode and connects to /ws/agent, not the removed /ws/sre endpoint', async () => {
+    // Regression test: the agent's WebSocket API removed /ws/sre and /ws/security
+    // (only /ws/agent and /ws/monitor remain). AgentClient must never default to
+    // 'sre', or every consumer that omits an explicit mode gets a 403 at connect.
+    const defaultClient = new AgentClient();
+    defaultClient.connect();
+    await new Promise((r) => setTimeout(r, 10));
+    const ws = (defaultClient as any).ws as MockWebSocket;
+    expect(ws.url).toContain('/ws/agent');
+    expect(ws.url).not.toContain('/ws/sre');
+    defaultClient.disconnect();
+  });
+
   it('connects and emits connected event', async () => {
     const events: string[] = [];
     client.on((e) => events.push(e.type));

--- a/src/kubeview/engine/agentClient.ts
+++ b/src/kubeview/engine/agentClient.ts
@@ -101,7 +101,7 @@ export class AgentClient {
   private refreshTimer: ReturnType<typeof setTimeout> | null = null;
   private _connected = false;
 
-  constructor(mode: AgentMode = 'sre') {
+  constructor(mode: AgentMode = 'auto') {
     this.mode = mode;
   }
 

--- a/src/kubeview/engine/agentNotifications.ts
+++ b/src/kubeview/engine/agentNotifications.ts
@@ -140,7 +140,9 @@ function subscribeToActionReportToasts() {
 function query(): Promise<string> {
   return new Promise((resolve, reject) => {
     let settled = false;
-    const c = new AgentClient('sre');
+    // 'sre' mode was removed from the agent's WebSocket API (see pulse-agent#fcce7b0) —
+    // only 'auto' (/ws/agent) and 'monitor' (/ws/monitor) remain. Using 'sre' here 403s.
+    const c = new AgentClient('auto');
     client = c;
 
     function cleanup() {

--- a/src/kubeview/store/__tests__/agentStore.test.ts
+++ b/src/kubeview/store/__tests__/agentStore.test.ts
@@ -66,6 +66,18 @@ describe('agentStore', () => {
     lastMockHandlers = null;
   });
 
+  it('migrates a stale persisted "sre" mode to "auto" (removed /ws/sre endpoint)', () => {
+    // Regression test: browsers that persisted mode: 'sre' before the agent
+    // removed /ws/sre and /ws/security must be healed on load, or the agent
+    // panel silently reconnects to a 403'ing endpoint forever ("Offline").
+    const migrate = useAgentStore.persist.getOptions().migrate;
+    expect(migrate).toBeTypeOf('function');
+    expect(migrate!({ mode: 'sre', messages: [] }, 0)).toEqual({ mode: 'auto', messages: [] });
+    expect(migrate!({ mode: 'security', messages: [] }, 0)).toEqual({ mode: 'auto', messages: [] });
+    // Already-healthy state should pass through unchanged
+    expect(migrate!({ mode: 'auto', messages: [] }, 1)).toEqual({ mode: 'auto', messages: [] });
+  });
+
   it('initializes with default state', () => {
     const state = useAgentStore.getState();
     expect(state.mode).toBe('sre');

--- a/src/kubeview/store/agentStore.ts
+++ b/src/kubeview/store/agentStore.ts
@@ -442,10 +442,22 @@ export const useAgentStore = create<AgentState>()(
     }),
     {
       name: 'openshiftpulse-agent',
+      version: 1,
       partialize: (state) => ({
         messages: state.messages.slice(-50), // Only persist last 50 messages
         mode: state.mode,
       }),
+      // v0 -> v1: 'sre' and 'security' were removed from the agent's WebSocket
+      // API (only /ws/agent and /ws/monitor remain — see pulse-agent#fcce7b0).
+      // Browsers that persisted mode: 'sre' before that migration would otherwise
+      // reconnect to the now-403'ing endpoint forever ("Pulse AI: Offline").
+      migrate: (persistedState) => {
+        const state = persistedState as { messages: AgentMessage[]; mode: AgentMode } | undefined;
+        if (state && ((state.mode as string) === 'sre' || (state.mode as string) === 'security')) {
+          return { ...state, mode: 'auto' as AgentMode };
+        }
+        return state;
+      },
     },
   ),
 );


### PR DESCRIPTION
## Summary
- `pulse-agent` removed the `/ws/sre` and `/ws/security` WebSocket routes in [`fcce7b0`](https://github.com/PulseSRE/pulse-agent/commit/fcce7b09c8df81ca67712b0335ffb82ab29b7e7e) — only `/ws/agent` (auto-routing) and `/ws/monitor` remain (confirmed in the deployed agent's `app.py` and `API_CONTRACT.md`).
- Three UI call sites (`agentNotifications.ts`, `NLFilterBar.tsx`, `AmbientInsight.tsx`) still hardcode `new AgentClient('sre')`, and `AgentClient`'s own default mode was still `'sre'`. Every connection from these paths now gets rejected with HTTP 403 at the WebSocket handshake.
- Confirmed live against the deployed cluster: pulse-agent's own server log shows `WebSocket /ws/sre?token=... 403` / `connection rejected (403 Forbidden)` from the real UI pod IP, right next to successful `/ws/agent` and `/ws/monitor` connections from the same session. nginx's access log shows the same 403s recurring every ~5 minutes.
- `agentStore`'s `mode` field is persisted to `localStorage` via zustand's `persist` middleware with no `version`/`migrate`. The in-code default changed from `'sre'` to `'auto'` on 2026-03-29, but any browser that cached `mode: 'sre'` before that (or ever had it set) keeps reconnecting to the dead endpoint forever — this is the likely cause of the main "Pulse AI" side panel showing **Offline** persistently even though `/ws/agent` itself works fine.

## Fix
- Default `AgentClient` mode: `'sre'` → `'auto'`.
- `agentNotifications.ts` / `NLFilterBar.tsx` / `AmbientInsight.tsx`: `AgentClient('sre')` → `AgentClient('auto')`.
- `agentStore`: added `version: 1` + a `migrate()` that heals any persisted `mode: 'sre' | 'security'` to `'auto'` on load.

## Test plan
- [x] Added a regression test asserting `new AgentClient()` (no args) connects to `/ws/agent`, never `/ws/sre`.
- [x] Added a regression test for the `agentStore` persist `migrate()` healing stale `'sre'`/`'security'` mode.
- [x] `pnpm run type-check` — clean.
- [x] `pnpm run test` (vitest) — 165 files / 1997 tests pass.
- [x] `pnpm run lint` on changed files — 0 errors (pre-existing warning patterns only).

Made with [Cursor](https://cursor.com)