### PR TITLE
fix: session expired modal redirected to '/', never actually logging in

### DIFF
--- a/src/kubeview/components/Shell.tsx
+++ b/src/kubeview/components/Shell.tsx
@@ -32,7 +32,17 @@ function SessionExpiredModal() {
 
   const redirectNow = useCallback(() => {
     disconnectAll();
-    window.location.href = '/';
+    // Must be oauth-proxy's own sign-out endpoint, not '/'. oauth-proxy's
+    // session cookie (--cookie-expire=168h) outlives the underlying OpenShift
+    // OAuth access token it forwards (typically ~24h), so once the access
+    // token expires the cookie itself is still "valid" from oauth-proxy's
+    // perspective. Navigating to '/' re-serves the app under that same
+    // still-valid-but-useless session instead of triggering a fresh login —
+    // which is exactly why this modal appeared to do nothing when clicked.
+    // /oauth/sign_out clears the session cookie server-side first, so the
+    // subsequent redirect to '/' has no session and correctly starts a new
+    // OAuth flow.
+    window.location.href = '/oauth/sign_out';
   }, []);
 
   useEffect(() => {

--- a/src/kubeview/components/__tests__/Shell.test.tsx
+++ b/src/kubeview/components/__tests__/Shell.test.tsx
@@ -261,4 +261,22 @@ describe('Shell', () => {
     expect(screen.getByText('Log in now')).toBeDefined();
     _mockUIState.degradedReasons = new Set();
   });
+
+  // Regression: "Log in now" (and the auto-redirect on countdown) used to
+  // navigate to '/' instead of '/oauth/sign_out'. oauth-proxy's session
+  // cookie outlives the OpenShift OAuth access token it forwards, so '/'
+  // just re-served the app under that same still-"valid" (per oauth-proxy)
+  // but useless session — the modal appeared to do nothing when clicked.
+  // Only /oauth/sign_out actually clears the cookie and forces a fresh login.
+  it('"Log in now" redirects to /oauth/sign_out, not /', () => {
+    _mockUIState.degradedReasons = new Set(['session_expired']);
+    const location = { ...window.location, href: 'http://localhost/' };
+    Object.defineProperty(window, 'location', { value: location, writable: true });
+
+    renderShell();
+    fireEvent.click(screen.getByText('Log in now'));
+
+    expect(window.location.href).toBe('/oauth/sign_out');
+    _mockUIState.degradedReasons = new Set();
+  });
 });


### PR DESCRIPTION
## Summary
"Log in now" on the Session Expired modal (and the auto-redirect after the 10s countdown) navigated to `/` instead of oauth-proxy's own `/oauth/sign_out` endpoint.

oauth-proxy's session cookie (`--cookie-expire=168h`) outlives the OpenShift OAuth access token it forwards to the Kubernetes API (typically ~24h). Once that access token expires and the app's own repeated-401 detection surfaces this modal, oauth-proxy itself still considers the session cookie perfectly valid. Navigating to `/` just re-served the app under that same still-"valid"-to-oauth-proxy-but-now-useless session — landing the user right back where they started. That's exactly why clicking the button appeared to do nothing.

Only `/oauth/sign_out` actually clears the session cookie server-side before redirecting, so the follow-up request to `/` has no session and correctly triggers a fresh OAuth login. This is already the correct, working pattern used by `performLogout()` elsewhere in this codebase (`engine/auth.ts`) — this modal's own redirect just never matched it.

## Fix
Changed `SessionExpiredModal`'s `redirectNow` in `Shell.tsx` to navigate to `/oauth/sign_out` instead of `/`.

## Test plan
- [x] New regression test: clicking "Log in now" sets `window.location.href` to `/oauth/sign_out`
- [x] Full suite: 2062 tests pass
- [x] `eslint`, `tsc --noEmit` — clean (pre-existing warnings only, unrelated to this change)

Made with [Cursor](https://cursor.com)