### PR TITLE
feat: real-time upgrade progress and stuck-update detection in Updates tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ podman login quay.io                         # Container registry
 | **Toolbox** | Consolidated tools hub at `/toolbox` — 8 tabs: Catalog (all 138 tools with native/MCP source badges), Skills (7 skill packages with status and routing config), Plans (plan templates and active executions), SLOs (SLO registry with burn rates), Connections (MCP server management with toolset toggles), Components (25 component kinds with mutation support), Usage (tool invocation audit log), Analytics (routing accuracy, fix strategies, agent learning) |
 | **Project** | Namespace-scoped dashboard at `/project/:namespace` with resource summary and health overview |
 | **Claim** | Share token claim view at `/share/:shareToken` for accepting shared custom views |
-| **Admin** | 8 tabs: Overview, Operators, Config, Updates, Snapshots, Quotas, Certificates, CRDs |
+| **Admin** | 8 tabs: Overview, Operators, Config, Updates, Snapshots, Quotas, Certificates, CRDs. Updates tab has real-time upgrade progress and blocker detection: per-MachineConfigPool/per-node rollout status, evidence-based ETA from observed rollout rate, and stuck-update diagnosis (stale desiredUpdate mismatch, Upgradeable=False/admin-ack, conditional update risks, PDB/node drain blockers) with concrete remediation actions |
 
 ---
 

