### PR TITLE
fix: apply Nodes' column-width fix to every resource table (Pods, Deployments, Services, Secrets)

### DIFF
--- a/src/kubeview/engine/enhancers/__tests__/enhancer-columns.test.ts
+++ b/src/kubeview/engine/enhancers/__tests__/enhancer-columns.test.ts
@@ -288,3 +288,26 @@ describe('secretEnhancer', () => {
     expect(col?.sortType).toBe('number');
   });
 });
+
+// Regression guard for the "table columns pervasively truncated / rows
+// growing tall" class of bug (Nodes, then Pods, then every other resource
+// list): a column with no explicit width falls back to an equal flex share
+// of whatever space is left after the widthed columns, so adding a new
+// enhancer column and forgetting a width silently squeezes every other
+// unwidthed column too. Percentage widths have their own, subtler failure
+// mode — they looked fine on a full-width panel but re-truncated everything
+// as soon as the window (or the Pulse AI side panel) narrowed, since every
+// percentage column shrinks proportionally with the container. Fail loudly
+// here instead of relying on someone noticing a screenshot.
+describe('enhancer column widths', () => {
+  const enhancers = { podEnhancer, deploymentEnhancer, nodeEnhancer, serviceEnhancer, secretEnhancer };
+
+  for (const [enhancerName, enhancer] of Object.entries(enhancers)) {
+    it(`${enhancerName}: every column has an explicit, non-percentage width`, () => {
+      for (const col of enhancer.columns) {
+        expect(col.width, `${enhancerName} column "${col.id}" must have a width`).toBeTruthy();
+        expect(col.width, `${enhancerName} column "${col.id}" must use a fixed pixel width, not a percentage (percentages shrink with the container and re-truncate on a narrow window)`).toMatch(/^\d+px$/);
+      }
+    });
+  }
+});

