### PR TITLE
fix: E2E suite has not run since 2026-08-07 (ESM config load failure)

### DIFF
--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -1,11 +1,17 @@
-import { execSync } from 'child_process';
-import { dirname } from 'path';
+import { execSync } from 'node:child_process';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Same ESM constraint as playwright.config.ts: __filename does not exist under
+// "type": "module". This never surfaced in CI because the config failed to load
+// first, so teardown was never reached.
+const teardownDir = dirname(fileURLToPath(import.meta.url));
 
 export default function globalTeardown() {
   if (process.env.PULSE_URL) return;
 
   try {
-    execSync('bash stop-agent.sh', { cwd: dirname(__filename), stdio: 'inherit' });
+    execSync('bash stop-agent.sh', { cwd: teardownDir, stdio: 'inherit' });
   } catch {
     // Best effort
   }

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,4 +1,15 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { defineConfig, devices } from 'playwright/test';
+
+// package.json sets "type": "module" (4431493, "major dependency upgrades
+// across frontend stack"), so this config is loaded as native ESM and the
+// CommonJS __dirname global does not exist. Playwright threw
+// "ReferenceError: __dirname is not defined in ES module scope" while loading
+// the config, before running a single test -- which is why every E2E run since
+// 2026-08-07 failed identically.
+const configDir = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   testDir: './tests',
@@ -33,14 +44,14 @@ export default defineConfig({
     webServer: [
       {
         command: 'node mock-k8s-server.mjs',
-        cwd: __dirname,
+        cwd: configDir,
         url: 'http://localhost:8001/api/v1/nodes',
         reuseExistingServer: true,
         timeout: 10_000,
       },
       {
         command: 'bash start-agent.sh',
-        cwd: __dirname,
+        cwd: configDir,
         url: 'http://localhost:8080/healthz',
         reuseExistingServer: true,
         timeout: 120_000,


### PR DESCRIPTION
## Summary

The `E2E Tests` job has failed on every main push for eleven days, and not because a test regressed — Playwright never started:

```
ReferenceError: __dirname is not defined in ES module scope
    at e2e/playwright.config.ts:36:14
```

`4431493` ("chore: major dependency upgrades across frontend stack") added `"type": "module"` to package.json, so the config is loaded as native ESM where the CommonJS `__dirname` global does not exist. The weekly scheduled E2E workflow brackets it exactly — last green 2026-08-02, red from 2026-08-09.

Replaced with the standard ESM equivalent, `dirname(fileURLToPath(import.meta.url))`.

**Also fixes `e2e/global-teardown.ts`**, which uses `dirname(__filename)` for the same purpose and would break for the same reason. It has never surfaced because the config fails to load first, so teardown is never reached — fixing only the config would have moved the failure rather than removed it.

## Scope

Deliberately limited to `e2e/`. Other files use `__dirname` or `require()` (`vitest.config.ts`, `rspack.config.ts`, `ErrorBoundary.tsx`, `FleetView.test.tsx`), but those are loaded by vitest/rspack, which transpile and shim them — Unit Tests, Lint & Type Check and Build are all green, so they work as-is and are left alone.

## Test plan

- [x] Confirmed the regression window matches `4431493` via both the push and scheduled workflow histories
- [x] Swept the repo for other CJS globals in ESM scope and confirmed which are bundler-handled vs genuinely broken
- [ ] **Not executed locally** — the authoring environment has no node/pnpm, so the config load is unverified outside CI. The pattern is the canonical ESM `__dirname` replacement, but CI is the real check.
- [ ] **This only proves the suite can start.** The E2E tests have not executed in eleven days; whatever they surface on their first real run is separate from this config fix and may need follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)