--- a/src/kubeview/engine/__tests__/upgradeHealth.test.ts
+++ b/src/kubeview/engine/__tests__/upgradeHealth.test.ts
@@ -1,0 +1,441 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getMachineConfigPoolProgress,
+  summarizeMachineConfigPools,
+  getNodeRolloutStatus,
+  getNodesInRollout,
+  getDrainBlockingNodes,
+  getBlockingPdbs,
+  detectDesiredUpdateMismatch,
+  getUpgradeableBlocker,
+  getConditionalUpdateRisks,
+  getDegradedOperators,
+  estimateUpgradeEta,
+} from '../upgradeHealth';
+import type { ClusterVersion, ClusterOperator, MachineConfigPool, Node } from '../types';
+
+// ---- Fixtures ----
+
+function makePool(overrides: Partial<NonNullable<MachineConfigPool['status']>> = {}, name = 'worker'): MachineConfigPool {
+  return {
+    apiVersion: 'machineconfiguration.openshift.io/v1',
+    kind: 'MachineConfigPool',
+    metadata: { name, uid: `mcp-${name}`, creationTimestamp: '2026-01-01T00:00:00Z' },
+    status: {
+      machineCount: 3,
+      readyMachineCount: 3,
+      updatedMachineCount: 3,
+      degradedMachineCount: 0,
+      unavailableMachineCount: 0,
+      configuration: { name: 'rendered-worker-abc123' },
+      conditions: [
+        { type: 'Updated', status: 'True' },
+        { type: 'Updating', status: 'False' },
+        { type: 'Degraded', status: 'False' },
+        { type: 'RenderDegraded', status: 'False' },
+      ],
+      ...overrides,
+    },
+  };
+}
+
+function makeNode(name: string, overrides: Partial<{
+  annotations: Record<string, string>;
+  ready: boolean;
+  unschedulable: boolean;
+}> = {}): Node {
+  const { annotations = {}, ready = true, unschedulable = false } = overrides;
+  return {
+    apiVersion: 'v1',
+    kind: 'Node',
+    metadata: { name, uid: `node-${name}`, creationTimestamp: '2026-01-01T00:00:00Z', annotations },
+    spec: { unschedulable },
+    status: { conditions: [{ type: 'Ready', status: ready ? 'True' : 'False' }] },
+  };
+}
+
+function makeClusterVersion(overrides: Partial<ClusterVersion> = {}): ClusterVersion {
+  return {
+    apiVersion: 'config.openshift.io/v1',
+    kind: 'ClusterVersion',
+    metadata: { name: 'version', uid: 'cv-1', creationTimestamp: '2026-01-01T00:00:00Z' },
+    spec: { clusterID: 'cluster-abc', channel: 'stable-4.21' },
+    status: { conditions: [], history: [] },
+    ...overrides,
+  };
+}
+
+function makeOperator(name: string, degraded = false, message = 'operator is degraded'): ClusterOperator {
+  return {
+    apiVersion: 'config.openshift.io/v1',
+    kind: 'ClusterOperator',
+    metadata: { name, uid: `co-${name}`, creationTimestamp: '2026-01-01T00:00:00Z' },
+    status: {
+      conditions: [
+        { type: 'Available', status: degraded ? 'False' : 'True' },
+        { type: 'Degraded', status: degraded ? 'True' : 'False', message: degraded ? message : undefined, reason: degraded ? 'SyncError' : undefined },
+      ],
+    },
+  };
+}
+
+// ---- MachineConfigPool rollout progress ----
+
+describe('getMachineConfigPoolProgress', () => {
+  it('reports real per-pool counts and Updated state — e.g. "3/6 worker nodes updated"', () => {
+    const pool = makePool({ machineCount: 6, updatedMachineCount: 6, readyMachineCount: 6 }, 'worker');
+    const result = getMachineConfigPoolProgress(pool);
+    expect(result.name).toBe('worker');
+    expect(result.machineCount).toBe(6);
+    expect(result.updatedMachineCount).toBe(6);
+    expect(result.isUpdated).toBe(true);
+    expect(result.isUpdating).toBe(false);
+    expect(result.isDegraded).toBe(false);
+  });
+
+  it('reports partial progress mid-rollout', () => {
+    const pool = makePool({
+      machineCount: 6, updatedMachineCount: 3, readyMachineCount: 4, unavailableMachineCount: 1,
+      conditions: [{ type: 'Updated', status: 'False' }, { type: 'Updating', status: 'True' }, { type: 'Degraded', status: 'False' }],
+    });
+    const result = getMachineConfigPoolProgress(pool);
+    expect(result.updatedMachineCount).toBe(3);
+    expect(result.machineCount).toBe(6);
+    expect(result.isUpdating).toBe(true);
+    expect(result.isUpdated).toBe(false);
+  });
+
+  it('surfaces the real Degraded condition message, not just a badge', () => {
+    const pool = makePool({
+      degradedMachineCount: 1,
+      conditions: [
+        { type: 'Updated', status: 'False' },
+        { type: 'Degraded', status: 'True', message: 'Node worker-3 is reporting: "failed to drain node: pod disruption budget violated"' },
+      ],
+    });
+    const result = getMachineConfigPoolProgress(pool);
+    expect(result.isDegraded).toBe(true);
+    expect(result.degradedMessage).toContain('pod disruption budget violated');
+  });
+
+  it('falls back to RenderDegraded message when Degraded has none', () => {
+    const pool = makePool({
+      conditions: [
+        { type: 'Updated', status: 'False' },
+        { type: 'Degraded', status: 'False' },
+        { type: 'RenderDegraded', status: 'True', message: 'error rendering machine config: invalid ignition' },
+      ],
+    });
+    const result = getMachineConfigPoolProgress(pool);
+    expect(result.isDegraded).toBe(true);
+    expect(result.degradedMessage).toContain('invalid ignition');
+  });
+
+  it('summarizes multiple pools (master + worker)', () => {
+    const pools = [makePool({}, 'master'), makePool({ machineCount: 6, updatedMachineCount: 2 }, 'worker')];
+    const result = summarizeMachineConfigPools(pools);
+    expect(result.map((p) => p.name)).toEqual(['master', 'worker']);
+    expect(result[1].updatedMachineCount).toBe(2);
+  });
+});
+
+// ---- Node rollout status ----
+
+describe('getNodeRolloutStatus / getNodesInRollout', () => {
+  it('reads real MCO annotations for current vs desired config', () => {
+    const node = makeNode('worker-1', {
+      annotations: {
+        'machineconfiguration.openshift.io/state': 'Working',
+        'machineconfiguration.openshift.io/desiredConfig': 'rendered-worker-new',
+        'machineconfiguration.openshift.io/currentConfig': 'rendered-worker-old',
+      },
+    });
+    const status = getNodeRolloutStatus(node);
+    expect(status.mcoState).toBe('Working');
+    expect(status.needsUpdate).toBe(true);
+  });
+
+  it('treats matching desired/current config as fully applied', () => {
+    const node = makeNode('worker-2', {
+      annotations: {
+        'machineconfiguration.openshift.io/state': 'Done',
+        'machineconfiguration.openshift.io/desiredConfig': 'rendered-worker-x',
+        'machineconfiguration.openshift.io/currentConfig': 'rendered-worker-x',
+      },
+    });
+    const status = getNodeRolloutStatus(node);
+    expect(status.needsUpdate).toBe(false);
+  });
+
+  it('getNodesInRollout only returns nodes mid-update, not fully-Done ones', () => {
+    const done = makeNode('worker-1', { annotations: { 'machineconfiguration.openshift.io/state': 'Done', 'machineconfiguration.openshift.io/desiredConfig': 'a', 'machineconfiguration.openshift.io/currentConfig': 'a' } });
+    const working = makeNode('worker-2', { annotations: { 'machineconfiguration.openshift.io/state': 'Working', 'machineconfiguration.openshift.io/desiredConfig': 'b', 'machineconfiguration.openshift.io/currentConfig': 'a' } });
+    const result = getNodesInRollout([done, working]);
+    expect(result.map((n) => n.name)).toEqual(['worker-2']);
+  });
+
+  it('surfaces the real machineconfiguration.openshift.io/reason annotation for degraded nodes', () => {
+    const node = makeNode('worker-3', {
+      annotations: {
+        'machineconfiguration.openshift.io/state': 'Degraded',
+        'machineconfiguration.openshift.io/reason': 'failed to drain node: timed out waiting for the condition',
+      },
+    });
+    const status = getNodeRolloutStatus(node);
+    expect(status.reason).toBe('failed to drain node: timed out waiting for the condition');
+  });
+});
+
+describe('getDrainBlockingNodes', () => {
+  it('flags cordoned/unschedulable nodes', () => {
+    const node = makeNode('worker-1', { unschedulable: true });
+    const result = getDrainBlockingNodes([node]);
+    expect(result).toHaveLength(1);
+    expect(result[0].unschedulable).toBe(true);
+  });
+
+  it('flags NotReady nodes', () => {
+    const node = makeNode('worker-1', { ready: false });
+    const result = getDrainBlockingNodes([node]);
+    expect(result).toHaveLength(1);
+    expect(result[0].ready).toBe(false);
+  });
+
+  it('does not flag healthy, schedulable nodes', () => {
+    const node = makeNode('worker-1');
+    expect(getDrainBlockingNodes([node])).toHaveLength(0);
+  });
+});
+
+// ---- Blocking PodDisruptionBudgets ----
+
+describe('getBlockingPdbs', () => {
+  const rolloutNodes = getNodesInRollout([
+    makeNode('worker-1', { annotations: { 'machineconfiguration.openshift.io/state': 'Working', 'machineconfiguration.openshift.io/desiredConfig': 'b', 'machineconfiguration.openshift.io/currentConfig': 'a' } }),
+  ]);
+
+  it('flags a PDB with disruptionsAllowed=0 whose pod sits on a node mid-rollout', () => {
+    const pdbs = [{ metadata: { name: 'app-pdb', namespace: 'my-app' }, spec: { selector: { matchLabels: { app: 'my-app' } } }, status: { disruptionsAllowed: 0 } }];
+    const pods = [{ metadata: { name: 'my-app-1', namespace: 'my-app', labels: { app: 'my-app' } }, spec: { nodeName: 'worker-1' } }];
+    const result = getBlockingPdbs(pdbs, pods, rolloutNodes);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('app-pdb');
+    expect(result[0].blockedNodeNames).toEqual(['worker-1']);
+  });
+
+  it('does not flag a PDB that still allows disruptions', () => {
+    const pdbs = [{ metadata: { name: 'app-pdb', namespace: 'my-app' }, spec: { selector: { matchLabels: { app: 'my-app' } } }, status: { disruptionsAllowed: 1 } }];
+    const pods = [{ metadata: { name: 'my-app-1', namespace: 'my-app', labels: { app: 'my-app' } }, spec: { nodeName: 'worker-1' } }];
+    expect(getBlockingPdbs(pdbs, pods, rolloutNodes)).toHaveLength(0);
+  });
+
+  it('does not flag a PDB whose covered pods are on a node that is not mid-rollout', () => {
+    const pdbs = [{ metadata: { name: 'app-pdb', namespace: 'my-app' }, spec: { selector: { matchLabels: { app: 'my-app' } } }, status: { disruptionsAllowed: 0 } }];
+    const pods = [{ metadata: { name: 'my-app-1', namespace: 'my-app', labels: { app: 'my-app' } }, spec: { nodeName: 'worker-99-not-updating' } }];
+    expect(getBlockingPdbs(pdbs, pods, rolloutNodes)).toHaveLength(0);
+  });
+
+  it('skips PDBs with an empty selector rather than guessing at a match', () => {
+    const pdbs = [{ metadata: { name: 'no-selector-pdb', namespace: 'my-app' }, spec: { selector: { matchLabels: {} } }, status: { disruptionsAllowed: 0 } }];
+    const pods = [{ metadata: { name: 'my-app-1', namespace: 'my-app', labels: { app: 'my-app' } }, spec: { nodeName: 'worker-1' } }];
+    expect(getBlockingPdbs(pdbs, pods, rolloutNodes)).toHaveLength(0);
+  });
+
+  it('returns nothing when no nodes are mid-rollout', () => {
+    const pdbs = [{ metadata: { name: 'app-pdb', namespace: 'my-app' }, spec: { selector: { matchLabels: { app: 'my-app' } } }, status: { disruptionsAllowed: 0 } }];
+    const pods = [{ metadata: { name: 'my-app-1', namespace: 'my-app', labels: { app: 'my-app' } }, spec: { nodeName: 'worker-1' } }];
+    expect(getBlockingPdbs(pdbs, pods, [])).toHaveLength(0);
+  });
+});
+
+// ---- Stuck / no-op desiredUpdate detection ----
+// Regression coverage for the exact production bug class fixed at the
+// write-path in UpdatesTab's handleStartUpdate (PR #50): spec.desiredUpdate
+// paired with a stale image silently no-ops. This is the read-path guard
+// that detects the same symptom regardless of what set spec.desiredUpdate.
+
+describe('detectDesiredUpdateMismatch', () => {
+  it('flags a version requested but never applied (stale-image no-op), after the grace window', () => {
+    const now = new Date('2026-08-18T12:10:00Z').getTime();
+    const cv = makeClusterVersion({
+      spec: { desiredUpdate: { version: '4.21.28', image: 'quay.io/openshift-release-dev/ocp-release@sha256:oldimage' } },
+      status: {
+        desired: { version: '4.21.27', image: 'quay.io/openshift-release-dev/ocp-release@sha256:oldimage' },
+        conditions: [{ type: 'Progressing', status: 'False', lastTransitionTime: '2026-08-18T10:00:00Z' }],
+      },
+    });
+    const result = detectDesiredUpdateMismatch(cv, { now });
+    expect(result).not.toBeNull();
+    expect(result?.requestedVersion).toBe('4.21.28');
+    expect(result?.actualVersion).toBe('4.21.27');
+    expect(result?.mismatchKind).toBe('version');
+    expect(result?.minutesSinceProgressingStable).toBe(130);
+  });
+
+  it('flags an image mismatch as the authoritative mismatch kind when both version and image disagree', () => {
+    const now = new Date('2026-08-18T12:10:00Z').getTime();
+    const cv = makeClusterVersion({
+      spec: { desiredUpdate: { version: '4.21.28', image: 'quay.io/openshift-release-dev/ocp-release@sha256:newimage' } },
+      status: {
+        desired: { version: '4.21.27', image: 'quay.io/openshift-release-dev/ocp-release@sha256:oldimage' },
+        conditions: [{ type: 'Progressing', status: 'False', lastTransitionTime: '2026-08-18T10:00:00Z' }],
+      },
+    });
+    const result = detectDesiredUpdateMismatch(cv, { now });
+    expect(result?.mismatchKind).toBe('image');
+  });
+
+  it('does NOT flag as stuck while Progressing=True (a real update is legitimately underway)', () => {
+    const cv = makeClusterVersion({
+      spec: { desiredUpdate: { version: '4.21.28', image: 'sha256:x' } },
+      status: {
+        desired: { version: '4.21.27', image: 'sha256:old' },
+        conditions: [{ type: 'Progressing', status: 'True', lastTransitionTime: '2026-08-18T10:00:00Z' }],
+      },
+    });
+    expect(detectDesiredUpdateMismatch(cv)).toBeNull();
+  });
+
+  it('does NOT flag within the grace window right after a legitimate patch', () => {
+    const now = new Date('2026-08-18T10:01:00Z').getTime(); // 1 minute after lastTransitionTime
+    const cv = makeClusterVersion({
+      spec: { desiredUpdate: { version: '4.21.28', image: 'sha256:new' } },
+      status: {
+        desired: { version: '4.21.27', image: 'sha256:old' },
+        conditions: [{ type: 'Progressing', status: 'False', lastTransitionTime: '2026-08-18T10:00:00Z' }],
+      },
+    });
+    expect(detectDesiredUpdateMismatch(cv, { now, graceMinutes: 2 })).toBeNull();
+  });
+
+  it('does NOT flag when nothing has been requested', () => {
+    const cv = makeClusterVersion({ spec: {}, status: { desired: { version: '4.21.27', image: 'sha256:old' }, conditions: [] } });
+    expect(detectDesiredUpdateMismatch(cv)).toBeNull();
+  });
+
+  it('does NOT flag when requested version/image match what is already active', () => {
+    const cv = makeClusterVersion({
+      spec: { desiredUpdate: { version: '4.21.27', image: 'sha256:old' } },
+      status: { desired: { version: '4.21.27', image: 'sha256:old' }, conditions: [{ type: 'Progressing', status: 'False' }] },
+    });
+    expect(detectDesiredUpdateMismatch(cv)).toBeNull();
+  });
+
+  it('handles a missing clusterVersion gracefully', () => {
+    expect(detectDesiredUpdateMismatch(null)).toBeNull();
+    expect(detectDesiredUpdateMismatch(undefined)).toBeNull();
+  });
+});
+
+// ---- Upgradeable=False / admin-ack blockers ----
+
+describe('getUpgradeableBlocker', () => {
+  it('returns null when Upgradeable is True or absent', () => {
+    expect(getUpgradeableBlocker(makeClusterVersion({ status: { conditions: [{ type: 'Upgradeable', status: 'True' }] } }))).toBeNull();
+    expect(getUpgradeableBlocker(makeClusterVersion({ status: { conditions: [] } }))).toBeNull();
+  });
+
+  it('surfaces the real Upgradeable=False message and reason verbatim', () => {
+    const message = 'Kubernetes 1.25 and therefore OpenShift 4.12 remove several APIs which require admin consideration.';
+    const cv = makeClusterVersion({ status: { conditions: [{ type: 'Upgradeable', status: 'False', reason: 'AdminAckRequired', message }] } });
+    const result = getUpgradeableBlocker(cv);
+    expect(result?.message).toBe(message);
+    expect(result?.reason).toBe('AdminAckRequired');
+  });
+
+  it('extracts a literal admin-acks unblock command when the message includes one, without inventing the ConfigMap key', () => {
+    const message = 'Admin ack required. Run the following to acknowledge: oc -n openshift-config patch configmap admin-acks --patch \'{"data":{"ack-4.11-kube-1.25-api-removals-in-4.12":"true"}}\' --type=merge';
+    const cv = makeClusterVersion({ status: { conditions: [{ type: 'Upgradeable', status: 'False', message }] } });
+    const result = getUpgradeableBlocker(cv);
+    expect(result?.adminAckCommand).toContain('ack-4.11-kube-1.25-api-removals-in-4.12');
+  });
+
+  it('returns null adminAckCommand (rather than a fabricated one) when the message has no literal command', () => {
+    const cv = makeClusterVersion({ status: { conditions: [{ type: 'Upgradeable', status: 'False', message: 'Not upgradeable for an unspecified reason.' }] } });
+    expect(getUpgradeableBlocker(cv)?.adminAckCommand).toBeNull();
+  });
+});
+
+// ---- Conditional update risks ----
+
+describe('getConditionalUpdateRisks', () => {
+  it('returns an empty list when there are no conditionalUpdates', () => {
+    expect(getConditionalUpdateRisks(makeClusterVersion())).toEqual([]);
+  });
+
+  it('flattens real risk entries verbatim, including message and url', () => {
+    const cv = makeClusterVersion({
+      status: {
+        conditionalUpdates: [
+          {
+            release: { version: '4.21.29', image: 'sha256:risky' },
+            risks: [{ name: 'AwsCsiKnownIssue', message: 'This update path is known to cause CSI driver instability on AWS.', url: 'https://access.redhat.com/solutions/1234' }],
+          },
+        ],
+      },
+    });
+    const result = getConditionalUpdateRisks(cv);
+    expect(result).toEqual([{ version: '4.21.29', image: 'sha256:risky', riskName: 'AwsCsiKnownIssue', message: 'This update path is known to cause CSI driver instability on AWS.', url: 'https://access.redhat.com/solutions/1234' }]);
+  });
+
+  it('skips risk entries with no message rather than fabricating one', () => {
+    const cv = makeClusterVersion({
+      status: { conditionalUpdates: [{ release: { version: '4.21.29' }, risks: [{ name: 'NoMessage' }] }] },
+    });
+    expect(getConditionalUpdateRisks(cv)).toEqual([]);
+  });
+});
+
+// ---- Degraded operators ----
+
+describe('getDegradedOperators', () => {
+  it('returns the real Degraded condition message for each degraded operator', () => {
+    const operators = [makeOperator('console', false), makeOperator('etcd', true, 'EtcdMembersDegraded: 1 of 3 members are unhealthy')];
+    const result = getDegradedOperators(operators);
+    expect(result).toEqual([{ name: 'etcd', message: 'EtcdMembersDegraded: 1 of 3 members are unhealthy', reason: 'SyncError' }]);
+  });
+
+  it('returns an empty list when nothing is degraded', () => {
+    expect(getDegradedOperators([makeOperator('console', false)])).toEqual([]);
+  });
+});
+
+// ---- Evidence-based ETA ----
+
+describe('estimateUpgradeEta', () => {
+  it('derives an ETA from observed MachineConfigPool rollout rate when progress data exists', () => {
+    // 20 minutes elapsed, 2/6 nodes updated => 10 min/node => 4 remaining => ~40 min
+    const now = new Date('2026-08-18T12:20:00Z').getTime();
+    const result = estimateUpgradeEta({
+      progressingSince: '2026-08-18T12:00:00Z',
+      pools: [{ name: 'worker', machineCount: 6, updatedMachineCount: 2, readyMachineCount: 2, degradedMachineCount: 0, unavailableMachineCount: 0, isUpdating: true, isDegraded: false, isUpdated: false, degradedMessage: undefined, configuration: '' }],
+      nodeCount: 6,
+      now,
+    });
+    expect(result.isEvidenceBased).toBe(true);
+    expect(result.minutes).toBe(40);
+  });
+
+  it('falls back to the rough per-node guess when there is no observed progress yet', () => {
+    const result = estimateUpgradeEta({ progressingSince: undefined, pools: [], nodeCount: 3 });
+    expect(result.isEvidenceBased).toBe(false);
+    expect(result.minutes).toBe(30); // Math.max(30, 3 * 10)
+    expect(result.label).toContain('Rough estimate');
+  });
+
+  it('falls back to the rough guess when 0 nodes have updated yet (rate would be undefined)', () => {
+    const result = estimateUpgradeEta({
+      progressingSince: '2026-08-18T12:00:00Z',
+      pools: [{ name: 'worker', machineCount: 6, updatedMachineCount: 0, readyMachineCount: 6, degradedMachineCount: 0, unavailableMachineCount: 0, isUpdating: true, isDegraded: false, isUpdated: false, degradedMessage: undefined, configuration: '' }],
+      nodeCount: 6,
+      now: new Date('2026-08-18T12:05:00Z').getTime(),
+    });
+    expect(result.isEvidenceBased).toBe(false);
+    expect(result.minutes).toBe(60); // Math.max(30, 6 * 10)
+  });
+
+  it('uses the larger node-count fallback rough estimate for big clusters', () => {
+    const result = estimateUpgradeEta({ progressingSince: undefined, pools: [], nodeCount: 12 });
+    expect(result.minutes).toBe(120);
+  });
+});

