### PR TITLE
fix: secrets-mgmt gate and ExternalSecret probes check stale v1beta1 only

### DIFF
--- a/src/kubeview/engine/readiness/__tests__/gates.test.ts
+++ b/src/kubeview/engine/readiness/__tests__/gates.test.ts
@@ -98,6 +98,60 @@ describe('etcd-backup gate', () => {
   });
 });
 
+describe('secrets-mgmt gate', () => {
+  it('detects an ExternalSecret under the current external-secrets.io/v1 (ESO 0.17+)', async () => {
+    const fetchJson = vi.fn(async (path: string) => {
+      if (path === '/apis/external-secrets.io/v1/externalsecrets') {
+        return { items: [{ metadata: { name: 'db-creds' } }] };
+      }
+      return notFound();
+    });
+
+    const result = await findGate('secrets-mgmt').evaluate(makeCtx(fetchJson));
+
+    expect(fetchJson).toHaveBeenCalledWith('/apis/external-secrets.io/v1/externalsecrets');
+    expect(result.status).toBe('passed');
+    expect(result.detail).toBe('1 ExternalSecret');
+  });
+
+  it('still detects a legacy external-secrets.io/v1beta1 ExternalSecret (ESO <0.17)', async () => {
+    const fetchJson = vi.fn(async (path: string) => {
+      if (path === '/apis/external-secrets.io/v1beta1/externalsecrets') {
+        return { items: [{ metadata: { name: 'db-creds' } }] };
+      }
+      return notFound();
+    });
+
+    const result = await findGate('secrets-mgmt').evaluate(makeCtx(fetchJson));
+
+    expect(fetchJson).toHaveBeenCalledWith('/apis/external-secrets.io/v1beta1/externalsecrets');
+    expect(result.status).toBe('passed');
+    expect(result.detail).toBe('1 ExternalSecret');
+  });
+
+  it('falls back to SealedSecrets when no ExternalSecret is found on either version', async () => {
+    const fetchJson = vi.fn(async (path: string) => {
+      if (path === '/apis/bitnami.com/v1alpha1/sealedsecrets') {
+        return { items: [{ metadata: { name: 'sealed-1' } }] };
+      }
+      return notFound();
+    });
+
+    const result = await findGate('secrets-mgmt').evaluate(makeCtx(fetchJson));
+
+    expect(result.status).toBe('passed');
+    expect(result.detail).toBe('1 SealedSecret');
+  });
+
+  it('reports needs_attention when no external secrets operator is detected on any version', async () => {
+    const fetchJson = vi.fn(async () => notFound());
+
+    const result = await findGate('secrets-mgmt').evaluate(makeCtx(fetchJson));
+
+    expect(result.status).toBe('needs_attention');
+  });
+});
+
 describe('log-forwarding gate', () => {
   it('detects a ClusterLogForwarder under the current observability.openshift.io group (Logging 6.0+)', async () => {
     const fetchJson = vi.fn(async (path: string) => {

--- a/src/kubeview/engine/readiness/gates.ts
+++ b/src/kubeview/engine/readiness/gates.ts
@@ -223,10 +223,17 @@ const secretsManagement: ReadinessGate = {
   category: 'security',
   priority: 'recommended',
   evaluate: (ctx) => safeEval(secretsManagement, async () => {
-    const [extSecrets, sealedSecrets] = await Promise.all([
+    // ESO 0.17+ (mid-2025) stops serving external-secrets.io/v1beta1 in
+    // favor of v1 (breaking change; see external-secrets/external-secrets#4785
+    // and the v0.17.0 release notes). ESO installs still on <0.17 only serve
+    // v1beta1. Check both rather than assuming one; either finding an
+    // ExternalSecret means the gate passes.
+    const [extSecretsV1, extSecretsV1beta1, sealedSecrets] = await Promise.all([
+      safeQuery(() => listItems(ctx, '/apis/external-secrets.io/v1/externalsecrets')).then(r => r ?? []),
       safeQuery(() => listItems(ctx, '/apis/external-secrets.io/v1beta1/externalsecrets')).then(r => r ?? []),
       safeQuery(() => listItems(ctx, '/apis/bitnami.com/v1alpha1/sealedsecrets')).then(r => r ?? []),
     ]);
+    const extSecrets = [...extSecretsV1, ...extSecretsV1beta1];
     const hasExt = extSecrets.length > 0;
     const hasSealed = sealedSecrets.length > 0;
     if (hasExt) return { status: 'passed', detail: `${extSecrets.length} ExternalSecret${extSecrets.length !== 1 ? 's' : ''}`, fixGuidance: '' };

--- a/src/kubeview/views/OperatorCatalogView.tsx
+++ b/src/kubeview/views/OperatorCatalogView.tsx
@@ -350,8 +350,11 @@ export default function OperatorCatalogView() {
       { title: 'Create a QuayRegistry', description: 'Deploy a Quay registry instance with managed storage and database', path: '/create/quay.redhat.com~v1~quayregistries', label: 'Create QuayRegistry' },
     ];
     if (name.includes('external-secrets')) return [
-      { title: 'Create a SecretStore', description: 'Connect to your secret provider (Vault, AWS Secrets Manager, GCP)', path: '/create/external-secrets.io~v1beta1~secretstores', label: 'Create SecretStore' },
-      { title: 'Create an ExternalSecret', description: 'Sync a secret from your provider into a K8s Secret', path: '/create/external-secrets.io~v1beta1~externalsecrets', label: 'Create ExternalSecret' },
+      // ESO 0.17+ (mid-2025) stopped serving external-secrets.io/v1beta1 —
+      // a fresh catalog install lands on a current ESO version, so these
+      // creation links use v1 (see external-secrets/external-secrets#4785).
+      { title: 'Create a SecretStore', description: 'Connect to your secret provider (Vault, AWS Secrets Manager, GCP)', path: '/create/external-secrets.io~v1~secretstores', label: 'Create SecretStore' },
+      { title: 'Create an ExternalSecret', description: 'Sync a secret from your provider into a K8s Secret', path: '/create/external-secrets.io~v1~externalsecrets', label: 'Create ExternalSecret' },
     ];
     if (name.includes('servicemesh') || name.includes('istio')) return [
       { title: 'Create a ServiceMeshControlPlane', description: 'Deploy the Istio control plane in your namespace', path: '/create/maistra.io~v2~servicemeshcontrolplanes', label: 'Create SMCP' },

--- a/src/kubeview/views/SecurityView.tsx
+++ b/src/kubeview/views/SecurityView.tsx
@@ -72,7 +72,15 @@ export default function SecurityView() {
   });
   const { data: externalSecrets = [] } = useQuery<K8sResource[]>({
     queryKey: ['security', 'externalsecrets'],
-    queryFn: async () => (await safeQuery(() => k8sList<K8sResource>('/apis/external-secrets.io/v1beta1/externalsecrets'))) ?? [],
+    queryFn: async () => {
+      // ESO 0.17+ serves ExternalSecret at v1 (v1beta1 is no longer served);
+      // ESO installs still on <0.17 only serve v1beta1 — check both.
+      const [v1, v1beta1] = await Promise.all([
+        safeQuery(() => k8sList<K8sResource>('/apis/external-secrets.io/v1/externalsecrets')),
+        safeQuery(() => k8sList<K8sResource>('/apis/external-secrets.io/v1beta1/externalsecrets')),
+      ]);
+      return [...(v1 ?? []), ...(v1beta1 ?? [])];
+    },
     staleTime: 120000,
     enabled: hasExternalSecrets,
   });


### PR DESCRIPTION
## Summary

An independent audit flagged that this repo probes for the `ExternalSecret`/`SecretStore` CRDs using the stale `external-secrets.io/v1beta1` API version. Verified against the real, current upstream [`external-secrets/external-secrets`](https://github.com/external-secrets/external-secrets) CRD source (`config/crds/bases/external-secrets.io_externalsecrets.yaml` and `..._secretstores.yaml` on `main`):

- `v1`: `served: true`, `storage: true`
- `v1beta1`: `deprecated: true`, `served: false`, `storage: false`

ESO **0.17.0+** (mid-2025) stopped serving `v1beta1` for these resources — a documented breaking change (see [external-secrets/external-secrets#4785](https://github.com/external-secrets/external-secrets/issues/4785): _"v0.17.0 Stops serving v1beta1 apis. You need to update your manifests from v1beta1 to v1 prior to updating from v0.16 to v0.17."_). On any cluster running ESO 0.17+, this repo's `v1beta1`-only probes always 404 and silently report "no external secrets operator detected" even when ESO is genuinely installed and in use.

Notably, #56 (merged) explicitly looked at this same `external-secrets.io/v1beta1` reference and called it *"correct group/version ... already handled gracefully via safeQuery — verified benign, no change."* That verification was itself incorrect per current upstream source — this is exactly the class of bug the audit caught, and what this PR fixes.

## Complete list of affected files (verified via repo-wide grep for `external-secrets.io`/`externalsecrets`/`ExternalSecret`)

- `src/kubeview/engine/readiness/gates.ts` — `secrets-mgmt` readiness gate
- `src/kubeview/views/SecurityView.tsx` — `externalsecrets` count query feeding the security audit checklist
- `src/kubeview/views/OperatorCatalogView.tsx` — post-install "Create a SecretStore" / "Create an ExternalSecret" guidance links

Two other hits (`TemplatesTab.tsx`'s `sub-externalsecrets` OLM `Subscription` snippet key, and `SnippetEngine.ts`/docs referencing that same key) are **not** affected — they target `operators.coreos.com/v1alpha1` `Subscription` objects, unrelated to the ExternalSecret CRD's own API version.

## Fix

Mirrors #56's `ClusterLogForwarder` dual-group pattern exactly, since ESO is a third-party operator users may have installed at any version:

- **`gates.ts` / `SecurityView.tsx`** (existence probes): check both `external-secrets.io/v1` and `/v1beta1` in parallel via `Promise.all`/`safeQuery`, treating either as "installed" — some clusters are still on ESO <0.17 (only `v1beta1` served), others on 0.17+ (only `v1` served).
- **`OperatorCatalogView.tsx`** (static "create new resource" links, not probes): point at `v1`, matching how this same file already points its `ClusterLogForwarder` creation link at the current/non-legacy group rather than probing for it — a fresh OLM catalog install lands on a current ESO version.

## Tests

Added 4 cases to `gates.test.ts` for the `secrets-mgmt` gate (detects current `v1`, still detects legacy `v1beta1`, falls back to SealedSecrets, `needs_attention` when neither operator is found), following the same style as the 3 `log-forwarding` gate tests #56 added for the analogous `ClusterLogForwarder` fix.

## Test plan

- [x] `pnpm run type-check` — passes
- [x] `pnpm run lint` — 0 errors (pre-existing warnings only, none in touched files)
- [x] `pnpm run test` — 2073/2073 passing across 169 files, including the 4 new `secrets-mgmt` cases
- [x] `pnpm run build` — production build succeeds
- [ ] CI green on this PR

Scope: `pulse-ui` only — no changes to `pulse-operator`, no container image rebuild, no cluster changes.

Made with [Cursor](https://cursor.com)