### PR TITLE
fix: Alertmanager receivers proxy path + wrong-API-version CRD probes

### DIFF
--- a/src/kubeview/engine/readiness/__tests__/gates.test.ts
+++ b/src/kubeview/engine/readiness/__tests__/gates.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../../store/uiStore', () => ({
+  useUIStore: {
+    getState: () => ({ addDegradedReason: vi.fn() }),
+  },
+}));
+
+import { ALL_GATES } from '../gates';
+import type { GateContext, ReadinessGate } from '../types';
+
+function findGate(id: string): ReadinessGate {
+  const gate = ALL_GATES.find((g) => g.id === id);
+  if (!gate) throw new Error(`gate not found: ${id}`);
+  return gate;
+}
+
+function makeCtx(fetchJson: GateContext['fetchJson']): GateContext {
+  return {
+    fetchJson,
+    fetchAgent: vi.fn(),
+    isHyperShift: false,
+  };
+}
+
+/** Simulates the 404 a real cluster returns for a CRD/resource that isn't installed. */
+function notFound(): never {
+  const err = Object.assign(new Error('not found'), { status: 404 });
+  throw err;
+}
+
+describe('notification-routing gate', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('reads receivers through the dedicated /api/alertmanager/ proxy, not the K8s service-proxy subresource', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([{ name: 'Default' }, { name: 'Critical' }]),
+    });
+
+    const result = await findGate('notification-routing').evaluate(makeCtx(vi.fn()));
+
+    // Regression guard: this must NOT be
+    // '/api/v1/namespaces/openshift-monitoring/services/alertmanager-main:web/proxy/api/v2/receivers'
+    // (the K8s API server's service-proxy subresource) — that path 400s
+    // because the apiserver defaults to plain HTTP for the unprefixed "web"
+    // port name against Alertmanager's TLS listener, and even corrected for
+    // scheme, it does not forward the caller's bearer token to the backend.
+    expect(global.fetch).toHaveBeenCalledWith('/api/alertmanager/api/v2/receivers');
+    expect(result.status).toBe('passed');
+    expect(result.detail).toBe('1 receiver configured');
+  });
+
+  it('reports not_started (not an unhandled rejection) when Alertmanager is unreachable', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 502,
+      statusText: 'Bad Gateway',
+    });
+
+    const result = await findGate('notification-routing').evaluate(makeCtx(vi.fn()));
+
+    expect(result.status).toBe('not_started');
+    expect(result.detail).toBe('Alertmanager not reachable');
+  });
+});
+
+describe('etcd-backup gate', () => {
+  it('probes config.openshift.io/v1alpha1/backups, not the nonexistent v1', async () => {
+    const fetchJson = vi.fn(async (path: string) => {
+      if (path === '/apis/config.openshift.io/v1alpha1/backups') {
+        return { items: [{ metadata: { name: 'cluster' } }] };
+      }
+      return notFound();
+    });
+
+    const result = await findGate('etcd-backup').evaluate(makeCtx(fetchJson));
+
+    expect(fetchJson).toHaveBeenCalledWith('/apis/config.openshift.io/v1alpha1/backups');
+    expect(fetchJson).not.toHaveBeenCalledWith('/apis/config.openshift.io/v1/backups');
+    expect(result.status).toBe('passed');
+  });
+
+  it('reports needs_attention when no Backup resource exists', async () => {
+    const fetchJson = vi.fn(async () => notFound());
+
+    const result = await findGate('etcd-backup').evaluate(makeCtx(fetchJson));
+
+    expect(result.status).toBe('needs_attention');
+  });
+});
+
+describe('log-forwarding gate', () => {
+  it('detects a ClusterLogForwarder under the current observability.openshift.io group (Logging 6.0+)', async () => {
+    const fetchJson = vi.fn(async (path: string) => {
+      if (path === '/apis/observability.openshift.io/v1/clusterlogforwarders') {
+        return { items: [{ metadata: { name: 'instance' } }] };
+      }
+      return notFound();
+    });
+
+    const result = await findGate('log-forwarding').evaluate(makeCtx(fetchJson));
+
+    expect(fetchJson).toHaveBeenCalledWith('/apis/observability.openshift.io/v1/clusterlogforwarders');
+    expect(result.status).toBe('passed');
+  });
+
+  it('still detects a legacy logging.openshift.io/v1 ClusterLogForwarder (Logging 5.x)', async () => {
+    const fetchJson = vi.fn(async (path: string) => {
+      if (path === '/apis/logging.openshift.io/v1/clusterlogforwarders') {
+        return { items: [{ metadata: { name: 'instance' } }] };
+      }
+      return notFound();
+    });
+
+    const result = await findGate('log-forwarding').evaluate(makeCtx(fetchJson));
+
+    expect(fetchJson).toHaveBeenCalledWith('/apis/logging.openshift.io/v1/clusterlogforwarders');
+    expect(result.status).toBe('passed');
+  });
+
+  it('reports needs_attention when neither group has a forwarder', async () => {
+    const fetchJson = vi.fn(async () => notFound());
+
+    const result = await findGate('log-forwarding').evaluate(makeCtx(fetchJson));
+
+    expect(result.status).toBe('needs_attention');
+  });
+});

