### PR TITLE
feat: describe the two liveness scanners in the scanner drawer

### DIFF
--- a/src/kubeview/views/mission-control/ScannerDrawer.tsx
+++ b/src/kubeview/views/mission-control/ScannerDrawer.tsx
@@ -24,6 +24,8 @@ const SCANNER_INFO: Record<string, { description: string; autoFixable?: boolean;
   audit_events: { description: 'High-frequency Warning events that may indicate emerging issues', severity: 'info' },
   audit_auth: { description: 'Auth anomalies — kubeadmin usage, login failures, service account token creation', severity: 'info' },
   security_posture: { description: 'Pod security violations — privileged containers, host networking, missing security contexts', severity: 'warning' },
+  stuck: { description: 'Deletions that never completed — namespaces, pods, PVCs, or CRDs held open by a finalizer', severity: 'critical' },
+  hot_loop: { description: 'Controllers burning API server capacity without making progress — sustained work-queue retries or write amplification', severity: 'warning' },
 };
 
 const SEVERITY_COLORS: Record<string, string> = {


### PR DESCRIPTION
Companion to PulseSRE/pulse-agent#20, which adds the `stuck` and `hot_loop` scanners.

`SCANNER_INFO` in the scanner drawer is keyed by scanner name and falls back to no description at all for keys it does not know, so both new scanners would render as bare toggles with nothing explaining what they watch for.