--- a/src/kubeview/engine/types/index.ts
+++ b/src/kubeview/engine/types/index.ts
@@ -40,7 +40,7 @@ export type { PolicyRule, RoleRef, Subject, ClusterRole, ClusterRoleBinding, Rol
 export type { Ingress, NetworkPolicy, Route } from './networking';
 
 // OpenShift
-export type { ClusterVersion, ClusterOperator, BuildConfig, Build, ImageStream, MachineSet, Machine, NodePool } from './openshift';
+export type { ClusterVersion, ClusterOperator, BuildConfig, Build, ImageStream, MachineSet, Machine, NodePool, MachineConfigPool } from './openshift';
 
 // Storage
 export type { StorageClass, VolumeSnapshot, CSIDriver } from './storage';
@@ -86,6 +86,7 @@ export type TypedK8sResource =
   | import('./openshift').ImageStream
   | import('./openshift').MachineSet
   | import('./openshift').Machine
+  | import('./openshift').MachineConfigPool
   | import('./storage').StorageClass
   | import('./storage').VolumeSnapshot
   | import('./storage').CSIDriver;

--- a/src/kubeview/engine/types/openshift.ts
+++ b/src/kubeview/engine/types/openshift.ts
@@ -2,7 +2,7 @@
  * OpenShift-specific resource types.
  */
 
-import type { ObjectMeta, Condition } from './common';
+import type { ObjectMeta, Condition, LabelSelector } from './common';
 
 export interface ClusterVersion {
   apiVersion: 'config.openshift.io/v1';
@@ -19,8 +19,55 @@ export interface ClusterVersion {
     history?: Array<{ state: string; version: string; startedTime?: string; completionTime?: string; image?: string }>;
     conditions?: Condition[];
     availableUpdates?: Array<{ version: string; image?: string }>;
+    // Conditional updates (config.openshift.io/v1 ClusterVersion.status.conditionalUpdates):
+    // recommended updates that carry known, structured risks for this cluster's
+    // specific configuration (e.g. platform, topology). Distinct from
+    // availableUpdates, which lists updates with no known caveats. Each risk's
+    // `message`/`url` are authored by the OpenShift update recommendation
+    // service — surface them verbatim rather than summarizing.
+    conditionalUpdates?: Array<{
+      release?: { version?: string; image?: string; url?: string };
+      risks?: Array<{
+        name?: string;
+        message?: string;
+        url?: string;
+        matchingRules?: Array<{ type?: string; [key: string]: unknown }>;
+      }>;
+      conditions?: Condition[];
+    }>;
     observedGeneration?: number;
     versionHash?: string;
+  };
+  [key: string]: unknown;
+}
+
+/**
+ * MachineConfigPool (machineconfiguration.openshift.io/v1) — the real
+ * mechanism OpenShift node updates roll out through. `master`/`worker` (and
+ * any custom pools) each track their own rollout: how many machines in the
+ * pool are updated, ready, degraded, or unavailable, plus which rendered
+ * MachineConfig they're converging on.
+ */
+export interface MachineConfigPool {
+  apiVersion: 'machineconfiguration.openshift.io/v1';
+  kind: 'MachineConfigPool';
+  metadata: ObjectMeta;
+  spec?: {
+    paused?: boolean;
+    maxUnavailable?: number | string;
+    configuration?: { name?: string; source?: Array<{ apiVersion?: string; kind?: string; name?: string }> };
+    machineConfigSelector?: LabelSelector;
+    nodeSelector?: LabelSelector;
+  };
+  status?: {
+    conditions?: Condition[];
+    configuration?: { name?: string; source?: Array<{ apiVersion?: string; kind?: string; name?: string }> };
+    machineCount?: number;
+    readyMachineCount?: number;
+    updatedMachineCount?: number;
+    degradedMachineCount?: number;
+    unavailableMachineCount?: number;
+    observedGeneration?: number;
   };
   [key: string]: unknown;
 }

--- a/src/kubeview/engine/upgradeHealth.ts
+++ b/src/kubeview/engine/upgradeHealth.ts
@@ -1,0 +1,349 @@
+/**
+ * Pure, unit-testable logic for OpenShift cluster-update progress and
+ * blocker detection. Every function here takes already-fetched API objects
+ * (ClusterVersion, MachineConfigPool[], Node[], ClusterOperator[], PDBs,
+ * Pods) as input and returns plain derived data — no JSX, no API calls, no
+ * fabricated numbers. UI components in views/admin/ render this output.
+ */
+
+import type { ClusterVersion, ClusterOperator, MachineConfigPool, Node, Condition } from './types';
+
+// ---- MachineConfigPool rollout progress ----
+
+export interface MachineConfigPoolProgress {
+  name: string;
+  machineCount: number;
+  updatedMachineCount: number;
+  readyMachineCount: number;
+  degradedMachineCount: number;
+  unavailableMachineCount: number;
+  isUpdating: boolean;
+  isDegraded: boolean;
+  isUpdated: boolean;
+  /** Real message/reason from the Degraded (or RenderDegraded) condition, when degraded. */
+  degradedMessage: string | undefined;
+  configuration: string;
+}
+
+export function getMachineConfigPoolProgress(pool: MachineConfigPool): MachineConfigPoolProgress {
+  const conditions: Condition[] = pool.status?.conditions || [];
+  const updated = conditions.find((c) => c.type === 'Updated');
+  const updating = conditions.find((c) => c.type === 'Updating');
+  const degraded = conditions.find((c) => c.type === 'Degraded');
+  const renderDegraded = conditions.find((c) => c.type === 'RenderDegraded');
+  const isDegraded = degraded?.status === 'True' || renderDegraded?.status === 'True';
+
+  return {
+    name: pool.metadata.name,
+    machineCount: pool.status?.machineCount ?? 0,
+    updatedMachineCount: pool.status?.updatedMachineCount ?? 0,
+    readyMachineCount: pool.status?.readyMachineCount ?? 0,
+    degradedMachineCount: pool.status?.degradedMachineCount ?? 0,
+    unavailableMachineCount: pool.status?.unavailableMachineCount ?? 0,
+    isUpdating: updating?.status === 'True',
+    isDegraded,
+    isUpdated: updated?.status === 'True',
+    degradedMessage: isDegraded
+      ? ((degraded?.status === 'True' ? degraded?.message || degraded?.reason : undefined) ??
+         (renderDegraded?.status === 'True' ? renderDegraded?.message || renderDegraded?.reason : undefined))
+      : undefined,
+    configuration: pool.status?.configuration?.name || pool.spec?.configuration?.name || '',
+  };
+}
+
+export function summarizeMachineConfigPools(pools: MachineConfigPool[]): MachineConfigPoolProgress[] {
+  return pools.map(getMachineConfigPoolProgress);
+}
+
+// ---- Per-node rollout status (cross-referenced from MCO annotations) ----
+
+const MCO_STATE_ANNOTATION = 'machineconfiguration.openshift.io/state';
+const MCO_DESIRED_CONFIG_ANNOTATION = 'machineconfiguration.openshift.io/desiredConfig';
+const MCO_CURRENT_CONFIG_ANNOTATION = 'machineconfiguration.openshift.io/currentConfig';
+const MCO_REASON_ANNOTATION = 'machineconfiguration.openshift.io/reason';
+
+export interface NodeRolloutStatus {
+  name: string;
+  /** Raw value of the machineconfiguration.openshift.io/state annotation (e.g. Done, Working, Degraded). */
+  mcoState: string;
+  desiredConfig: string | undefined;
+  currentConfig: string | undefined;
+  /** desiredConfig and currentConfig annotations disagree — a config rollout is pending/in-flight for this node. */
+  needsUpdate: boolean;
+  ready: boolean;
+  unschedulable: boolean;
+  /** machineconfiguration.openshift.io/reason annotation — populated when MCO reports a specific failure. */
+  reason: string | undefined;
+}
+
+export function getNodeRolloutStatus(node: Node): NodeRolloutStatus {
+  const annotations = node.metadata.annotations || {};
+  const desiredConfig = annotations[MCO_DESIRED_CONFIG_ANNOTATION];
+  const currentConfig = annotations[MCO_CURRENT_CONFIG_ANNOTATION];
+  const conditions: Condition[] = node.status?.conditions || [];
+  const ready = conditions.some((c) => c.type === 'Ready' && c.status === 'True');
+
+  return {
+    name: node.metadata.name,
+    mcoState: annotations[MCO_STATE_ANNOTATION] || 'Unknown',
+    desiredConfig,
+    currentConfig,
+    needsUpdate: !!desiredConfig && !!currentConfig && desiredConfig !== currentConfig,
+    ready,
+    unschedulable: !!node.spec?.unschedulable,
+    reason: annotations[MCO_REASON_ANNOTATION] || undefined,
+  };
+}
+
+/** Nodes MCO is actively rolling a config change through (mid-drain/reboot/apply, or degraded). */
+export function getNodesInRollout(nodes: Node[]): NodeRolloutStatus[] {
+  return nodes
+    .map(getNodeRolloutStatus)
+    .filter((n) => n.needsUpdate || (n.mcoState !== 'Done' && n.mcoState !== 'Unknown'));
+}
+
+/** Nodes that can stall a drain indefinitely: cordoned/unschedulable or NotReady. */
+export function getDrainBlockingNodes(nodes: Node[]): NodeRolloutStatus[] {
+  return nodes.map(getNodeRolloutStatus).filter((n) => n.unschedulable || !n.ready);
+}
+
+// ---- PodDisruptionBudgets that could block node draining ----
+
+export interface PdbLike {
+  metadata: { name: string; namespace?: string; uid?: string };
+  spec?: { selector?: { matchLabels?: Record<string, string> } };
+  status?: { disruptionsAllowed?: number };
+}
+
+export interface PodLike {
+  metadata: { name: string; namespace?: string; labels?: Record<string, string> };
+  spec?: { nodeName?: string };
+}
+
+export interface BlockingPdb {
+  name: string;
+  namespace: string;
+  disruptionsAllowed: number;
+  /** Names of in-rollout nodes running a pod this PDB's selector covers. */
+  blockedNodeNames: string[];
+}
+
+/**
+ * PDBs with zero remaining disruptions allowed, where a pod they cover is
+ * currently scheduled on a node that's mid-rollout — i.e. `oc adm drain`
+ * would be refused for that pod today, which can stall the whole pool.
+ * PDBs with an empty selector are skipped rather than guessed at, since an
+ * empty matchLabels technically matches every pod and would produce noisy
+ * false positives.
+ */
+export function getBlockingPdbs(pdbs: PdbLike[], pods: PodLike[], nodesInRollout: NodeRolloutStatus[]): BlockingPdb[] {
+  const rolloutNodeNames = new Set(nodesInRollout.map((n) => n.name));
+  if (rolloutNodeNames.size === 0) return [];
+
+  const result: BlockingPdb[] = [];
+  for (const pdb of pdbs) {
+    const disruptionsAllowed = pdb.status?.disruptionsAllowed;
+    if (disruptionsAllowed === undefined || disruptionsAllowed > 0) continue;
+
+    const namespace = pdb.metadata.namespace || '';
+    const selectorEntries = Object.entries(pdb.spec?.selector?.matchLabels || {});
+    if (selectorEntries.length === 0) continue;
+
+    const blockedNodeNames = new Set<string>();
+    for (const pod of pods) {
+      if ((pod.metadata.namespace || '') !== namespace) continue;
+      const nodeName = pod.spec?.nodeName;
+      if (!nodeName || !rolloutNodeNames.has(nodeName)) continue;
+      const podLabels = pod.metadata.labels || {};
+      const matchesSelector = selectorEntries.every(([key, value]) => podLabels[key] === value);
+      if (matchesSelector) blockedNodeNames.add(nodeName);
+    }
+
+    if (blockedNodeNames.size > 0) {
+      result.push({ name: pdb.metadata.name, namespace, disruptionsAllowed, blockedNodeNames: [...blockedNodeNames] });
+    }
+  }
+  return result;
+}
+
+// ---- Stale/no-op desiredUpdate detection (read-path guard) ----
+
+export interface DesiredUpdateMismatch {
+  requestedVersion: string;
+  requestedImage: string | undefined;
+  actualVersion: string | undefined;
+  actualImage: string | undefined;
+  /** Which field CVO is treating as authoritative and ignoring the request for. */
+  mismatchKind: 'image' | 'version';
+  /** Minutes the Progressing condition has continuously reported False, when known. */
+  minutesSinceProgressingStable: number | null;
+}
+
+/**
+ * Detects the write-path bug class (fixed in UpdatesTab's own PATCH logic)
+ * from the read side too, since spec.desiredUpdate can also be set directly
+ * by other tooling (e.g. `oc adm upgrade`, GitOps, another admin) — this
+ * repo's fix only guarantees *this UI* never sends a mismatched pair again.
+ *
+ * A mismatch alone isn't proof of a stuck update — right after a *good*
+ * patch, CVO needs a brief moment to notice and flip Progressing=True. We
+ * only flag it once the Progressing condition has been reporting False for
+ * at least `graceMinutes`, using its real `lastTransitionTime` (not a
+ * fabricated "request sent at" clock, which this API doesn't expose).
+ */
+export function detectDesiredUpdateMismatch(
+  clusterVersion: ClusterVersion | null | undefined,
+  options: { graceMinutes?: number; now?: number } = {},
+): DesiredUpdateMismatch | null {
+  const { graceMinutes = 2, now = Date.now() } = options;
+  const desiredUpdate = clusterVersion?.spec?.desiredUpdate;
+  if (!desiredUpdate?.version) return null;
+
+  const conditions: Condition[] = clusterVersion?.status?.conditions || [];
+  const progressing = conditions.find((c) => c.type === 'Progressing');
+  if (progressing?.status === 'True') return null; // actively working toward it — not stuck
+
+  const statusDesired = clusterVersion?.status?.desired;
+  const imageMismatch = !!desiredUpdate.image && !!statusDesired?.image && desiredUpdate.image !== statusDesired.image;
+  const versionMismatch = !imageMismatch && !!statusDesired?.version && desiredUpdate.version !== statusDesired.version;
+  if (!imageMismatch && !versionMismatch) return null;
+
+  const base: Omit<DesiredUpdateMismatch, 'minutesSinceProgressingStable'> = {
+    requestedVersion: desiredUpdate.version,
+    requestedImage: desiredUpdate.image,
+    actualVersion: statusDesired?.version,
+    actualImage: statusDesired?.image,
+    mismatchKind: imageMismatch ? 'image' : 'version',
+  };
+
+  if (!progressing?.lastTransitionTime) {
+    // No timestamp to apply a grace window against — trust the real mismatch as-is.
+    return { ...base, minutesSinceProgressingStable: null };
+  }
+
+  const minutesSince = (now - new Date(progressing.lastTransitionTime).getTime()) / 60000;
+  if (minutesSince < graceMinutes) return null;
+
+  return { ...base, minutesSinceProgressingStable: Math.round(minutesSince) };
+}
+
+// ---- Upgradeable=False / admin-ack style blockers ----
+
+export interface UpgradeableBlocker {
+  message: string;
+  reason: string | undefined;
+  /** A literal `oc -n openshift-config patch configmap admin-acks ...` command, extracted verbatim from the real condition message when CVO includes one. Never fabricated. */
+  adminAckCommand: string | null;
+}
+
+export function getUpgradeableBlocker(clusterVersion: ClusterVersion | null | undefined): UpgradeableBlocker | null {
+  const conditions: Condition[] = clusterVersion?.status?.conditions || [];
+  const upgradeable = conditions.find((c) => c.type === 'Upgradeable');
+  if (!upgradeable || upgradeable.status !== 'False') return null;
+
+  const message = upgradeable.message || 'Cluster reports Upgradeable=False with no message.';
+  // CVO's Upgradeable=False message for admin-ack-gated boundaries (e.g. Kubernetes
+  // API removals) typically embeds the exact unblock command. Extract it verbatim
+  // rather than reconstructing the ConfigMap key ourselves — it's version- and
+  // risk-specific and only the live condition text can be trusted for it.
+  const commandMatch = message.match(/oc\s+-n\s+openshift-config\s+patch\s+configmap\s+admin-acks[^\n`]*/i);
+
+  return {
+    message,
+    reason: upgradeable.reason,
+    adminAckCommand: commandMatch ? commandMatch[0].trim() : null,
+  };
+}
+
+// ---- Conditional update risks ----
+
+export interface ConditionalUpdateRisk {
+  version: string;
+  image: string | undefined;
+  riskName: string | undefined;
+  message: string;
+  url: string | undefined;
+}
+
+/** Flattens status.conditionalUpdates[].risks[] into a display-ready list, using each risk's real message/url verbatim. */
+export function getConditionalUpdateRisks(clusterVersion: ClusterVersion | null | undefined): ConditionalUpdateRisk[] {
+  const conditionalUpdates = clusterVersion?.status?.conditionalUpdates || [];
+  const risks: ConditionalUpdateRisk[] = [];
+  for (const cu of conditionalUpdates) {
+    const version = cu.release?.version;
+    if (!version) continue;
+    for (const risk of cu.risks || []) {
+      if (!risk.message) continue;
+      risks.push({ version, image: cu.release?.image, riskName: risk.name, message: risk.message, url: risk.url });
+    }
+  }
+  return risks;
+}
+
+// ---- Degraded operators (with real blocking message/reason) ----
+
+export interface DegradedOperatorInfo {
+  name: string;
+  message: string | undefined;
+  reason: string | undefined;
+}
+
+export function getDegradedOperators(operators: ClusterOperator[]): DegradedOperatorInfo[] {
+  const result: DegradedOperatorInfo[] = [];
+  for (const op of operators) {
+    const degraded = (op.status?.conditions || []).find((c) => c.type === 'Degraded' && c.status === 'True');
+    if (!degraded) continue;
+    result.push({ name: op.metadata.name, message: degraded.message, reason: degraded.reason });
+  }
+  return result;
+}
+
+// ---- Evidence-based ETA ----
+
+export interface UpgradeEtaEstimate {
+  minutes: number;
+  /** True when derived from observed MachineConfigPool rollout rate; false for the static node-count fallback guess. */
+  isEvidenceBased: boolean;
+  label: string;
+}
+
+/**
+ * Estimates remaining upgrade time from the observed rollout rate
+ * (minutes-per-node so far, from real MachineConfigPool counters and the
+ * ClusterVersion Progressing condition's real lastTransitionTime) rather
+ * than a flat per-node guess. Falls back to the original `nodes.length *
+ * 10min` rough estimate — clearly labeled as such — when there isn't yet
+ * enough real progress to extrapolate from.
+ */
+export function estimateUpgradeEta(params: {
+  /** ClusterVersion's Progressing condition lastTransitionTime, only meaningful while Progressing=True. */
+  progressingSince: string | undefined;
+  pools: MachineConfigPoolProgress[];
+  nodeCount: number;
+  now?: number;
+}): UpgradeEtaEstimate {
+  const { progressingSince, pools, nodeCount, now = Date.now() } = params;
+  const totalMachines = pools.reduce((sum, p) => sum + p.machineCount, 0);
+  const totalUpdated = pools.reduce((sum, p) => sum + p.updatedMachineCount, 0);
+
+  if (progressingSince && totalMachines > 0 && totalUpdated > 0 && totalUpdated < totalMachines) {
+    const elapsedMinutes = (now - new Date(progressingSince).getTime()) / 60000;
+    if (elapsedMinutes > 0) {
+      const minutesPerNode = elapsedMinutes / totalUpdated;
+      const remaining = totalMachines - totalUpdated;
+      const minutes = Math.round(minutesPerNode * remaining);
+      return {
+        minutes,
+        isEvidenceBased: true,
+        label: `~${minutes} min remaining \u2014 based on ${totalUpdated}/${totalMachines} nodes updated over the last ${Math.round(elapsedMinutes)} min`,
+      };
+    }
+  }
+
+  const minutes = Math.max(30, nodeCount * 10);
+  return {
+    minutes,
+    isEvidenceBased: false,
+    label: `Rough estimate: ~${minutes} min (${nodeCount} nodes \u00d7 ~10min each) \u2014 no in-progress rollout data yet`,
+  };
+}

--- a/src/kubeview/views/AdminView.tsx
+++ b/src/kubeview/views/AdminView.tsx
@@ -12,7 +12,7 @@ import { k8sList, k8sGet } from '../engine/query';
 import { safeQuery } from '../engine/safeQuery';
 import { useK8sListWatch } from '../hooks/useK8sListWatch';
 import type { K8sResource } from '../engine/renderers';
-import type { ClusterVersion, ClusterOperator, Node, Deployment, Condition, Namespace } from '../engine/types';
+import type { ClusterVersion, ClusterOperator, Node, Deployment, Condition, Namespace, MachineConfigPool, Pod } from '../engine/types';
 import { useNavigateTab } from '../hooks/useNavigateTab';
 import { useClusterStore } from '../store/clusterStore';
 import ClusterConfig from '../components/ClusterConfig';
@@ -92,6 +92,10 @@ interface LimitRange extends K8sResource {
 interface PodDisruptionBudget extends K8sResource {
   spec?: {
     selector?: { matchLabels?: Record<string, string> };
+    [key: string]: unknown;
+  };
+  status?: {
+    disruptionsAllowed?: number;
     [key: string]: unknown;
   };
 }
@@ -256,6 +260,23 @@ export default function AdminView() {
     queryKey: ['k8s', 'list', '/apis/apps/v1/deployments'],
     queryFn: async () => (await safeQuery(() => k8sList<Deployment>('/apis/apps/v1/deployments'))) ?? [],
     staleTime: 60000,
+  });
+
+  // Same queryKey ComputeView uses for MachineConfigPools — real per-pool node
+  // rollout progress (updatedMachineCount/machineCount, Degraded/Updating
+  // conditions), shared cache when both views have fetched it.
+  const { data: machineConfigPools = [] } = useQuery<MachineConfigPool[]>({
+    queryKey: ['compute', 'machineconfigpools'],
+    queryFn: async () => (await safeQuery(() => k8sList<MachineConfigPool>('/apis/machineconfiguration.openshift.io/v1/machineconfigpools'))) ?? [],
+    staleTime: 60000,
+  });
+
+  // Pods are only needed to correlate PodDisruptionBudgets against nodes
+  // that are actually draining right now — skip the cluster-wide fetch
+  // entirely unless an update is actively progressing.
+  const { data: pods = [] } = useK8sListWatch<Pod>({
+    apiPath: '/api/v1/pods',
+    enabled: (clusterVersion?.status?.conditions || []).some((c: Condition) => c.type === 'Progressing' && c.status === 'True'),
   });
 
   const { data: etcdBackupExists } = useQuery({
@@ -528,6 +549,9 @@ export default function AdminView() {
             pdbs={pdbs}
             etcdBackupExists={etcdBackupExists}
             isHyperShift={isHyperShift}
+            machineConfigPools={machineConfigPools}
+            pods={pods}
+            go={go}
           />
         )}
 

--- a/src/kubeview/views/admin/UpdatesTab.tsx
+++ b/src/kubeview/views/admin/UpdatesTab.tsx
@@ -7,18 +7,24 @@ import {
 import { cn } from '@/lib/utils';
 import { k8sPatch } from '../../engine/query';
 import type { K8sResource } from '../../engine/renderers';
-import type { ClusterVersion, ClusterOperator, Node, Deployment, Condition } from '../../engine/types';
+import { resourceDetailUrl } from '../../engine/gvr';
+import type { ClusterVersion, ClusterOperator, Node, Deployment, Condition, MachineConfigPool, Pod } from '../../engine/types';
 import { useUIStore } from '../../store/uiStore';
 import { useQueryClient } from '@tanstack/react-query';
 import { ConfirmDialog } from '../../components/feedback/ConfirmDialog';
 import { Panel } from '../../components/primitives/Panel';
 import { SnapshotsTab } from './SnapshotsTab';
+import { UpgradeProgressPanel } from './UpgradeProgressPanel';
 import { showErrorToast } from '../../engine/errorToast';
 
 /** PDB resource */
 interface PodDisruptionBudget extends K8sResource {
   spec?: {
     selector?: { matchLabels?: Record<string, string> };
+    [key: string]: unknown;
+  };
+  status?: {
+    disruptionsAllowed?: number;
     [key: string]: unknown;
   };
 }
@@ -43,6 +49,9 @@ export interface UpdatesTabProps {
   pdbs: PodDisruptionBudget[];
   etcdBackupExists: boolean | undefined;
   isHyperShift: boolean;
+  machineConfigPools: MachineConfigPool[];
+  pods: Pod[];
+  go: (path: string, title: string) => void;
 }
 
 export function UpdatesTab({
@@ -50,6 +59,7 @@ export function UpdatesTab({
   availableUpdates, isUpdating,
   operators, nodes, deployments, pdbs,
   etcdBackupExists, isHyperShift,
+  machineConfigPools, pods, go,
 }: UpdatesTabProps) {
   const addToast = useUIStore((s) => s.addToast);
   const queryClient = useQueryClient();
@@ -147,6 +157,18 @@ export function UpdatesTab({
           </>
         );
       })()}
+
+      {/* Real-time rollout progress, blocker detection, and stuck-update diagnosis */}
+      <UpgradeProgressPanel
+        clusterVersion={clusterVersion}
+        isUpdating={isUpdating}
+        nodes={nodes}
+        machineConfigPools={machineConfigPools}
+        pdbs={pdbs}
+        pods={pods}
+        availableUpdates={availableUpdates}
+        onReapplyUpdate={handleStartUpdate}
+      />
 
       {/* Current version + channel */}
       <Panel title="Current Version" icon={<Settings className="w-4 h-4 text-slate-400" />}>
@@ -287,21 +309,30 @@ export function UpdatesTab({
             {operators.map((op) => {
               const conds: Condition[] = op.status?.conditions || [];
               const progressing = conds.find((c) => c.type === 'Progressing');
-              const available = conds.find((c) => c.type === 'Available');
               const degraded = conds.find((c) => c.type === 'Degraded');
               const isProgressing = progressing?.status === 'True';
               const isDegraded = degraded?.status === 'True';
-              const isAvailable = available?.status === 'True';
               const version = op.status?.versions?.find((v) => v.name === 'operator')?.version || '';
+              // Surface *why* — the actual blocking condition message/reason, not just a badge.
+              const detailMessage = isDegraded ? (degraded?.message || degraded?.reason)
+                : isProgressing ? (progressing?.message || progressing?.reason)
+                : '';
               return (
-                <div key={op.metadata.uid} className="flex items-center justify-between py-1.5 px-2 hover:bg-slate-800/30 rounded-sm">
-                  <div className="flex items-center gap-2">
-                    {isDegraded ? <XCircle className="w-3.5 h-3.5 text-red-500" /> :
-                     isProgressing ? <RefreshCw className="w-3.5 h-3.5 text-blue-400 animate-spin" /> :
-                     <CheckCircle className="w-3.5 h-3.5 text-green-500" />}
-                    <span className="text-sm text-slate-200">{op.metadata.name}</span>
+                <button
+                  key={op.metadata.uid}
+                  onClick={() => go(resourceDetailUrl({ apiVersion: 'config.openshift.io/v1', kind: 'ClusterOperator', metadata: { name: op.metadata.name } }), op.metadata.name)}
+                  className="w-full flex items-start justify-between gap-2 py-1.5 px-2 hover:bg-slate-800/30 rounded-sm text-left transition-colors"
+                >
+                  <div className="flex items-start gap-2 min-w-0">
+                    {isDegraded ? <XCircle className="w-3.5 h-3.5 text-red-500 shrink-0 mt-0.5" /> :
+                     isProgressing ? <RefreshCw className="w-3.5 h-3.5 text-blue-400 animate-spin shrink-0 mt-0.5" /> :
+                     <CheckCircle className="w-3.5 h-3.5 text-green-500 shrink-0 mt-0.5" />}
+                    <div className="min-w-0">
+                      <span className="text-sm text-slate-200">{op.metadata.name}</span>
+                      {detailMessage && <p className="text-xs text-slate-500 mt-0.5 line-clamp-2">{detailMessage}</p>}
+                    </div>
                   </div>
-                  <div className="flex items-center gap-2">
+                  <div className="flex items-center gap-2 shrink-0">
                     {version && <span className="text-xs font-mono text-slate-500">{version}</span>}
                     <span className={cn('text-xs px-1.5 py-0.5 rounded-sm',
                       isDegraded ? 'bg-red-900/50 text-red-300' :
@@ -311,7 +342,7 @@ export function UpdatesTab({
                       {isDegraded ? 'Degraded' : isProgressing ? 'Updating' : 'Ready'}
                     </span>
                   </div>
-                </div>
+                </button>
               );
             })}
           </div>

--- a/src/kubeview/views/admin/UpgradeProgressPanel.tsx
+++ b/src/kubeview/views/admin/UpgradeProgressPanel.tsx
@@ -1,0 +1,229 @@
+import React from 'react';
+import {
+  AlertOctagon, ShieldAlert, Ban, Clock, ExternalLink, Server, AlertTriangle, XCircle,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Panel } from '../../components/primitives/Panel';
+import type { ClusterVersion, MachineConfigPool, Node } from '../../engine/types';
+import {
+  detectDesiredUpdateMismatch,
+  getUpgradeableBlocker,
+  getConditionalUpdateRisks,
+  summarizeMachineConfigPools,
+  getNodesInRollout,
+  getDrainBlockingNodes,
+  getBlockingPdbs,
+  estimateUpgradeEta,
+  type PdbLike,
+  type PodLike,
+} from '../../engine/upgradeHealth';
+
+export interface UpgradeProgressPanelProps {
+  clusterVersion: ClusterVersion | null | undefined;
+  isUpdating: boolean;
+  nodes: Node[];
+  machineConfigPools: MachineConfigPool[];
+  pdbs: PdbLike[];
+  pods: PodLike[];
+  availableUpdates: Array<{ version: string; image?: string }>;
+  onReapplyUpdate: (version: string, image: string | undefined) => void;
+}
+
+/**
+ * Real-time upgrade progress and blocker detection. Everything here is
+ * derived from actual ClusterVersion / MachineConfigPool / Node / PDB
+ * objects via the pure functions in engine/upgradeHealth.ts — no fabricated
+ * percentages or invented risk text.
+ */
+export function UpgradeProgressPanel({
+  clusterVersion, isUpdating, nodes, machineConfigPools, pdbs, pods,
+  availableUpdates, onReapplyUpdate,
+}: UpgradeProgressPanelProps) {
+  const mismatch = React.useMemo(() => detectDesiredUpdateMismatch(clusterVersion), [clusterVersion]);
+  const upgradeableBlocker = React.useMemo(() => getUpgradeableBlocker(clusterVersion), [clusterVersion]);
+  const conditionalRisks = React.useMemo(() => getConditionalUpdateRisks(clusterVersion), [clusterVersion]);
+  const poolProgress = React.useMemo(() => summarizeMachineConfigPools(machineConfigPools), [machineConfigPools]);
+  const nodesInRollout = React.useMemo(() => getNodesInRollout(nodes), [nodes]);
+  const drainBlockingNodes = React.useMemo(() => getDrainBlockingNodes(nodes), [nodes]);
+  const blockingPdbs = React.useMemo(() => getBlockingPdbs(pdbs, pods, nodesInRollout), [pdbs, pods, nodesInRollout]);
+
+  const progressingCond = (clusterVersion?.status?.conditions || []).find((c) => c.type === 'Progressing');
+  const eta = React.useMemo(() => estimateUpgradeEta({
+    progressingSince: progressingCond?.status === 'True' ? progressingCond.lastTransitionTime : undefined,
+    pools: poolProgress,
+    nodeCount: nodes.length,
+  }), [progressingCond, poolProgress, nodes.length]);
+
+  const matchingAvailableUpdate = mismatch ? availableUpdates.find((u) => u.version === mismatch.requestedVersion) : undefined;
+
+  const hasBlockers = !!mismatch || !!upgradeableBlocker || conditionalRisks.length > 0;
+  const showRollout = isUpdating || poolProgress.some((p) => p.isUpdating) || nodesInRollout.length > 0;
+
+  if (!hasBlockers && !showRollout) return null;
+
+  return (
+    <div className="space-y-6">
+      {/* Stuck / no-op update — read-path detection of the stale desiredUpdate.image class of bug */}
+      {mismatch && (
+        <div className="px-4 py-3 bg-red-950/30 border border-red-900 rounded-lg">
+          <div className="flex items-start gap-3">
+            <AlertOctagon className="w-5 h-5 text-red-400 shrink-0 mt-0.5" />
+            <div className="flex-1 min-w-0">
+              <div className="text-sm font-medium text-red-300">Update appears stuck \u2014 requested {mismatch.mismatchKind} does not match what&apos;s active</div>
+              <div className="text-xs text-slate-400 mt-1">
+                <span className="text-slate-300">spec.desiredUpdate</span> requests <span className="font-mono text-slate-300">{mismatch.requestedVersion}</span>
+                {mismatch.requestedImage && <> (<span className="font-mono text-slate-300">{mismatch.requestedImage.slice(0, 28)}\u2026</span>)</>}
+                {', but the cluster is still targeting '}
+                <span className="font-mono text-slate-300">{mismatch.actualVersion || '\u2014'}</span>
+                {mismatch.actualImage && <> (<span className="font-mono text-slate-300">{mismatch.actualImage.slice(0, 28)}\u2026</span>)</>}
+                {'. cluster-version-operator treats '}{mismatch.mismatchKind}{' as authoritative and has not started \u2014 '}
+                {mismatch.minutesSinceProgressingStable !== null
+                  ? `no progress for ${mismatch.minutesSinceProgressingStable} min.`
+                  : 'Progressing has no recorded transition time.'}
+              </div>
+              <div className="mt-2">
+                {matchingAvailableUpdate ? (
+                  <button
+                    onClick={() => onReapplyUpdate(matchingAvailableUpdate.version, matchingAvailableUpdate.image)}
+                    className="px-3 py-1.5 text-xs bg-red-700 hover:bg-red-600 text-white rounded-sm"
+                  >
+                    Re-apply update to {matchingAvailableUpdate.version}
+                  </button>
+                ) : (
+                  <span className="text-xs text-slate-500">
+                    {mismatch.requestedVersion} is no longer listed under Available Updates below \u2014 select it again once it reappears, or correct spec.desiredUpdate directly with <code className="mx-1 px-1 bg-slate-800 rounded-sm">oc adm upgrade --to-image=&lt;correct digest&gt;</code>.
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Upgradeable=False — often gated behind an admin acknowledgment */}
+      {upgradeableBlocker && (
+        <div className="px-4 py-3 bg-amber-950/30 border border-amber-800 rounded-lg">
+          <div className="flex items-start gap-3">
+            <ShieldAlert className="w-5 h-5 text-amber-400 shrink-0 mt-0.5" />
+            <div className="flex-1 min-w-0">
+              <div className="text-sm font-medium text-amber-300">Cluster is not upgradeable{upgradeableBlocker.reason ? ` (${upgradeableBlocker.reason})` : ''}</div>
+              <p className="text-xs text-slate-400 mt-1 whitespace-pre-wrap">{upgradeableBlocker.message}</p>
+              {upgradeableBlocker.adminAckCommand ? (
+                <div className="mt-2">
+                  <div className="text-xs text-slate-500 mb-1">Unblock by running the acknowledgment command from the message above:</div>
+                  <pre className="text-xs font-mono bg-slate-950 border border-slate-800 rounded-sm p-2 overflow-x-auto text-slate-300">{upgradeableBlocker.adminAckCommand}</pre>
+                </div>
+              ) : (
+                <p className="text-xs text-slate-500 mt-2">
+                  Boundaries like this commonly require an administrator acknowledgment \u2014 run <code className="mx-1 px-1 bg-slate-800 rounded-sm">oc adm upgrade</code> for the exact <code className="mx-1 px-1 bg-slate-800 rounded-sm">admin-acks</code> ConfigMap key this cluster needs before the update can proceed.
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Conditional update risks — real, structured data from status.conditionalUpdates */}
+      {conditionalRisks.length > 0 && (
+        <Panel title={`Conditional Update Risks (${conditionalRisks.length})`} icon={<AlertTriangle className="w-4 h-4 text-amber-500" />}>
+          <div className="space-y-2">
+            {conditionalRisks.map((risk, i) => (
+              <div key={i} className="p-2.5 rounded-sm bg-amber-950/20 border border-amber-900/30">
+                <div className="flex items-center gap-2 text-xs">
+                  <span className="font-mono text-slate-300">{risk.version}</span>
+                  {risk.riskName && <span className="px-1.5 py-0.5 bg-amber-900/50 text-amber-300 rounded-sm">{risk.riskName}</span>}
+                </div>
+                <p className="text-xs text-slate-400 mt-1">{risk.message}</p>
+                {risk.url && (
+                  <a href={risk.url} target="_blank" rel="noreferrer" className="text-xs text-blue-400 hover:text-blue-300 flex items-center gap-1 mt-1">
+                    Details <ExternalLink className="w-3 h-3" />
+                  </a>
+                )}
+              </div>
+            ))}
+          </div>
+        </Panel>
+      )}
+
+      {/* Real per-pool / per-node rollout progress */}
+      {showRollout && (
+        <Panel title="Node Rollout Progress" icon={<Server className="w-4 h-4 text-blue-500" />}>
+          <div className="space-y-4">
+            <div className={cn('flex items-center gap-2 text-xs px-2.5 py-1.5 rounded-sm', eta.isEvidenceBased ? 'bg-blue-950/30 text-blue-300' : 'bg-slate-800/50 text-slate-400')}>
+              <Clock className="w-3.5 h-3.5 shrink-0" />
+              {eta.label}
+            </div>
+
+            {poolProgress.length > 0 && (
+              <div className="space-y-3">
+                {poolProgress.map((pool) => (
+                  <div key={pool.name}>
+                    <div className="flex items-center justify-between text-sm mb-1">
+                      <span className="flex items-center gap-2 text-slate-200">
+                        {pool.name}
+                        {pool.isDegraded && <span className="text-xs px-1.5 py-0.5 bg-red-900/50 text-red-300 rounded-sm">Degraded</span>}
+                        {pool.isUpdating && <span className="text-xs px-1.5 py-0.5 bg-blue-900/50 text-blue-300 rounded-sm">Updating</span>}
+                      </span>
+                      <span className="text-xs font-mono text-slate-400">{pool.updatedMachineCount}/{pool.machineCount} nodes updated</span>
+                    </div>
+                    <div className="h-1.5 bg-slate-800 rounded-full overflow-hidden">
+                      <div
+                        className={cn('h-full rounded-full', pool.isDegraded ? 'bg-red-500' : 'bg-blue-500')}
+                        style={{ width: `${pool.machineCount > 0 ? (pool.updatedMachineCount / pool.machineCount) * 100 : 0}%` }}
+                      />
+                    </div>
+                    {pool.degradedMessage && <p className="text-xs text-red-400/80 mt-1">{pool.degradedMessage}</p>}
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {nodesInRollout.length > 0 && (
+              <div>
+                <div className="text-xs text-slate-400 mb-1.5">Nodes in rollout ({nodesInRollout.length})</div>
+                <div className="space-y-1 max-h-48 overflow-auto">
+                  {nodesInRollout.map((n) => (
+                    <div key={n.name} className="flex items-center justify-between py-1 px-2 text-xs hover:bg-slate-800/30 rounded-sm">
+                      <span className="font-mono text-slate-300 truncate">{n.name}</span>
+                      <span className={cn('px-1.5 py-0.5 rounded-sm shrink-0 ml-2', n.mcoState === 'Degraded' ? 'bg-red-900/50 text-red-300' : 'bg-blue-900/50 text-blue-300')}>
+                        {n.mcoState}{n.reason ? `: ${n.reason}` : ''}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </Panel>
+      )}
+
+      {/* Drain blockers — nodes/PDBs that can stall a rollout indefinitely */}
+      {showRollout && (drainBlockingNodes.length > 0 || blockingPdbs.length > 0) && (
+        <Panel title="Drain Blockers" icon={<Ban className="w-4 h-4 text-red-500" />}>
+          <div className="space-y-2">
+            {drainBlockingNodes.map((n) => (
+              <div key={n.name} className="flex items-start gap-2 p-2 rounded-sm bg-red-950/20 border border-red-900/30">
+                <XCircle className="w-3.5 h-3.5 text-red-400 shrink-0 mt-0.5" />
+                <div className="text-xs">
+                  <span className="font-mono text-red-300">{n.name}</span>
+                  <span className="text-slate-400 ml-2">
+                    {[n.unschedulable && 'cordoned/unschedulable', !n.ready && 'NotReady'].filter(Boolean).join(', ')} \u2014 can stall a drain indefinitely
+                  </span>
+                </div>
+              </div>
+            ))}
+            {blockingPdbs.map((pdb) => (
+              <div key={`${pdb.namespace}/${pdb.name}`} className="flex items-start gap-2 p-2 rounded-sm bg-red-950/20 border border-red-900/30">
+                <Ban className="w-3.5 h-3.5 text-red-400 shrink-0 mt-0.5" />
+                <div className="text-xs">
+                  <span className="font-mono text-red-300">{pdb.namespace}/{pdb.name}</span>
+                  <span className="text-slate-400 ml-2">allows 0 disruptions \u2014 blocks draining {pdb.blockedNodeNames.join(', ')}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </Panel>
+      )}
+    </div>
+  );
+}

--- a/src/kubeview/views/admin/UpgradeProgressPanel.tsx
+++ b/src/kubeview/views/admin/UpgradeProgressPanel.tsx
@@ -69,13 +69,13 @@ export function UpgradeProgressPanel({
           <div className="flex items-start gap-3">
             <AlertOctagon className="w-5 h-5 text-red-400 shrink-0 mt-0.5" />
             <div className="flex-1 min-w-0">
-              <div className="text-sm font-medium text-red-300">Update appears stuck \u2014 requested {mismatch.mismatchKind} does not match what&apos;s active</div>
+              <div className="text-sm font-medium text-red-300">Update appears stuck {'\u2014'} requested {mismatch.mismatchKind} does not match what&apos;s active</div>
               <div className="text-xs text-slate-400 mt-1">
                 <span className="text-slate-300">spec.desiredUpdate</span> requests <span className="font-mono text-slate-300">{mismatch.requestedVersion}</span>
-                {mismatch.requestedImage && <> (<span className="font-mono text-slate-300">{mismatch.requestedImage.slice(0, 28)}\u2026</span>)</>}
+                {mismatch.requestedImage && <> (<span className="font-mono text-slate-300">{mismatch.requestedImage.slice(0, 28)}{'\u2026'}</span>)</>}
                 {', but the cluster is still targeting '}
                 <span className="font-mono text-slate-300">{mismatch.actualVersion || '\u2014'}</span>
-                {mismatch.actualImage && <> (<span className="font-mono text-slate-300">{mismatch.actualImage.slice(0, 28)}\u2026</span>)</>}
+                {mismatch.actualImage && <> (<span className="font-mono text-slate-300">{mismatch.actualImage.slice(0, 28)}{'\u2026'}</span>)</>}
                 {'. cluster-version-operator treats '}{mismatch.mismatchKind}{' as authoritative and has not started \u2014 '}
                 {mismatch.minutesSinceProgressingStable !== null
                   ? `no progress for ${mismatch.minutesSinceProgressingStable} min.`
@@ -91,7 +91,7 @@ export function UpgradeProgressPanel({
                   </button>
                 ) : (
                   <span className="text-xs text-slate-500">
-                    {mismatch.requestedVersion} is no longer listed under Available Updates below \u2014 select it again once it reappears, or correct spec.desiredUpdate directly with <code className="mx-1 px-1 bg-slate-800 rounded-sm">oc adm upgrade --to-image=&lt;correct digest&gt;</code>.
+                    {mismatch.requestedVersion} is no longer listed under Available Updates below {'\u2014'} select it again once it reappears, or correct spec.desiredUpdate directly with <code className="mx-1 px-1 bg-slate-800 rounded-sm">oc adm upgrade --to-image=&lt;correct digest&gt;</code>.
                   </span>
                 )}
               </div>
@@ -115,7 +115,7 @@ export function UpgradeProgressPanel({
                 </div>
               ) : (
                 <p className="text-xs text-slate-500 mt-2">
-                  Boundaries like this commonly require an administrator acknowledgment \u2014 run <code className="mx-1 px-1 bg-slate-800 rounded-sm">oc adm upgrade</code> for the exact <code className="mx-1 px-1 bg-slate-800 rounded-sm">admin-acks</code> ConfigMap key this cluster needs before the update can proceed.
+                  Boundaries like this commonly require an administrator acknowledgment {'\u2014'} run <code className="mx-1 px-1 bg-slate-800 rounded-sm">oc adm upgrade</code> for the exact <code className="mx-1 px-1 bg-slate-800 rounded-sm">admin-acks</code> ConfigMap key this cluster needs before the update can proceed.
                 </p>
               )}
             </div>
@@ -207,7 +207,7 @@ export function UpgradeProgressPanel({
                 <div className="text-xs">
                   <span className="font-mono text-red-300">{n.name}</span>
                   <span className="text-slate-400 ml-2">
-                    {[n.unschedulable && 'cordoned/unschedulable', !n.ready && 'NotReady'].filter(Boolean).join(', ')} \u2014 can stall a drain indefinitely
+                    {[n.unschedulable && 'cordoned/unschedulable', !n.ready && 'NotReady'].filter(Boolean).join(', ')} {'\u2014'} can stall a drain indefinitely
                   </span>
                 </div>
               </div>
@@ -217,7 +217,7 @@ export function UpgradeProgressPanel({
                 <Ban className="w-3.5 h-3.5 text-red-400 shrink-0 mt-0.5" />
                 <div className="text-xs">
                   <span className="font-mono text-red-300">{pdb.namespace}/{pdb.name}</span>
-                  <span className="text-slate-400 ml-2">allows 0 disruptions \u2014 blocks draining {pdb.blockedNodeNames.join(', ')}</span>
+                  <span className="text-slate-400 ml-2">allows 0 disruptions {'\u2014'} blocks draining {pdb.blockedNodeNames.join(', ')}</span>
                 </div>
               </div>
             ))}

--- a/src/kubeview/views/admin/__tests__/UpdatesTab.test.tsx
+++ b/src/kubeview/views/admin/__tests__/UpdatesTab.test.tsx
@@ -5,7 +5,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 
-import type { ClusterVersion } from '../../../engine/types';
+import type { ClusterVersion, ClusterOperator, Node, MachineConfigPool, Pod } from '../../../engine/types';
 import type { UpdatesTabProps } from '../UpdatesTab';
 
 // --- Mocks ---
@@ -49,6 +49,9 @@ function renderTab(props: Partial<UpdatesTabProps> = {}) {
     pdbs: [],
     etcdBackupExists: false,
     isHyperShift: false,
+    machineConfigPools: [],
+    pods: [],
+    go: vi.fn(),
     ...props,
   };
 
@@ -356,5 +359,123 @@ describe('UpdatesTab', () => {
     });
 
     expect(screen.getByText('Managed by hosting provider')).toBeDefined();
+  });
+
+  it('shows the actual Degraded condition message on operators, not just a badge, and links to the operator detail page', () => {
+    const go = vi.fn();
+    const operators: ClusterOperator[] = [{
+      apiVersion: 'config.openshift.io/v1', kind: 'ClusterOperator',
+      metadata: { name: 'etcd', uid: 'co-etcd', creationTimestamp: '2026-01-01T00:00:00Z' },
+      status: {
+        conditions: [
+          { type: 'Available', status: 'False' },
+          { type: 'Degraded', status: 'True', message: 'EtcdMembersDegraded: 1 of 3 members are unhealthy' },
+        ],
+      },
+    }];
+
+    renderTab({ isUpdating: true, operators, go });
+
+    expect(screen.getByText('EtcdMembersDegraded: 1 of 3 members are unhealthy')).toBeDefined();
+    fireEvent.click(screen.getByText('etcd'));
+    expect(go).toHaveBeenCalledWith('/r/config.openshift.io~v1~clusteroperators/_/etcd', 'etcd');
+  });
+
+  // Regression: this is the read-path counterpart to the stale-image write-path
+  // fix (#50) — spec.desiredUpdate can also be set directly by other tooling
+  // (e.g. `oc adm upgrade`), so the UI must still be able to detect and explain
+  // a stuck/no-op update even when this app's own PATCH logic wasn't involved.
+  it('shows a stuck-update banner with a working Re-apply button when spec.desiredUpdate silently no-ops', async () => {
+    const cv = makeClusterVersion({
+      spec: { desiredUpdate: { version: '4.21.28', image: 'quay.io/openshift-release-dev/ocp-release@sha256:oldimage' } },
+      status: {
+        desired: { version: '4.21.27', image: 'quay.io/openshift-release-dev/ocp-release@sha256:oldimage' },
+        conditions: [{ type: 'Progressing', status: 'False', lastTransitionTime: new Date(Date.now() - 10 * 60000).toISOString() }],
+        history: [],
+      },
+    });
+
+    renderTab({
+      clusterVersion: cv,
+      availableUpdates: [{ version: '4.21.28', image: 'quay.io/openshift-release-dev/ocp-release@sha256:correct-new-image' }],
+    });
+
+    expect(screen.getByText(/Update appears stuck/)).toBeDefined();
+
+    const { k8sPatch } = await import('../../../engine/query');
+    fireEvent.click(screen.getByText('Re-apply update to 4.21.28'));
+    fireEvent.click(screen.getByText('Start Update'));
+    await vi.waitFor(() => {
+      expect(k8sPatch).toHaveBeenCalledWith(
+        '/apis/config.openshift.io/v1/clusterversions/version',
+        { spec: { desiredUpdate: { version: '4.21.28', image: 'quay.io/openshift-release-dev/ocp-release@sha256:correct-new-image' } } },
+        'application/merge-patch+json',
+      );
+    });
+  });
+
+  it('does not show a stuck-update banner while a real update is progressing', () => {
+    const cv = makeClusterVersion({
+      spec: { desiredUpdate: { version: '4.21.28', image: 'sha256:new' } },
+      status: {
+        desired: { version: '4.21.27', image: 'sha256:old' },
+        conditions: [{ type: 'Progressing', status: 'True', message: 'Working towards 4.21.28', lastTransitionTime: new Date().toISOString() }],
+        history: [],
+      },
+    });
+    renderTab({ clusterVersion: cv, isUpdating: true });
+    expect(screen.queryByText(/Update appears stuck/)).toBeNull();
+  });
+
+  it('shows real MachineConfigPool rollout progress during an update', () => {
+    const pools: MachineConfigPool[] = [{
+      apiVersion: 'machineconfiguration.openshift.io/v1', kind: 'MachineConfigPool',
+      metadata: { name: 'worker', uid: 'mcp-worker', creationTimestamp: '2026-01-01T00:00:00Z' },
+      status: {
+        machineCount: 6, updatedMachineCount: 3, readyMachineCount: 3, degradedMachineCount: 0, unavailableMachineCount: 0,
+        conditions: [{ type: 'Updated', status: 'False' }, { type: 'Updating', status: 'True' }, { type: 'Degraded', status: 'False' }],
+      },
+    }];
+
+    renderTab({ isUpdating: true, machineConfigPools: pools });
+
+    expect(screen.getByText('Node Rollout Progress')).toBeDefined();
+    expect(screen.getByText('worker')).toBeDefined();
+    expect(screen.getByText('3/6 nodes updated')).toBeDefined();
+  });
+
+  it('shows a PDB drain blocker when it has 0 disruptions allowed and covers a pod on a node mid-rollout', () => {
+    const nodes: Node[] = [{
+      apiVersion: 'v1', kind: 'Node',
+      metadata: {
+        name: 'worker-1', uid: 'node-worker-1', creationTimestamp: '2026-01-01T00:00:00Z',
+        annotations: {
+          'machineconfiguration.openshift.io/state': 'Working',
+          'machineconfiguration.openshift.io/desiredConfig': 'rendered-worker-new',
+          'machineconfiguration.openshift.io/currentConfig': 'rendered-worker-old',
+        },
+      },
+      status: { conditions: [{ type: 'Ready', status: 'True' }] },
+    }];
+    const pods: Pod[] = [{
+      apiVersion: 'v1', kind: 'Pod',
+      metadata: { name: 'checkout-1', namespace: 'checkout', uid: 'pod-1', creationTimestamp: '2026-01-01T00:00:00Z', labels: { app: 'checkout' } },
+      spec: { containers: [], nodeName: 'worker-1' },
+    }];
+
+    renderTab({
+      isUpdating: true,
+      nodes,
+      pdbs: [{
+        apiVersion: 'policy/v1', kind: 'PodDisruptionBudget',
+        metadata: { name: 'checkout-pdb', namespace: 'checkout', uid: 'pdb-1' },
+        spec: { selector: { matchLabels: { app: 'checkout' } } },
+        status: { disruptionsAllowed: 0 },
+      }],
+      pods,
+    });
+
+    expect(screen.getByText('Drain Blockers')).toBeDefined();
+    expect(screen.getByText('checkout/checkout-pdb')).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary
The Updates tab previously showed only a generic "Update in Progress" spinner, a flat `nodes.length * 10min` duration guess, and a simple Progressing/Degraded/Ready badge per operator — no way to tell *why* a rollout was stalled, which node/operator/PDB was actually blocking it, or whether it had silently stopped altogether. #50 fixed one specific cause of that last case (a stale `spec.desiredUpdate.image` silently pairing with a new version), but there was still no way for a user to *notice* that class of problem from the UI, and no coverage for the other real ways an OpenShift upgrade can get stuck.

This adds `engine/upgradeHealth.ts` — pure, unit-tested functions that derive every signal from real API objects already available in this app (`ClusterVersion`, `MachineConfigPool`, `Node`, `ClusterOperator`, PDBs) — no fabricated percentages, ETAs, or risk text:

- **Real per-pool / per-node rollout progress.** `MachineConfigPool.status.updatedMachineCount/machineCount` per pool (e.g. "3/6 worker nodes updated"), plus per-node status cross-referenced from the real `machineconfiguration.openshift.io/state`, `desiredConfig`, `currentConfig` node annotations. Rendered in a new `UpgradeProgressPanel`.
- **Read-path stuck-update detection.** Compares `spec.desiredUpdate.version/.image` against `status.desired.version/.image` once the `Progressing` condition has stayed `False` for a grace period (using its real `lastTransitionTime`, not a fabricated clock) — flags the stale-image/no-op bug class even when triggered outside this UI (e.g. `oc adm upgrade`, another tool). Includes a "Re-apply update" action that reuses the same version+image PATCH path #50 already fixed.
- **`Upgradeable=False` / admin-ack blockers.** Surfaces the real condition message and reason, and extracts a literal `oc ... patch configmap admin-acks ...` command from the message when CVO includes one, instead of guessing at a cluster/version-specific ConfigMap key.
- **Conditional update risks.** `status.conditionalUpdates[].risks[]` surfaced verbatim (message + url) — distinct from `availableUpdates`.
- **Drain blockers.** PodDisruptionBudgets with `disruptionsAllowed === 0` covering a pod on a node that's mid-rollout, and cordoned/unschedulable/NotReady nodes, both surfaced with the specific resource name.
- **Evidence-based ETA.** Once a pool has real progress, ETA is derived from the observed update rate (elapsed time since `Progressing` went `True`, divided by nodes updated so far) instead of a flat per-node guess. Falls back to the original rough estimate — now clearly labeled as such — when there's no progress yet to extrapolate from.
- **Enriched Operator Update Progress.** Each operator now shows its actual `Degraded`/`Progressing` condition message and links to its detail page, instead of just a color-coded badge.

## Test plan
- [x] `engine/__tests__/upgradeHealth.test.ts` — 37 new unit tests for every pure function (MCP progress, node rollout status, PDB blocker correlation, desiredUpdate mismatch detection, admin-ack extraction, conditional risks, degraded operators, evidence-based ETA)
- [x] `views/admin/__tests__/UpdatesTab.test.tsx` — 5 new integration tests (stuck-update banner + working Re-apply button, no false-positive while genuinely progressing, MachineConfigPool progress rendering, PDB drain blocker rendering, operator message + detail-page link) plus all 21 pre-existing tests still pass unchanged
- [x] Confirmed the 3 most important new tests (`detectDesiredUpdateMismatch`, `estimateUpgradeEta` evidence-based branch, and the UpdatesTab stuck-banner integration test) fail with clear assertion errors when their corresponding logic is reverted, and pass again once restored
- [x] `tsc --noEmit` — clean
- [x] `eslint` on all changed/new files — 0 errors, 0 *new* warnings (18 total, all pre-existing lines; full-repo warning count actually dropped by 1 after removing an unused variable in the block I touched)
- [x] `vitest --run` — 2061/2061 passed (2019 pre-existing + 42 new)
- [x] `npm run build` — clean production build

## Note
Validated the underlying data shapes (`MachineConfigPool.status` fields, node MCO annotations, PDB `disruptionsAllowed`) directly against a live cluster. That cluster currently has no active `desiredUpdate` mismatch, `Upgradeable=False` condition, or `conditionalUpdates` entries, so the stuck/blocked-state UI paths are covered by unit + integration tests with realistic fixtures rather than a live example — flagging this for visibility rather than silently assuming it's been seen working end-to-end on real blocked-state data.

Made with [Cursor](https://cursor.com)