### PR TITLE
test: E2E stack guards fail in CI instead of skipping silently

### DIFF
--- a/e2e/tests/integration.spec.ts
+++ b/e2e/tests/integration.spec.ts
@@ -4,11 +4,13 @@
 
 import { test, expect } from 'playwright/test';
 
+import { bailUnlessStackAvailable } from './stack-guard';
+
 test.describe('Integration: Agent Health', () => {
   test('agent health endpoint is reachable from UI', async ({ page }) => {
     const response = await page.goto('/api/agent/health');
     if (!response || response.status() !== 200) {
-      test.skip(true, 'Agent not running — skipping');
+      bailUnlessStackAvailable('Agent not running — skipping');
       return;
     }
     const body = await response.json();

--- a/e2e/tests/stack-guard.ts
+++ b/e2e/tests/stack-guard.ts
@@ -1,0 +1,28 @@
+import { test } from 'playwright/test';
+
+/**
+ * Bail out of a test when the mock agent stack is not reachable.
+ *
+ * Locally this skips, so a developer who has not run `pnpm run e2e:stack` still
+ * gets a useful partial run out of the suite.
+ *
+ * In CI it throws instead. playwright.config.ts starts the mock K8s server, the
+ * agent and the dev server via its `webServer` block, so in CI the stack is
+ * always supposed to be up -- an unreachable agent there means something is
+ * genuinely broken. Every one of these guards sits directly in front of the
+ * assertions it protects, so a guard that fires in CI converts a real failure
+ * into a silent pass and takes the test's coverage with it.
+ *
+ * That is not hypothetical: this suite did not run at all between 2026-08-07
+ * and 2026-08-18 because the Playwright config failed to load, and nothing
+ * about a green-looking board revealed it.
+ */
+export function bailUnlessStackAvailable(reason: string): void {
+  if (process.env.CI) {
+    throw new Error(
+      `${reason} — the mock agent stack must be reachable in CI ` +
+        '(started by the webServer block in e2e/playwright.config.ts)',
+    );
+  }
+  test.skip(true, reason);
+}

--- a/e2e/tests/views.spec.ts
+++ b/e2e/tests/views.spec.ts
@@ -8,6 +8,8 @@
 
 import { test, expect, type Page } from 'playwright/test';
 
+import { bailUnlessStackAvailable } from './stack-guard';
+
 const AGENT_BASE = '/api/agent';
 const AGENT_TOKEN = process.env.E2E_AGENT_TOKEN || 'e2e-test-token';
 
@@ -78,16 +80,16 @@ test.beforeAll(async ({ request }) => {
   try {
     const health = await request.get(`${AGENT_BASE}/healthz`);
     if (!health.ok()) {
-      test.skip(true, 'Agent not running — skipping view E2E tests');
+      bailUnlessStackAvailable('Agent not running — skipping view E2E tests');
       return;
     }
     // Verify views API is accessible with token
     const views = await request.get(withToken(`${AGENT_BASE}/views`));
     if (!views.ok()) {
-      test.skip(true, 'Views API not accessible — skipping view E2E tests');
+      bailUnlessStackAvailable('Views API not accessible — skipping view E2E tests');
     }
   } catch {
-    test.skip(true, 'Agent not reachable — skipping view E2E tests');
+    bailUnlessStackAvailable('Agent not reachable — skipping view E2E tests');
   }
 });
 
@@ -108,7 +110,7 @@ test.describe('View API: CRUD', () => {
   test('POST /views creates a view and GET /views lists it', async ({ page }) => {
     testViewId = await createView(page, 'E2E Create Test');
     if (!testViewId) {
-      test.skip(true, 'Could not create view — agent may not support views');
+      bailUnlessStackAvailable('Could not create view — agent may not support views');
       return;
     }
     expect(testViewId).toBeTruthy();
@@ -122,7 +124,7 @@ test.describe('View API: CRUD', () => {
 
   test('GET /views/:id returns the view', async ({ page }) => {
     testViewId = await createView(page, 'E2E Get Test');
-    if (!testViewId) { test.skip(true, 'Agent unavailable'); return; }
+    if (!testViewId) { bailUnlessStackAvailable('Agent unavailable'); return; }
 
     const response = await page.request.get(withToken(`${AGENT_BASE}/views/${testViewId}`));
     expect(response.ok()).toBe(true);
@@ -133,7 +135,7 @@ test.describe('View API: CRUD', () => {
 
   test('PUT /views/:id updates title and description', async ({ page }) => {
     testViewId = await createView(page, 'E2E Update Test');
-    if (!testViewId) { test.skip(true, 'Agent unavailable'); return; }
+    if (!testViewId) { bailUnlessStackAvailable('Agent unavailable'); return; }
 
     const response = await page.request.put(withToken(`${AGENT_BASE}/views/${testViewId}`), {
       data: { title: 'Updated Title', description: 'Updated description' },
@@ -148,7 +150,7 @@ test.describe('View API: CRUD', () => {
 
   test('PUT /views/:id updates positions', async ({ page }) => {
     testViewId = await createView(page, 'E2E Positions Test');
-    if (!testViewId) { test.skip(true, 'Agent unavailable'); return; }
+    if (!testViewId) { bailUnlessStackAvailable('Agent unavailable'); return; }
 
     const positions = { 0: { x: 0, y: 0, w: 4, h: 3 }, 1: { x: 0, y: 3, w: 2, h: 2 } };
     const response = await page.request.put(withToken(`${AGENT_BASE}/views/${testViewId}`), {
@@ -163,7 +165,7 @@ test.describe('View API: CRUD', () => {
 
   test('DELETE /views/:id removes the view', async ({ page }) => {
     const viewId = await createView(page, 'E2E Delete Test');
-    if (!viewId) { test.skip(true, 'Agent unavailable'); return; }
+    if (!viewId) { bailUnlessStackAvailable('Agent unavailable'); return; }
 
     const delResp = await page.request.delete(withToken(`${AGENT_BASE}/views/${viewId}`));
     expect(delResp.ok()).toBe(true);
@@ -211,7 +213,7 @@ test.describe('View API: Share & Clone', () => {
 
   test('POST /views/:id/share generates a share token', async ({ page }) => {
     testViewId = await createView(page, 'E2E Share Test');
-    if (!testViewId) { test.skip(true, 'Agent unavailable'); return; }
+    if (!testViewId) { bailUnlessStackAvailable('Agent unavailable'); return; }
 
     const response = await page.request.post(withToken(`${AGENT_BASE}/views/${testViewId}/share`));
     expect(response.ok()).toBe(true);
@@ -223,7 +225,7 @@ test.describe('View API: Share & Clone', () => {
 
   test('POST /views/claim/:token clones the view', async ({ page }) => {
     testViewId = await createView(page, 'E2E Clone Source');
-    if (!testViewId) { test.skip(true, 'Agent unavailable'); return; }
+    if (!testViewId) { bailUnlessStackAvailable('Agent unavailable'); return; }
 
     // Generate share token
     const shareResp = await page.request.post(withToken(`${AGENT_BASE}/views/${testViewId}/share`));
@@ -292,14 +294,14 @@ test.describe('View UI: Render & Edit', () => {
   });
 
   test('custom view page renders title and widgets', async ({ page }) => {
-    if (!testViewId) { test.skip(true, 'Agent unavailable'); return; }
+    if (!testViewId) { bailUnlessStackAvailable('Agent unavailable'); return; }
     await gotoView(page, testViewId, 'E2E UI Test View');
     // Should render at least one widget (data_table or info_card_grid)
     await expect(page.locator('[class*="border-slate-800"]').first()).toBeVisible({ timeout: 5_000 });
   });
 
   test('edit mode toggle shows drag handles', async ({ page }) => {
-    if (!testViewId) { test.skip(true, 'Agent unavailable'); return; }
+    if (!testViewId) { bailUnlessStackAvailable('Agent unavailable'); return; }
     await gotoView(page, testViewId, 'E2E UI Test View');
 
     // Click Edit Layout button (pencil icon with title="Edit layout")
@@ -313,7 +315,7 @@ test.describe('View UI: Render & Edit', () => {
   });
 
   test('inline title rename works', async ({ page }) => {
-    if (!testViewId) { test.skip(true, 'Agent unavailable'); return; }
+    if (!testViewId) { bailUnlessStackAvailable('Agent unavailable'); return; }
     await gotoView(page, testViewId, 'E2E UI Test View');
 
     const heading = page.locator('h1').filter({ hasText: 'E2E UI Test View' });
@@ -328,7 +330,7 @@ test.describe('View UI: Render & Edit', () => {
   });
 
   test('share button copies link', async ({ page }) => {
-    if (!testViewId) { test.skip(true, 'Agent unavailable'); return; }
+    if (!testViewId) { bailUnlessStackAvailable('Agent unavailable'); return; }
     await gotoView(page, testViewId, 'E2E UI Test View');
 
     await page.click('button[title="Share view"]');
@@ -341,7 +343,7 @@ test.describe('View UI: Render & Edit', () => {
   });
 
   test('widgets render full-width (not crammed left)', async ({ page }) => {
-    if (!testViewId) { test.skip(true, 'Agent unavailable'); return; }
+    if (!testViewId) { bailUnlessStackAvailable('Agent unavailable'); return; }
     await gotoView(page, testViewId, 'E2E UI Test View');
 
     // Get the grid container and first widget widths
@@ -360,7 +362,7 @@ test.describe('View UI: Render & Edit', () => {
   });
 
   test('multiple widgets stack vertically, not side by side', async ({ page }) => {
-    if (!testViewId) { test.skip(true, 'Agent unavailable'); return; }
+    if (!testViewId) { bailUnlessStackAvailable('Agent unavailable'); return; }
     await gotoView(page, testViewId, 'E2E UI Test View');
 
     const widgets = page.locator('[class*="border-slate-800"]');
@@ -462,7 +464,7 @@ test.describe('View UI: All Component Types', () => {
   });
 
   test('all 6 component types render visibly', async ({ page }) => {
-    if (!testViewId) { test.skip(true, 'Agent unavailable'); return; }
+    if (!testViewId) { bailUnlessStackAvailable('Agent unavailable'); return; }
     await gotoView(page, testViewId, 'E2E All Components');
     await expect(page.locator('text=Test Table')).toBeVisible({ timeout: 5_000 });
     await expect(page.locator('text=Nodes')).toBeVisible({ timeout: 3_000 });
@@ -473,7 +475,7 @@ test.describe('View UI: All Component Types', () => {
   });
 
   test('all widgets are full-width (>80% container)', async ({ page }) => {
-    if (!testViewId) { test.skip(true, 'Agent unavailable'); return; }
+    if (!testViewId) { bailUnlessStackAvailable('Agent unavailable'); return; }
     await gotoView(page, testViewId, 'E2E All Components');
 
     const container = page.locator('.react-grid-layout').first();
@@ -493,7 +495,7 @@ test.describe('View UI: All Component Types', () => {
   });
 
   test('data table shows columns and rows', async ({ page }) => {
-    if (!testViewId) { test.skip(true, 'Agent unavailable'); return; }
+    if (!testViewId) { bailUnlessStackAvailable('Agent unavailable'); return; }
     await page.goto(`/custom/${testViewId}`);
     await expect(page.locator('th:has-text("Name")')).toBeVisible({ timeout: 10_000 });
     await expect(page.locator('th:has-text("Status")')).toBeVisible();
@@ -501,14 +503,14 @@ test.describe('View UI: All Component Types', () => {
   });
 
   test('chart renders title and range footer', async ({ page }) => {
-    if (!testViewId) { test.skip(true, 'Agent unavailable'); return; }
+    if (!testViewId) { bailUnlessStackAvailable('Agent unavailable'); return; }
     await page.goto(`/custom/${testViewId}`);
     await expect(page.locator('text=CPU Over Time')).toBeVisible({ timeout: 10_000 });
     await expect(page.locator('text=Range:')).toBeVisible({ timeout: 5_000 });
   });
 
   test('status list shows all items', async ({ page }) => {
-    if (!testViewId) { test.skip(true, 'Agent unavailable'); return; }
+    if (!testViewId) { bailUnlessStackAvailable('Agent unavailable'); return; }
     await page.goto(`/custom/${testViewId}`);
     await expect(page.locator('text=dns')).toBeVisible({ timeout: 10_000 });
     await expect(page.locator('text=etcd')).toBeVisible();


### PR DESCRIPTION
## Summary

`views.spec.ts` and `integration.spec.ts` carried 22 conditional guards:

```ts
if (!testViewId) { test.skip(true, 'Agent unavailable'); return; }
```

These are **not** disabled tests — all 56 E2E tests run today and none of the guards fired on the last run (56 declared, 56 executed). But each sits directly in front of the assertions it protects, so if the mock agent stack ever became unreachable in CI, those tests would report as skipped, the board would stay green, and the coverage would quietly vanish.

Not theoretical here: this suite did not execute at all between 2026-08-07 and 2026-08-18 because the Playwright config failed to load, and nothing about that said "your E2E coverage is gone" until someone read the log.

`playwright.config.ts` starts the mock K8s server, agent and dev server via its `webServer` block, so in CI the stack is always meant to be up — an unreachable agent there means something is broken. The new `bailUnlessStackAvailable()` helper throws in CI, and still skips locally so a developer who hasn't run `pnpm run e2e:stack` gets a useful partial run.

## Test plan

- [x] All 22 sites converted; the only remaining `test.skip` is inside the helper's local-dev path
- [x] Behaviour unchanged when the stack is healthy — which is every current run
- [ ] **Not run locally** (no node/pnpm in the authoring environment); CI is the check. Expect 56 passed, 0 skipped, exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)