### PR TITLE
fix: cluster update silently no-ops when spec.desiredUpdate has a stale image

### DIFF
--- a/src/kubeview/views/admin/UpdatesTab.tsx
+++ b/src/kubeview/views/admin/UpdatesTab.tsx
@@ -63,7 +63,7 @@ export function UpdatesTab({
     variant: 'danger' | 'warning'; onConfirm: () => void;
   } | null>(null);
 
-  const handleStartUpdate = (version: string) => {
+  const handleStartUpdate = (version: string, image: string | undefined) => {
     setConfirmDialog({
       title: `Start cluster update to ${version}?`,
       description: `This will rolling-restart all nodes in the cluster. The update process cannot be easily reversed. Make sure you have a recent etcd backup before proceeding.`,
@@ -73,8 +73,22 @@ export function UpdatesTab({
         setConfirmDialog(null);
         setUpdating(true);
         try {
+          // JSON merge-patch merges nested objects field-by-field rather than
+          // replacing them, so a patch of just { version } here would leave
+          // any existing spec.desiredUpdate.image untouched. ClusterVersion's
+          // spec.desiredUpdate.image is authoritative over .version when both
+          // are set — CVO targets the image, using version only for display.
+          // A stale image (e.g. left over from a prior desiredUpdate) paired
+          // with a new version silently makes this a no-op: CVO logs "Update
+          // work is equal to current target; no change required" and never
+          // starts the upgrade, while the UI shows a success toast because
+          // the PATCH request itself succeeds. Always send the full pair so
+          // a merge can never reintroduce a mismatched image.
+          if (!image) {
+            throw new Error(`No image digest available for ${version} — refusing to patch desiredUpdate with version only, which can silently no-op against a stale image.`);
+          }
           await k8sPatch('/apis/config.openshift.io/v1/clusterversions/version', {
-            spec: { desiredUpdate: { version } },
+            spec: { desiredUpdate: { version, image } },
           }, 'application/merge-patch+json');
           addToast({ type: 'success', title: 'Cluster update started', detail: `Updating to ${version}` });
           queryClient.invalidateQueries({ queryKey: ['admin', 'clusterversion'] });
@@ -249,7 +263,7 @@ export function UpdatesTab({
                     {u.risks && u.risks.length > 0 && <span className="ml-2 text-xs px-1.5 py-0.5 bg-red-900 text-red-300 rounded-sm">{u.risks.length} known risk{u.risks.length > 1 ? 's' : ''}</span>}
                   </div>
                   <button
-                    onClick={() => handleStartUpdate(u.version)}
+                    onClick={() => handleStartUpdate(u.version, u.image)}
                     disabled={updating || isUpdating}
                     className="px-3 py-1.5 text-xs bg-blue-600 hover:bg-blue-500 text-white rounded-sm disabled:opacity-50 flex items-center gap-1.5"
                   >

--- a/src/kubeview/views/admin/__tests__/UpdatesTab.test.tsx
+++ b/src/kubeview/views/admin/__tests__/UpdatesTab.test.tsx
@@ -170,6 +170,51 @@ describe('UpdatesTab', () => {
     expect(screen.getByText('Start Update')).toBeDefined();
   });
 
+  // Regression: reported "I clicked cluster update but nothing is happening".
+  // Root cause: the PATCH used JSON merge-patch semantics, which merges
+  // nested objects field-by-field rather than replacing them — sending just
+  // { version } left any pre-existing spec.desiredUpdate.image on the live
+  // object untouched. ClusterVersion's desiredUpdate.image is authoritative
+  // over .version when both are set, so a stale image paired with a new
+  // version made the whole update silently a no-op (CVO logs "Update work
+  // is equal to current target; no change required" and never starts),
+  // while the UI still showed a success toast because the PATCH itself
+  // succeeded. Confirmed live on a real cluster: exactly this mismatch.
+  it('sends both version and image together so a merge-patch cannot reintroduce a stale image', async () => {
+    const { k8sPatch } = await import('../../../engine/query');
+    renderTab({
+      availableUpdates: [{ version: '4.21.28', image: 'quay.io/openshift-release-dev/ocp-release@sha256:newdigest' }],
+    });
+
+    fireEvent.click(screen.getByText('Update'));
+    fireEvent.click(screen.getByText('Start Update'));
+
+    await vi.waitFor(() => {
+      expect(k8sPatch).toHaveBeenCalledWith(
+        '/apis/config.openshift.io/v1/clusterversions/version',
+        { spec: { desiredUpdate: { version: '4.21.28', image: 'quay.io/openshift-release-dev/ocp-release@sha256:newdigest' } } },
+        'application/merge-patch+json',
+      );
+    });
+  });
+
+  it('refuses to patch (and never silently no-ops) when an available update has no image', async () => {
+    const { k8sPatch } = await import('../../../engine/query');
+    const { showErrorToast } = await import('../../../engine/errorToast');
+    vi.mocked(k8sPatch).mockClear();
+    renderTab({
+      availableUpdates: [{ version: '4.21.28' }], // no image field
+    });
+
+    fireEvent.click(screen.getByText('Update'));
+    fireEvent.click(screen.getByText('Start Update'));
+
+    await vi.waitFor(() => {
+      expect(showErrorToast).toHaveBeenCalled();
+    });
+    expect(k8sPatch).not.toHaveBeenCalled();
+  });
+
   it('shows channel change UI when Change button is clicked', () => {
     renderTab({ cvVersion: '4.15.3', cvChannel: 'stable-4.15' });
 


### PR DESCRIPTION
## Summary
Reported: *"I clicked cluster update but nothing is happening."*

Confirmed live on the actual cluster:
- After clicking Update, the PATCH succeeded and `spec.desiredUpdate.version` was set to the requested `4.21.28`.
- But `spec.desiredUpdate.image` still held the digest for the **currently-running** `4.21.27`.
- cluster-version-operator treats `image` as authoritative over `version` when both are set, logged `"Update work is equal to current target; no change required"`, and never started the upgrade — while the UI showed a success toast regardless, since the PATCH request itself succeeded.

## Root cause
The PATCH used JSON merge-patch semantics (`application/merge-patch+json`), which merges nested objects field-by-field instead of replacing them. Sending only `{ version }` left whatever was already in `spec.desiredUpdate.image` on the live object completely untouched — so a stale image from an earlier `desiredUpdate` silently paired with the newly-requested version, and CVO had nothing to do.

## Fix
Always send `version` and `image` together (`image` comes from the same `AvailableUpdate` entry the `version` does), so a merge-patch can never reintroduce a stale image. If an available update has no `image` for some reason, refuse to patch at all rather than risk a silent no-op — or, in the opposite and more dangerous direction, a version/image mismatch pointing at the wrong release entirely.

## Test plan
- [x] New regression test: confirms `k8sPatch` is called with **both** `version` and `image` together
- [x] New regression test: confirms the code refuses to patch (and shows an error) when an available update has no `image`, instead of silently no-op'ing
- [x] Confirmed both new tests fail with the exact reported symptom when reverted, and pass with the fix
- [x] `tsc --noEmit` — clean
- [x] `eslint` — 0 errors (11 pre-existing unrelated warnings)
- [x] `vitest --run` — 2019/2019 passed
- [x] `npm run build` — clean production build

## Note
This PR only fixes the code path going forward. The live cluster's `spec.desiredUpdate` currently still has the stale-image/new-version mismatch from the original click — I have **not** touched it, since correcting it would actually kick off a real, hours-long OpenShift upgrade. Flagging for the user to decide next steps.

Made with [Cursor](https://cursor.com)