### PR TITLE
fix: charts crash with a NaN SVG path when Prometheus returns a non-finite sample

### DIFF
--- a/src/kubeview/components/metrics/Sparkline.tsx
+++ b/src/kubeview/components/metrics/Sparkline.tsx
@@ -44,7 +44,13 @@ export function Sparkline({
     staleTime: 30000,
   });
 
-  const values = series[0]?.values?.map(([, v]) => parseFloat(v)) || [];
+  // Prometheus can legitimately return "NaN"/"+Inf"/"-Inf" samples (e.g. a
+  // rate() or division query with no data at that instant) — parseFloat
+  // passes those straight through as non-finite numbers, and a single one
+  // anywhere in the series poisons Math.min/Math.max for the whole array,
+  // producing a `NaN` SVG path ("M2,NaN L2.98,NaN ...") that fails to render.
+  // Drop non-finite samples so the line just has a small gap instead.
+  const values = (series[0]?.values?.map(([, v]) => parseFloat(v)) || []).filter(Number.isFinite);
 
   if (values.length < 2) {
     return (
@@ -120,7 +126,9 @@ export function MetricCard({
     staleTime: 30000,
   });
 
-  const values = series[0]?.values?.map(([, v]) => parseFloat(v)) || [];
+  // See the matching comment in Sparkline above: filter out non-finite
+  // Prometheus samples before they poison min/max and produce a NaN path.
+  const values = (series[0]?.values?.map(([, v]) => parseFloat(v)) || []).filter(Number.isFinite);
   const current = values.length > 0 ? values[values.length - 1] : null;
   const min = values.length > 0 ? Math.min(...values) : 0;
   const max = values.length > 0 ? Math.max(...values) : 0;

--- a/src/kubeview/components/metrics/__tests__/Sparkline.test.tsx
+++ b/src/kubeview/components/metrics/__tests__/Sparkline.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor, cleanup } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach } from 'vitest';
+import { Sparkline, MetricCard } from '../Sparkline';
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+afterEach(() => {
+  cleanup();
+});
+
+function mockRangeResponse(values: [number, string][]) {
+  mockFetch.mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({
+      status: 'success',
+      data: { resultType: 'matrix', result: [{ metric: {}, values }] },
+    }),
+  });
+}
+
+function renderWithClient(ui: React.ReactElement) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+}
+
+// Regression: Prometheus can legitimately return "NaN"/"+Inf"/"-Inf" string
+// samples (e.g. a rate() or division query with no data at that instant).
+// A single one anywhere in the series used to poison Math.min/Math.max for
+// the whole array, producing an SVG <path> with a "NaN" d attribute
+// ("M2,NaN L2.98,NaN ...") that the browser rejects outright.
+describe('Sparkline', () => {
+  it('never renders a NaN in the path d attribute when a sample is "NaN"', async () => {
+    mockRangeResponse([
+      [1000, '10'], [1060, 'NaN'], [1120, '20'], [1180, '15'], [1240, '25'],
+    ]);
+
+    const { container } = renderWithClient(<Sparkline query="up" />);
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('path').length).toBeGreaterThan(0);
+    });
+
+    const paths = container.querySelectorAll('path');
+    paths.forEach((p) => {
+      const d = p.getAttribute('d');
+      expect(d).not.toBeNull();
+      expect(d).not.toContain('NaN');
+    });
+  });
+
+  it('never renders a NaN in the path d attribute when a sample is "+Inf"', async () => {
+    mockRangeResponse([
+      [1000, '10'], [1060, '+Inf'], [1120, '20'], [1180, '-Inf'], [1240, '25'],
+    ]);
+
+    const { container } = renderWithClient(<Sparkline query="up" />);
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('path').length).toBeGreaterThan(0);
+    });
+
+    container.querySelectorAll('path').forEach((p) => {
+      expect(p.getAttribute('d')).not.toContain('NaN');
+    });
+  });
+});
+
+describe('MetricCard', () => {
+  it('never renders a NaN in the path d attribute when a sample is "NaN"', async () => {
+    mockRangeResponse([
+      [1000, '10'], [1060, 'NaN'], [1120, '20'], [1180, '15'], [1240, '25'],
+    ]);
+
+    const { container } = renderWithClient(<MetricCard title="CPU" query="up" />);
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('path').length).toBeGreaterThan(0);
+    });
+
+    container.querySelectorAll('path').forEach((p) => {
+      expect(p.getAttribute('d')).not.toContain('NaN');
+    });
+  });
+
+  it('shows "No data" instead of a broken chart when every sample is non-finite', async () => {
+    mockRangeResponse([[1000, 'NaN'], [1060, 'NaN'], [1120, '+Inf']]);
+
+    const { findByText } = renderWithClient(<MetricCard title="CPU" query="up" />);
+
+    expect(await findByText('No data')).toBeTruthy();
+  });
+});

--- a/src/kubeview/hooks/useMultiSourceTable.tsx
+++ b/src/kubeview/hooks/useMultiSourceTable.tsx
@@ -219,7 +219,10 @@ export function useMultiSourceTable(
             const series = await queryRange(ds.query, start, now, step);
             results[ds.id] = series.map((s) => ({
               metric: s.metric,
-              values: s.values.map(([, v]) => parseFloat(v)),
+              // Prometheus can return "NaN"/"+Inf"/"-Inf" samples (e.g. a
+              // rate() with no data at that instant); a single one poisons
+              // Sparkline's Math.min/Math.max below and breaks the chart.
+              values: s.values.map(([, v]) => parseFloat(v)).filter(Number.isFinite),
             }));
           } catch {
             results[ds.id] = [];


### PR DESCRIPTION
## Summary
Reported browser error:
\`\`\`
Error: <path> attribute d: Expected number, "M2,NaN L2.98,NaN L3…".
\`\`\`

Prometheus/Thanos can legitimately return \`"NaN"\`/\`"+Inf"\`/\`"-Inf"\` string samples in a range query result — e.g. a \`rate()\` or division query (like the CPU utilization card's \`.../ sum(machine_cpu_cores) * 100\`) with no data at a given instant. \`parseFloat()\` passes those straight through as non-finite numbers, and since \`Math.min(...values)\`/\`Math.max(...values)\` return \`NaN\` if *any* argument is non-finite, a single bad sample anywhere in the series poisons the min/max for the whole array — every point's y-coordinate becomes \`NaN\`, and the entire line (not just the bad sample) renders as a broken SVG path.

## Fix
Filter to \`Number.isFinite\` right after \`parseFloat\` in both shared chart components (\`Sparkline\`, \`MetricCard\` in \`components/metrics/Sparkline.tsx\`) and the duplicated per-row \`Sparkline\` in \`useMultiSourceTable.tsx\`, so a single bad sample just leaves a small gap in the line instead of breaking the whole chart. This is a defensive fix at the rendering layer rather than chasing every possible upstream query that could produce a stray non-finite value (including AI-generated dashboard queries), since any of them can hit this.

## Test plan
- [x] New regression tests (`Sparkline.test.tsx`, previously nonexistent for this component) reproduce the exact reported path string — confirmed they fail without the fix (`"M2,NaN L41,NaN L80,NaN..."`) and pass with it
- [x] `tsc --noEmit` — clean
- [x] `eslint` — 0 errors (2 pre-existing unrelated warnings)
- [x] `vitest --run` — 2002/2002 passed
- [x] `npm run build` — clean production build

Made with [Cursor](https://cursor.com)