### PR TITLE
fix: node CPU/memory always shown as "—" — kube_node_info join errors are swallowed silently

### DIFF
--- a/src/kubeview/views/ComputeView.tsx
+++ b/src/kubeview/views/ComputeView.tsx
@@ -88,24 +88,36 @@ export default function ComputeView() {
     enabled: isHyperShift,
   });
 
-  // Per-node CPU usage from Prometheus (joined via kube_node_info for reliable node name matching)
+  // Per-node CPU usage from Prometheus. Tries the kube_node_info join first
+  // (gives reliable node-name matching on clusters where node-exporter's
+  // `instance` label isn't the node name), falling back to the plain
+  // by-instance query if the join errors — e.g. on clusters where
+  // kube_node_info has no `instance` label at all, which makes `on(instance)`
+  // match every node into one ambiguous group ("duplicate series for the
+  // match group") and Thanos rejects the query outright (422). safeQuery only
+  // swallows 404s, so that failure must be caught here or the plain query
+  // never runs and the UI shows no data.
   const { data: nodeCpuMetrics = [] } = useQuery({
     queryKey: ['compute', 'node-cpu'],
     queryFn: async () => {
-      const result = await safeQuery(() => queryInstant('sum(rate(node_cpu_seconds_total{mode!="idle"}[5m])) by (instance) * on(instance) group_left(node) kube_node_info'));
-      if (result !== null) return result;
-      return (await safeQuery(() => queryInstant('sum(rate(node_cpu_seconds_total{mode!="idle"}[5m])) by (instance)'))) ?? [];
+      try {
+        return await queryInstant('sum(rate(node_cpu_seconds_total{mode!="idle"}[5m])) by (instance) * on(instance) group_left(node) kube_node_info');
+      } catch {
+        return (await safeQuery(() => queryInstant('sum(rate(node_cpu_seconds_total{mode!="idle"}[5m])) by (instance)'))) ?? [];
+      }
     },
     refetchInterval: 30000,
   });
 
-  // Per-node memory usage from Prometheus (joined via kube_node_info for reliable node name matching)
+  // Per-node memory usage from Prometheus — same join-then-fallback strategy as node-cpu above.
   const { data: nodeMemMetrics = [] } = useQuery({
     queryKey: ['compute', 'node-mem'],
     queryFn: async () => {
-      const result = await safeQuery(() => queryInstant('(1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100 * on(instance) group_left(node) kube_node_info'));
-      if (result !== null) return result;
-      return (await safeQuery(() => queryInstant('(1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100'))) ?? [];
+      try {
+        return await queryInstant('(1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100 * on(instance) group_left(node) kube_node_info');
+      } catch {
+        return (await safeQuery(() => queryInstant('(1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100'))) ?? [];
+      }
     },
     refetchInterval: 30000,
   });

--- a/src/kubeview/views/__tests__/ComputeView.test.tsx
+++ b/src/kubeview/views/__tests__/ComputeView.test.tsx
@@ -70,4 +70,45 @@ describe('ComputeView', () => {
     expect(screen.getByText('Compute')).toBeTruthy();
     expect(screen.getByText('Nodes')).toBeTruthy();
   });
+
+  // Regression: on clusters where kube_node_info has no `instance` label,
+  // `on(instance) group_left(node) kube_node_info` makes Thanos collapse every
+  // node into one ambiguous match group and reject the query with a
+  // non-404 error (422 "duplicate series for the match group"). safeQuery only
+  // swallows 404s, so the plain by-instance fallback query must be tried
+  // explicitly — otherwise the hex map/table show "—" for every node's
+  // CPU/memory forever, even though Prometheus itself is reachable and healthy.
+  it('falls back to the plain per-node query and still shows CPU/memory when the kube_node_info join errors', async () => {
+    const { queryInstant } = await import('../../components/metrics/prometheus');
+    (queryInstant as any).mockImplementation((query: string) => {
+      if (query.includes('kube_node_info')) {
+        return Promise.reject(new Error('Prometheus query failed: 422 Unprocessable Entity'));
+      }
+      // node-cpu resolves usage in cores (the component divides by node
+      // capacity to get a percentage); node-mem resolves an already-computed percentage.
+      if (query.includes('node_cpu_seconds_total')) {
+        return Promise.resolve([{ metric: { instance: 'node-1' }, value: 1.6 }]);
+      }
+      if (query.includes('node_memory_MemAvailable_bytes')) {
+        return Promise.resolve([{ metric: { instance: 'node-1' }, value: 55 }]);
+      }
+      return Promise.resolve([]);
+    });
+
+    mockData['/api/v1/nodes'] = [{
+      metadata: { name: 'node-1', uid: '1', labels: { 'node-role.kubernetes.io/worker': '' }, creationTimestamp: '2025-01-01T00:00:00Z' },
+      status: {
+        conditions: [{ type: 'Ready', status: 'True' }],
+        allocatable: { cpu: '4', memory: '16Gi', pods: '250' },
+        capacity: { cpu: '4', memory: '16Gi' },
+        nodeInfo: { kubeletVersion: 'v1.28.0', osImage: 'RHCOS', containerRuntimeVersion: 'cri-o://1.28' },
+      },
+    }];
+
+    renderView();
+
+    // 1.6 cores / 4 cores capacity = 40%
+    expect(await screen.findByText('40%')).toBeTruthy();
+    expect(screen.getByText('55%')).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary
- **Cluster Nodes** (hex map, node table) showed no CPU/memory data for any node — every gauge showed `—`.
- The per-node queries join `node_cpu_seconds_total` / `node_memory_MemAvailable_bytes` to `kube_node_info` via `on(instance) group_left(node)` for reliable node-name matching, with an intended fallback to the plain by-instance query if that join doesn't work on a given cluster.
- On this cluster `kube_node_info` carries no `instance` label at all (only `node`/`internal_ip`), so `on(instance)` matches every node's series into one ambiguous group and Thanos rejects the query outright — `422`, `"duplicate series for the match group {}"`. Verified directly against thanos-querier.
- The fallback never actually ran: it was gated on `safeQuery` returning `null`, but `safeQuery` only returns `null` for `404`s and rethrows everything else. The `422` propagated straight out of the `queryFn`, so `nodeCpuMetrics`/`nodeMemMetrics` silently stayed at their default `[]` — no error surfaced in the UI, only console/network noise.

## Fix
Catch the join query's own failure locally in each `queryFn` and fall through to the plain query, instead of relying on `safeQuery`'s narrow null-on-404 semantics. The existing per-node metric matching (`instance` label substring) already handles the plain (unjoined) query correctly — confirmed `node_cpu_seconds_total`'s `instance` label on this cluster is already the node's FQDN, so no join is even needed for the match to succeed.

## Test plan
- [x] `tsc --noEmit` — clean
- [x] `eslint` on changed file — 0 errors (pre-existing unrelated warnings only)
- [x] New regression test: mocks the join query rejecting and the plain query resolving, asserts CPU/memory percentages render instead of falling back to nothing
- [x] Full suite: `vitest --run` — 1998/1998 passed
- [x] `npm run build` — clean production build
- [x] Root-caused live: reproduced the exact `422` against `thanos-querier` from a cluster pod, confirmed `kube_node_info` has no `instance` label here

Made with [Cursor](https://cursor.com)