--- a/src/kubeview/engine/enhancers/deployments.tsx
+++ b/src/kubeview/engine/enhancers/deployments.tsx
@@ -7,10 +7,13 @@ import { getDeploymentStatus } from '../renderers/statusUtils';
 export const deploymentEnhancer: ResourceEnhancer = {
   matches: ['apps/v1/deployments', 'apps/v1/statefulsets', 'apps/v1/daemonsets'],
 
+  // Fixed pixel widths sized to content, not percentages — see the comment
+  // on getDefaultColumns for why.
   columns: [
     {
       id: 'status',
       header: 'Status',
+      width: '150px',
       accessorFn: (resource) => {
         const status = getDeploymentStatus(resource);
         if (status.available) return 'Available';
@@ -36,7 +39,7 @@ export const deploymentEnhancer: ResourceEnhancer = {
         const dotClass = `inline-block w-2 h-2 rounded-full mr-2 ${colorMap[color] || 'bg-slate-500'}`;
 
         return (
-          <span className="inline-flex items-center text-sm">
+          <span className="inline-flex items-center text-sm" title={status}>
             <span className={dotClass} />
             <span>{status}</span>
           </span>
@@ -48,6 +51,7 @@ export const deploymentEnhancer: ResourceEnhancer = {
     {
       id: 'ready',
       header: 'Ready',
+      width: '70px',
       accessorFn: (resource) => {
         const status = getDeploymentStatus(resource);
         return `${status.ready}/${status.desired}`;
@@ -94,12 +98,13 @@ export const deploymentEnhancer: ResourceEnhancer = {
         );
       },
       sortable: false,
-      width: '25%',
+      width: '260px',
       priority: 12,
     },
     {
       id: 'strategy',
       header: 'Strategy',
+      width: '130px',
       accessorFn: (resource) => {
         const spec = resource.spec as Record<string, unknown> | undefined;
         const strategy = spec?.strategy as Record<string, unknown> | undefined;

--- a/src/kubeview/engine/enhancers/pods.tsx
+++ b/src/kubeview/engine/enhancers/pods.tsx
@@ -8,10 +8,15 @@ import { getPodStatus } from '../renderers/statusUtils';
 export const podEnhancer: ResourceEnhancer = {
   matches: ['v1/pods'],
 
+  // Fixed pixel widths sized to content, not percentages — see the comment
+  // on getDefaultColumns for why: percentages re-truncate everything as
+  // soon as the window (or the Pulse AI panel) narrows, since every column
+  // shrinks proportionally with the container.
   columns: [
     {
       id: 'status',
       header: 'Status',
+      width: '150px',
       accessorFn: (resource) => {
         const podStatus = getPodStatus(resource);
         return podStatus.reason ?? podStatus.phase;
@@ -39,7 +44,7 @@ export const podEnhancer: ResourceEnhancer = {
         const dotClass = `inline-block w-2 h-2 rounded-full mr-2 ${colorMap[color] || 'bg-slate-500'}`;
 
         return (
-          <span className="inline-flex items-center text-sm">
+          <span className="inline-flex items-center text-sm" title={displayText}>
             <span className={dotClass} />
             <span>{displayText}</span>
           </span>
@@ -51,6 +56,7 @@ export const podEnhancer: ResourceEnhancer = {
     {
       id: 'ready',
       header: 'Ready',
+      width: '70px',
       accessorFn: (resource) => {
         const p = resource as Pod;
         const containerStatuses = p.status?.containerStatuses ?? [];
@@ -75,6 +81,7 @@ export const podEnhancer: ResourceEnhancer = {
     {
       id: 'restarts',
       header: 'Restarts',
+      width: '90px',
       accessorFn: (resource) => {
         const podStatus = getPodStatus(resource);
         return podStatus.restartCount;
@@ -96,6 +103,7 @@ export const podEnhancer: ResourceEnhancer = {
     {
       id: 'node',
       header: 'Node',
+      width: '180px',
       accessorFn: (resource) => {
         const p = resource as Pod;
         return p.spec?.nodeName ?? '-';
@@ -110,6 +118,7 @@ export const podEnhancer: ResourceEnhancer = {
           <Link
             to={`/r/v1~nodes/_/${nodeName}`}
             className="text-blue-400 hover:text-blue-300 hover:underline text-sm"
+            title={nodeName}
           >
             {nodeName}
           </Link>
@@ -121,6 +130,7 @@ export const podEnhancer: ResourceEnhancer = {
     {
       id: 'ip',
       header: 'IP',
+      width: '110px',
       accessorFn: (resource) => {
         const p = resource as Pod;
         return p.status?.podIP ?? '-';

--- a/src/kubeview/engine/enhancers/secrets.tsx
+++ b/src/kubeview/engine/enhancers/secrets.tsx
@@ -4,10 +4,13 @@ import type { ResourceEnhancer } from './index';
 export const secretEnhancer: ResourceEnhancer = {
   matches: ['v1/secrets'],
 
+  // Fixed pixel widths sized to content, not percentages — see the comment
+  // on getDefaultColumns for why.
   columns: [
     {
       id: 'type',
       header: 'Type',
+      width: '190px',
       accessorFn: (resource) => {
         return resource.type ?? 'Opaque';
       },
@@ -36,6 +39,7 @@ export const secretEnhancer: ResourceEnhancer = {
     {
       id: 'keys',
       header: 'Data Keys',
+      width: '220px',
       accessorFn: (resource) => {
         const data = resource.data as Record<string, unknown> | undefined;
         const keys = data ? Object.keys(data) : [];

--- a/src/kubeview/engine/enhancers/services.tsx
+++ b/src/kubeview/engine/enhancers/services.tsx
@@ -4,10 +4,15 @@ import type { ResourceEnhancer } from './index';
 export const serviceEnhancer: ResourceEnhancer = {
   matches: ['v1/services'],
 
+  // Fixed pixel widths sized to content, not percentages — see the comment
+  // on getDefaultColumns for why (ports/selector previously used
+  // percentages too, which shrink proportionally with the container and
+  // re-truncate on a narrower window).
   columns: [
     {
       id: 'type',
       header: 'Type',
+      width: '130px',
       accessorFn: (resource) => {
         const spec = resource.spec as Record<string, unknown> | undefined;
         return spec?.type ?? 'ClusterIP';
@@ -36,6 +41,7 @@ export const serviceEnhancer: ResourceEnhancer = {
     {
       id: 'clusterIP',
       header: 'Cluster IP',
+      width: '130px',
       accessorFn: (resource) => {
         const spec = resource.spec as Record<string, unknown> | undefined;
         return spec?.clusterIP ?? '-';
@@ -91,7 +97,7 @@ export const serviceEnhancer: ResourceEnhancer = {
         );
       },
       sortable: false,
-      width: '20%',
+      width: '260px',
       priority: 12,
     },
     {
@@ -122,7 +128,7 @@ export const serviceEnhancer: ResourceEnhancer = {
         );
       },
       sortable: false,
-      width: '20%',
+      width: '220px',
       priority: 13,
     },
   ],

--- a/src/kubeview/engine/renderers/index.tsx
+++ b/src/kubeview/engine/renderers/index.tsx
@@ -156,6 +156,7 @@ export function renderNamespace(value: unknown): ReactNode {
   return (
     <span
       className="inline-block px-2 py-0.5 text-xs font-medium rounded-sm bg-slate-700 text-slate-300"
+      title={ns}
     >
       {ns}
     </span>
@@ -730,7 +731,18 @@ function renderAutoValue(value: unknown): ReactNode {
   return React.createElement('span', { className: 'text-sm text-slate-300' }, str);
 }
 
-// Default columns that every resource gets
+// Default columns that every resource gets.
+//
+// `name` is the one column left as a percentage: resource names have no
+// realistic upper bound, and letting it grow with the viewport is actually
+// desirable. Every other column below uses a fixed pixel width sized to its
+// typical content instead — percentages looked fine on a full-width panel
+// but re-truncated everything ("Read..." for "Ready", single-letter label
+// badges, etc.) as soon as the window (or the Pulse AI side panel) narrowed,
+// since every percentage column shrinks proportionally with the container.
+// The table already scrolls horizontally on overflow, so a narrow window
+// now scrolls instead of mangling text again. See the Nodes enhancer for
+// the original instance of this bug and fix.
 export function getDefaultColumns(namespaced: boolean): ColumnDef[] {
   const cols: ColumnDef[] = [
     {
@@ -751,7 +763,7 @@ export function getDefaultColumns(namespaced: boolean): ColumnDef[] {
       accessorFn: (resource) => resource.metadata.namespace,
       render: renderNamespace,
       sortable: true,
-      width: '15%',
+      width: '190px',
       priority: 1,
     });
   }
@@ -763,7 +775,7 @@ export function getDefaultColumns(namespaced: boolean): ColumnDef[] {
     render: renderAge,
     sortable: true,
     sortType: 'date',
-    width: '10%',
+    width: '70px',
     priority: 2,
   });
 
@@ -773,6 +785,7 @@ export function getDefaultColumns(namespaced: boolean): ColumnDef[] {
     accessorFn: (resource) => resource.metadata.labels,
     render: renderLabels,
     sortable: false,
+    width: '170px',
     priority: 3,
   });
 
@@ -782,6 +795,7 @@ export function getDefaultColumns(namespaced: boolean): ColumnDef[] {
     accessorFn: (resource) => resource.metadata.ownerReferences,
     render: renderOwner,
     sortable: true,
+    width: '150px',
     priority: 3,
   });
 


### PR DESCRIPTION
## Summary
Pods, Deployments/StatefulSets/DaemonSets, Services, and Secrets all had the same bug already found and fixed for Nodes (#43, #44): most of their list-view columns had no explicit width, so they fell back to an equal flex share of whatever space was left after the widthed columns — every value clipped mid-word ("Ru..." for "Running", "1..." for a pod IP, single-letter label badges) regardless of how short the content actually was.

## Fix
- Give every column in `podEnhancer`, `deploymentEnhancer`, `serviceEnhancer`, `secretEnhancer` an explicit, fixed-pixel width sized to its typical content — not a percentage, since percentages shrink proportionally with the container and re-truncate on a narrower window (the same follow-up bug found and fixed for Nodes in #44).
- Fixed the two shared default columns every resource table uses regardless of enhancer (`labels`, `owner`, plus `namespace`/`age`) in `getDefaultColumns`, so resource kinds with no dedicated enhancer at all (ConfigMaps, PVCs, Routes, etc., via `autoDetectColumns`) benefit too.
- Added `title` tooltips to a few renders that previously had none (pod status, pod node, deployment status, namespace badge) for hover-reveal when content still exceeds the fixed width.

## Regression guard
This class of bug has now recurred three times as a screenshot-driven bug report (Nodes, then this same PR for four more resource kinds). Added a test that asserts **every column in every enhancer has an explicit, non-percentage width** — confirmed it fails with a clear message (`podEnhancer column "status" must have a width`) when a width is removed, so the next missing-width column gets caught in CI instead of a screenshot.

## Test plan
- [x] `tsc --noEmit` — clean
- [x] `eslint` on changed files — 0 errors
- [x] `vitest --run` — 2007/2007 passed (2002 existing + 5 new width-guard tests, one per enhancer)
- [x] `npm run build` — clean production build
- [x] Verified the new guard test fails with a clear message when a column's width is removed, and passes once restored

Made with [Cursor](https://cursor.com)