--- a/src/kubeview/engine/readiness/gates.ts
+++ b/src/kubeview/engine/readiness/gates.ts
@@ -264,7 +264,17 @@ const logForwarding: ReadinessGate = {
   category: 'observability',
   priority: 'recommended',
   evaluate: (ctx) => safeEval(logForwarding, async () => {
-    const items = await listItems(ctx, '/apis/logging.openshift.io/v1/clusterlogforwarders');
+    // Logging 6.0+ (current) serves ClusterLogForwarder under
+    // observability.openshift.io/v1 — logging.openshift.io/v1 was removed
+    // for that resource (see Red Hat OpenShift Logging 6.0 release notes,
+    // LOG-5803). Older 5.x installs may still only have the legacy group,
+    // so check both rather than assuming one; either finding a forwarder
+    // means the gate passes.
+    const [current, legacy] = await Promise.all([
+      safeQuery(() => listItems(ctx, '/apis/observability.openshift.io/v1/clusterlogforwarders')).then(r => r ?? []),
+      safeQuery(() => listItems(ctx, '/apis/logging.openshift.io/v1/clusterlogforwarders')).then(r => r ?? []),
+    ]);
+    const items = [...current, ...legacy];
     return {
       status: items.length > 0 ? 'passed' : 'needs_attention',
       detail: items.length > 0 ? 'Configured' : 'Not configured — logs only available on cluster',
@@ -409,7 +419,11 @@ const etcdBackup: ReadinessGate = {
   priority: 'blocking',
   evaluate: (ctx) => safeEval(etcdBackup, async () => {
     if (ctx.isHyperShift) return { status: 'passed', detail: 'Managed by hosting provider', fixGuidance: '' };
-    const items = (await safeQuery(() => listItems(ctx, '/apis/config.openshift.io/v1/backups'))) ?? [];
+    // Backup is served at config.openshift.io/v1alpha1 (feature-gated by
+    // AutomatedEtcdBackup), not v1 — see openshift/api's
+    // config/v1alpha1/types_backup.go. v1 has never existed for this
+    // resource, so probing it always 404s even when backups are configured.
+    const items = (await safeQuery(() => listItems(ctx, '/apis/config.openshift.io/v1alpha1/backups'))) ?? [];
     return {
       status: items.length > 0 ? 'passed' : 'needs_attention',
       detail: items.length > 0 ? 'Backup configured' : 'No automated backup configured',
@@ -458,9 +472,20 @@ const notificationRouting: ReadinessGate = {
   whyItMatters: 'Without notification routing, alerts fire silently. Teams are not notified of critical issues until they discover them manually.',
   category: 'operations',
   priority: 'recommended',
-  evaluate: (ctx) => safeEval(notificationRouting, async () => {
+  evaluate: (_ctx) => safeEval(notificationRouting, async () => {
     try {
-      const receivers = await ctx.fetchJson<any[]>('/api/v1/namespaces/openshift-monitoring/services/alertmanager-main:web/proxy/api/v2/receivers');
+      // Go through the operator's dedicated /api/alertmanager/ proxy (same
+      // path AlertsView uses for silences) rather than the generic
+      // Kubernetes API server service-proxy subresource: the apiserver's
+      // service proxy assumes plain HTTP for a port named "web" (no
+      // "https:" scheme prefix), which Alertmanager's TLS-terminating
+      // listener rejects with a raw "Client sent an HTTP request to an
+      // HTTPS server." 400 — and even with the scheme prefix, that proxy
+      // path does not forward the caller's bearer token to the backend, so
+      // Alertmanager's kube-rbac-proxy sidecar then rejects it with 401.
+      const res = await fetch('/api/alertmanager/api/v2/receivers');
+      if (!res.ok) throw new Error(`Alertmanager returned ${res.status} ${res.statusText}`);
+      const receivers = (await res.json()) as any[];
       const nonDefault = (receivers || []).filter((r: any) => r.name !== 'Default' && r.name !== 'null' && r.name !== 'watchdog');
       return {
         status: nonDefault.length > 0 ? 'passed' : 'needs_attention',

--- a/src/kubeview/views/AdminView.tsx
+++ b/src/kubeview/views/AdminView.tsx
@@ -281,7 +281,9 @@ export default function AdminView() {
 
   const { data: etcdBackupExists } = useQuery({
     queryKey: ['admin', 'etcd-backup'],
-    queryFn: async () => { const items = await safeQuery(() => k8sList('/apis/config.openshift.io/v1/backups')); return items ? items.length > 0 : false; },
+    // Backup is served at config.openshift.io/v1alpha1 (feature-gated by
+    // AutomatedEtcdBackup), not v1 — v1 has never existed for this resource.
+    queryFn: async () => { const items = await safeQuery(() => k8sList('/apis/config.openshift.io/v1alpha1/backups')); return items ? items.length > 0 : false; },
     staleTime: 60000,
   });
 


### PR DESCRIPTION
## Summary

Fixes browser console errors reported on the live Pulse UI, investigated against `pulse-operator`'s nginx proxy config and a live OpenShift cluster.

**Alertmanager receivers (real bug — functional, not just noise)**

The `notification-routing` readiness gate fetched `/api/v2/receivers` through the generic Kubernetes API server service-proxy subresource:

```
/api/v1/namespaces/openshift-monitoring/services/alertmanager-main:web/proxy/api/v2/receivers
```

instead of the operator's purpose-built `/api/alertmanager/` nginx location that `AlertsView` already uses for silences. Confirmed live against the cluster:

- Direct `alertmanager-main.openshift-monitoring.svc:9094/api/v2/receivers` → `200`, `[{"name":"Default"},{"name":"Watchdog"},{"name":"Critical"}]`
- Same request via the K8s API server's service-proxy subresource (the browser's actual request pattern) → `400 Client sent an HTTP request to an HTTPS server.` (apiserver defaults to plain HTTP for the unprefixed `web` port name against Alertmanager's TLS-terminating listener)
- Same request with an `https:` port-name prefix (`services/https:alertmanager-main:web/proxy/...`) → `401 Unauthorized` (the apiserver's service-proxy does not forward the caller's bearer token to the backend, so Alertmanager's kube-rbac-proxy sidecar rejects it)
- Same request through nginx's existing `/api/alertmanager/api/v2/receivers` location (exec'd into the UI pod) → `200`, same receivers JSON

Fix: use `fetch('/api/alertmanager/api/v2/receivers')` directly, matching the existing silences pattern. No `pulse-operator`/nginx changes needed — the `/api/alertmanager/` location already proxies this path correctly.

**CRD-probe 404s (mixed: two benign, two real wrong-API-version bugs)**

- `external-secrets.io/v1beta1/externalsecrets`, `bitnami.com/v1alpha1/sealedsecrets` — verified correct, currently-served group/versions for those upstream projects. Already handled gracefully via `safeQuery` (404 → `null`, no throw). **Benign — no change.**
- `config.openshift.io/v1/backups` — **real bug.** That version has never existed for this resource; the real one is `v1alpha1` (feature-gated by `AutomatedEtcdBackup`, see `openshift/api`'s `config/v1alpha1/types_backup.go`). Fixed in both the `etcd-backup` gate and `AdminView`'s etcd-backup check — previously this always reported "not configured" even on a cluster where it genuinely was.
- `logging.openshift.io/v1/clusterlogforwarders` — **real bug**, different flavor: Logging 6.0+ serves `ClusterLogForwarder` under `observability.openshift.io/v1` only (`logging.openshift.io/v1` was removed for this resource per the 6.0 release notes); the rest of this codebase (`TemplatesTab`, `OperatorCatalogView`) already assumes the new group, but this gate only checked the old one. Fixed to check both, so it works for clusters on either the current or legacy logging stack.

## Test plan

- [x] `pnpm run type-check` — clean
- [x] `pnpm run lint` — 0 errors, no new warnings introduced
- [x] `pnpm exec vitest --run` — 2069/2069 passed (including 7 new tests in `src/kubeview/engine/readiness/__tests__/gates.test.ts` covering the receivers proxy path and both CRD-probe fixes)
- [x] `pnpm run build` — succeeds
- [x] Reproduced the original 400/`ERR_INCOMPLETE_CHUNKED_ENCODING` against the live cluster, confirmed root cause via direct curl comparisons (see above), and confirmed the new `/api/alertmanager/api/v2/receivers` path returns `200` with real data through the deployed nginx proxy

Made with [Cursor](https://cursor.com)