### PR TITLE
fix: hover-prefetch sent every cluster-scoped resource through a malformed /namespaces/*/... URL

### DIFF
--- a/src/kubeview/engine/__tests__/query.test.ts
+++ b/src/kubeview/engine/__tests__/query.test.ts
@@ -89,6 +89,19 @@ describe('k8sList', () => {
     expect(mockFetch).toHaveBeenCalledWith('/api/kubernetes/api/v1/pods', expect.any(Object));
   });
 
+  // Regression: reported live 404 for /api/kubernetes/api/v1/namespaces/*/nodes.
+  // '*' — not 'all' — is the sentinel useUIStore's selectedNamespace actually
+  // uses for "all namespaces" everywhere else in the app; without this,
+  // any caller that forwards it straight through builds a malformed
+  // /namespaces/*/... URL, which 404s for every resource and is invalid
+  // for cluster-scoped ones (like nodes) regardless of namespace value.
+  it('skips namespace injection for "*" (the app\'s actual "all namespaces" sentinel)', async () => {
+    mockOk({ apiVersion: 'v1', kind: 'NodeList', items: [] });
+
+    await k8sList('/api/v1/nodes', '*');
+    expect(mockFetch).toHaveBeenCalledWith('/api/kubernetes/api/v1/nodes', expect.any(Object));
+  });
+
   it('skips namespace injection if already present', async () => {
     mockOk({ apiVersion: 'v1', kind: 'PodList', items: [] });
 

--- a/src/kubeview/engine/query.ts
+++ b/src/kubeview/engine/query.ts
@@ -56,8 +56,15 @@ export async function k8sList<T = K8sResource>(
   const base = getClusterBase(clusterId);
   let url = `${base}${apiPath}`;
 
-  // Add namespace to path if specified and not "all"
-  if (namespace && namespace !== 'all' && !apiPath.includes('/namespaces/')) {
+  // Add namespace to path if specified and not an "all namespaces" sentinel.
+  // '*' is the sentinel the rest of the app actually uses (useUIStore's
+  // selectedNamespace defaults to '*', not 'all') — without this, any
+  // caller that forwards selectedNamespace straight through (e.g.
+  // usePrefetchOnHover) builds a malformed /namespaces/*/... URL. That's
+  // always a 404, and for cluster-scoped resources like nodes it's invalid
+  // regardless of namespace value. 'all' is kept for backward compatibility
+  // with existing callers/tests that already relied on it.
+  if (namespace && namespace !== 'all' && namespace !== '*' && !apiPath.includes('/namespaces/')) {
     const parts = apiPath.split('/');
     const resourceIndex = parts.length - 1;
     parts.splice(resourceIndex, 0, 'namespaces', namespace);

--- a/src/kubeview/hooks/__tests__/usePrefetchOnHover.test.ts
+++ b/src/kubeview/hooks/__tests__/usePrefetchOnHover.test.ts
@@ -68,9 +68,35 @@ describe('usePrefetchOnHover', () => {
       vi.advanceTimersByTime(200);
     });
 
-    // /compute requires /api/v1/nodes and /api/v1/pods
-    expect(k8sListMock).toHaveBeenCalledWith('/api/v1/nodes', 'default');
+    // /compute requires /api/v1/nodes (cluster-scoped — must never get a
+    // namespace, even a real one, not just the '*' "all" sentinel) and
+    // /api/v1/pods (namespaced — gets the current namespace).
+    expect(k8sListMock).toHaveBeenCalledWith('/api/v1/nodes', undefined);
     expect(k8sListMock).toHaveBeenCalledWith('/api/v1/pods', 'default');
+  });
+
+  // Regression: reported error was a live 404 for
+  // /api/kubernetes/api/v1/namespaces/*/nodes — this hook forwarded
+  // selectedNamespace ('*' by default, but the same bug applies to any real
+  // namespace too) straight into k8sList for every path in a view's list,
+  // including cluster-scoped ones, producing a malformed URL. Nodes must
+  // never get a namespace regardless of what's selected.
+  it('never applies a namespace to cluster-scoped resources, even when a real namespace is selected', () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => usePrefetchOnHover('/compute'), { wrapper });
+
+    act(() => {
+      result.current.onMouseEnter();
+    });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    for (const call of k8sListMock.mock.calls) {
+      if (call[0] === '/api/v1/nodes') {
+        expect(call[1]).toBeUndefined();
+      }
+    }
   });
 
   it('cancels prefetch when onMouseLeave fires before debounce', () => {

--- a/src/kubeview/hooks/usePrefetchOnHover.ts
+++ b/src/kubeview/hooks/usePrefetchOnHover.ts
@@ -69,6 +69,24 @@ const VIEW_DATA_REQUIREMENTS: Record<string, string[]> = {
 };
 
 /**
+ * Cluster-scoped resources must never get a namespace segment, regardless
+ * of what the user has selected — unlike TableView (which only calls
+ * useK8sListWatch with the resource it's actually showing), this hook
+ * blindly reuses the same `namespace` for every path in a view's
+ * requirements list, so a namespaced-and-cluster-scoped mix (e.g. /compute's
+ * pods + nodes) needs to know which is which. Mirrors the
+ * `likelyClusterScoped` heuristic in TableView.tsx.
+ */
+function isLikelyClusterScoped(apiPath: string): boolean {
+  const resourceName = apiPath.split('?')[0].split('/').filter(Boolean).pop() ?? '';
+  return resourceName.startsWith('cluster')
+    || resourceName === 'nodes'
+    || resourceName === 'namespaces'
+    || resourceName === 'persistentvolumes'
+    || resourceName.includes('customresourcedefinition');
+}
+
+/**
  * Convert a GVR URL segment (e.g. "apps~v1~deployments") to an API path.
  * Mirrors the logic in TableView and buildApiPath.
  */
@@ -119,15 +137,25 @@ export function usePrefetchOnHover(path: string) {
 
     timerRef.current = setTimeout(() => {
       const apiPaths = getApiPathsForRoute(path);
-      // Read namespace from store (same as views do)
-      const namespace = useUIStore.getState().selectedNamespace;
+      // Read namespace from store (same as views do), normalized the same
+      // way every view does it (e.g. WorkloadsView's `nsFilter`): '*' means
+      // "all namespaces" and must become undefined, not be forwarded
+      // literally — otherwise this prefetch's query key can never match the
+      // real view's, so nothing here would ever actually get reused.
+      const rawNamespace = useUIStore.getState().selectedNamespace;
+      const namespace = rawNamespace && rawNamespace !== '*' ? rawNamespace : undefined;
 
       for (const apiPath of apiPaths) {
+        // Cluster-scoped resources (nodes, namespaces, PVs, CRDs, ...) never
+        // take a namespace — mixing in the currently-selected one produces
+        // an always-404 /namespaces/{ns}/{resource} URL regardless of
+        // whether that namespace is a real one or the '*' "all" sentinel.
+        const effectiveNamespace = isLikelyClusterScoped(apiPath) ? undefined : namespace;
         // Use the same query key pattern as useK8sListWatch:
         // ['k8s', 'list', apiPath, namespace, clusterId]
         queryClient.prefetchQuery({
-          queryKey: ['k8s', 'list', apiPath, namespace, undefined],
-          queryFn: () => k8sList(apiPath, namespace),
+          queryKey: ['k8s', 'list', apiPath, effectiveNamespace, undefined],
+          queryFn: () => k8sList(apiPath, effectiveNamespace),
           staleTime: PREFETCH_STALE_TIME,
         });
       }


### PR DESCRIPTION
## Summary
Reported: `GET .../api/kubernetes/api/v1/namespaces/*/nodes 404 (Not Found)`.

Two compounding bugs, both in the hover-prefetch path (`usePrefetchOnHover`) — the real views already build these URLs correctly:

1. `k8sList()`'s "skip namespace injection" check only recognized the literal string `'all'`, but the app's actual "all namespaces" sentinel (`useUIStore`'s `selectedNamespace`, defaulting to `'*'`) is `'*'` — nowhere else in the codebase ever passes `'all'`. Any caller that forwards `selectedNamespace` straight through, unlike views that pre-normalize it (e.g. `WorkloadsView`'s `nsFilter = selectedNamespace !== '*' ? selectedNamespace : undefined`), built a literal `/namespaces/*/...` URL.
2. `usePrefetchOnHover` applies the *same* namespace to every API path in a view's prefetch list, but some views mix namespaced and cluster-scoped resources (`/compute` needs both `nodes` and `pods`). Nodes must never get a namespace at all, regardless of whether a real namespace or `'*'` is selected — the real `ComputeView` never passes one.

## Fix
- `k8sList` now also treats `'*'` as "no namespace" (keeping `'all'` for back-compat with the existing test/API surface).
- Added an `isLikelyClusterScoped` check to `usePrefetchOnHover` (mirrors `TableView`'s own heuristic) so it stops passing a namespace to cluster-scoped resources at all.
- Also normalized the namespace used for regular namespaced resources in the prefetch — it previously never converted `'*'` to `undefined` for the query key either, so the prefetched cache entry could never be reused by the real view's own query even when the fetch succeeded (a silent, pre-existing efficiency bug in the same function).

## Test plan
- [x] New `k8sList` test: `'*'` skips namespace injection (reproduces the exact reported URL when reverted: `/namespaces/*/nodes`)
- [x] New `usePrefetchOnHover` test: cluster-scoped resources never get a namespace, even a real one
- [x] Fixed an existing test that had encoded the bug as expected behavior (asserted nodes got a literal namespace)
- [x] Confirmed all 3 new/updated assertions fail with the exact right message when the fix is reverted, and pass when restored
- [x] `tsc --noEmit` — clean
- [x] `eslint` — 0 errors (9 pre-existing unrelated warnings)
- [x] `vitest --run` — 2017/2017 passed
- [x] `npm run build` — clean production build

Made with [Cursor](https://cursor.com)