### PR TITLE
fix: pod log viewers default to a sidecar container instead of the app

### DIFF
--- a/src/kubeview/components/agent/renderers/VisualizationRenderer.tsx
+++ b/src/kubeview/components/agent/renderers/VisualizationRenderer.tsx
@@ -10,6 +10,7 @@ import { useNavigate } from 'react-router-dom';
 import { cn } from '@/lib/utils';
 import { formatRelativeTime } from '../../../engine/formatters';
 import { MetricCard as SparklineMetricCard } from '../../metrics/Sparkline';
+import { pickDefaultContainer } from '../../logs/pickDefaultContainer';
 import type {
   ComponentSpec,
   ChartSpec,
@@ -676,6 +677,25 @@ export function AgentLogViewer({ spec }: { spec: LogViewerSpec }) {
     const fetchLogs = async (previous: boolean) => {
       if (previous) params.set('previous', 'true');
       const res = await fetch(`/api/kubernetes/api/v1/namespaces/${ns}/pods/${resource}/log?${params}`);
+      // A pod-level log request without `container` 400s for any
+      // multi-container pod. The AI-generated spec doesn't always know
+      // which container to pick, so fall back to a sensible default
+      // instead of silently showing "no logs" for the whole widget.
+      if (res.status === 400 && !params.has('container')) {
+        try {
+          const podRes = await fetch(`/api/kubernetes/api/v1/namespaces/${ns}/pods/${resource}`);
+          if (podRes.ok) {
+            const podData = await podRes.json();
+            const containerNames = (podData?.spec?.containers ?? []).map((c: { name?: string }) => c.name);
+            const defaultContainer = pickDefaultContainer(containerNames);
+            if (defaultContainer) {
+              params.set('container', defaultContainer);
+              return fetchLogs(previous);
+            }
+          }
+        } catch { /* fall through to empty */ }
+        return '';
+      }
       if (!res.ok) return '';
       return res.text();
     };

--- a/src/kubeview/components/logs/LogStream.tsx
+++ b/src/kubeview/components/logs/LogStream.tsx
@@ -6,6 +6,7 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Search, Play, Pause, WrapText, Download, Copy } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { parseLogLine, detectLogFormat, type ParsedLogLine, type LogFormat } from './LogParser';
+import { pickDefaultContainer } from './pickDefaultContainer';
 
 interface LogStreamProps {
   namespace: string;
@@ -93,9 +94,10 @@ export default function LogStream({
           });
           if (podRes.ok) {
             const podData = await podRes.json();
-            const firstContainer = podData?.spec?.containers?.[0]?.name;
-            if (firstContainer) {
-              const retryUrl = url + (url.includes('?') ? '&' : '?') + `container=${encodeURIComponent(firstContainer)}`;
+            const containerNames = (podData?.spec?.containers ?? []).map((c: { name?: string }) => c.name);
+            const defaultContainer = pickDefaultContainer(containerNames);
+            if (defaultContainer) {
+              const retryUrl = url + (url.includes('?') ? '&' : '?') + `container=${encodeURIComponent(defaultContainer)}`;
               response = await fetch(retryUrl, { signal: abortControllerRef.current.signal });
             }
           }

--- a/src/kubeview/components/logs/MultiPodLogs.tsx
+++ b/src/kubeview/components/logs/MultiPodLogs.tsx
@@ -6,6 +6,7 @@ import React, { useState, useEffect } from 'react';
 import { cn } from '@/lib/utils';
 import LogStream from './LogStream';
 import { parseLogLine, type ParsedLogLine } from './LogParser';
+import { pickDefaultContainer } from './pickDefaultContainer';
 
 interface MultiPodLogsProps {
   namespace: string;
@@ -71,9 +72,10 @@ export default function MultiPodLogs({
               const podRes = await fetch(`/api/kubernetes/api/v1/namespaces/${namespace}/pods/${podName}`);
               if (podRes.ok) {
                 const podData = await podRes.json();
-                const firstContainer = podData?.spec?.containers?.[0]?.name;
-                if (firstContainer) {
-                  params.set('container', firstContainer);
+                const containerNames = (podData?.spec?.containers ?? []).map((c: { name?: string }) => c.name);
+                const defaultContainer = pickDefaultContainer(containerNames);
+                if (defaultContainer) {
+                  params.set('container', defaultContainer);
                   response = await fetch(`/api/kubernetes/api/v1/namespaces/${namespace}/pods/${podName}/log?${params}`);
                 }
               }

--- a/src/kubeview/components/logs/__tests__/LogStream.test.tsx
+++ b/src/kubeview/components/logs/__tests__/LogStream.test.tsx
@@ -62,6 +62,26 @@ describe('LogStream', () => {
     expect(screen.getByText('log line 2')).toBeTruthy();
   });
 
+  // Regression: the auto-detected default used to be spec.containers[0]
+  // unconditionally, which for many real pods (including this cluster's own
+  // acm-agent pods) is a sidecar like oauth-proxy — logs "worked" but showed
+  // the wrong container by default instead of the actual app.
+  it('skips a known sidecar container and picks the app container as the default', async () => {
+    vi.mocked(fetch).mockReturnValueOnce(mockFetchResponse(400, 'must specify container'));
+    vi.mocked(fetch).mockReturnValueOnce(
+      mockFetchResponse(200, { spec: { containers: [{ name: 'oauth-proxy' }, { name: 'streamlit-app' }] } })
+    );
+    vi.mocked(fetch).mockReturnValueOnce(mockFetchResponse(200, 'app log line'));
+
+    await act(async () => {
+      render(<LogStream namespace="acm-agent" podName="acm-agent-54875b54c8-klmb4" />);
+    });
+
+    const calls = vi.mocked(fetch).mock.calls;
+    expect(calls[2][0]).toContain('container=streamlit-app');
+    expect(screen.getByText('app log line')).toBeTruthy();
+  });
+
   it('shows error on non-400 failure', async () => {
     vi.mocked(fetch).mockReturnValueOnce(mockFetchResponse(500, 'Internal Server Error'));
 

--- a/src/kubeview/components/logs/__tests__/pickDefaultContainer.test.ts
+++ b/src/kubeview/components/logs/__tests__/pickDefaultContainer.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { pickDefaultContainer } from '../pickDefaultContainer';
+
+describe('pickDefaultContainer', () => {
+  it('returns undefined for an empty list', () => {
+    expect(pickDefaultContainer([])).toBeUndefined();
+  });
+
+  it('returns the only container when there is just one', () => {
+    expect(pickDefaultContainer(['app'])).toBe('app');
+  });
+
+  it('skips a leading sidecar and picks the app container', () => {
+    expect(pickDefaultContainer(['oauth-proxy', 'streamlit-app'])).toBe('streamlit-app');
+  });
+
+  it('skips a leading sidecar regardless of how many app containers follow', () => {
+    expect(pickDefaultContainer(['istio-proxy', 'api', 'worker'])).toBe('api');
+  });
+
+  it('falls back to the first container if every container is a known sidecar', () => {
+    expect(pickDefaultContainer(['oauth-proxy', 'istio-proxy'])).toBe('oauth-proxy');
+  });
+
+  it('ignores undefined/empty entries', () => {
+    expect(pickDefaultContainer([undefined, 'app', undefined])).toBe('app');
+  });
+
+  it('picks the first non-sidecar container even when it is not first in the list', () => {
+    expect(pickDefaultContainer(['vault-agent-init', 'vault-agent', 'main'])).toBe('main');
+  });
+});

--- a/src/kubeview/components/logs/pickDefaultContainer.ts
+++ b/src/kubeview/components/logs/pickDefaultContainer.ts
@@ -1,0 +1,31 @@
+/**
+ * pickDefaultContainer — chooses a sensible default container to show logs
+ * for when the user hasn't picked one explicitly.
+ *
+ * `spec.containers[0]` is not a reliable proxy for "the container the user
+ * actually wants to see" — sidecars (oauth-proxy, istio-proxy, etc.) are
+ * commonly placed first in a pod spec, so blindly using index 0 tends to
+ * show the wrong container's logs by default while still "working"
+ * (no error, just not the app the user was debugging).
+ */
+
+// Sidecar container names common enough across this cluster's workloads to
+// be worth skipping by default. Not exhaustive — this only affects the
+// *default* pick; every caller still lets the user switch containers.
+const KNOWN_SIDECAR_NAMES = new Set([
+  'oauth-proxy',
+  'istio-proxy',
+  'istio-init',
+  'envoy',
+  'linkerd-proxy',
+  'linkerd-init',
+  'vault-agent',
+  'vault-agent-init',
+  'pilot-agent',
+]);
+
+export function pickDefaultContainer(containerNames: Array<string | undefined>): string | undefined {
+  const names = containerNames.filter((n): n is string => Boolean(n));
+  if (names.length === 0) return undefined;
+  return names.find((name) => !KNOWN_SIDECAR_NAMES.has(name)) ?? names[0];
+}

--- a/src/kubeview/views/detail/IncidentContext.tsx
+++ b/src/kubeview/views/detail/IncidentContext.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { cn } from '@/lib/utils';
 import { ScrollText, Loader2 } from 'lucide-react';
 import { k8sLogs } from '../../engine/query';
+import { pickDefaultContainer } from '../../components/logs/pickDefaultContainer';
 import { MetricCard } from '../../components/metrics/Sparkline';
 import { CHART_COLORS } from '../../engine/colors';
 import type { K8sResource } from '../../engine/renderers';
@@ -62,7 +63,7 @@ export function IncidentContext({ resource, managedPods, events, namespace, go }
   const [selectedContainer, setSelectedContainer] = React.useState<string>('');
   const [showPrevious, setShowPrevious] = React.useState(false);
 
-  const activeContainer = selectedContainer || containers[0]?.name || '';
+  const activeContainer = selectedContainer || pickDefaultContainer(containers.map((c) => c.name)) || '';
   const logPodName = isPod ? resource.metadata.name : worstPodName;
   const logPodNs = isPod ? namespace : worstPodNs;
 


### PR DESCRIPTION
## Summary
Reported: `GET .../pods/acm-agent-.../log?timestamps=true&tailLines=500 400 (Bad Request)`.

- Root cause: the K8s API's pod `/log` endpoint requires a `container` query param for any pod with more than one container — kube-apiserver can't guess which one you want (confirmed live: `"a container name must be specified for pod ..., choose one of: [oauth-proxy streamlit-app debug-ysctb5]"`).
- `LogStream`, `MultiPodLogs`, and `AgentLogViewer` (the AI-generated dashboard log widget) already retry on `400` by fetching the pod spec and picking a container, so the `400` itself is benign, self-healing console noise, not a hard failure — confirmed the retry succeeds (`200`).
- **But** all of them (plus `IncidentContext`'s log preview) picked `spec.containers[0]` unconditionally, which isn't a reliable proxy for "the container the user actually wants" — sidecars (`oauth-proxy`, `istio-proxy`, etc.) are commonly placed first in a pod spec. For the exact pod in the report, `spec.containers[0]` is `oauth-proxy`, not `streamlit-app`: the retry silently "worked" but showed the wrong container's logs by default.

## Fix
- Added a shared `pickDefaultContainer()` helper (`components/logs/pickDefaultContainer.ts`) that skips known sidecar names and picks the first remaining (real app) container, falling back to the first container if every one matches the sidecar list.
- Applied it everywhere the same `containers[0]` pattern was duplicated: `LogStream`, `MultiPodLogs`, `IncidentContext`, and `AgentLogViewer` — the last of which previously had **no fallback at all** and would silently show "no logs" for any multi-container pod referenced by an AI-generated dashboard widget.

## Test plan
- [x] New unit tests for `pickDefaultContainer` (7 cases: empty, single, sidecar-first, multiple app containers, all-sidecar fallback, undefined entries, sidecar-in-middle)
- [x] New `LogStream` regression test using the exact reported pod's container list (`oauth-proxy`, `streamlit-app`) — confirms the retry now requests `container=streamlit-app`, not `oauth-proxy`
- [x] `tsc --noEmit` — clean
- [x] `eslint` — 0 errors (3 pre-existing unrelated warnings)
- [x] `vitest --run` — 2015/2015 passed
- [x] `npm run build` — clean production build

Made with [Cursor](https://cursor.com)