### PR TITLE
feat: show the cause above its symptoms, and say when Pulse is blind

### DIFF
--- a/src/kubeview/components/__tests__/CapabilityBanner.test.tsx
+++ b/src/kubeview/components/__tests__/CapabilityBanner.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
 import { CapabilityBanner } from '../primitives/CapabilityBanner';
 
 const state: { findings: Array<Record<string, unknown>> } = { findings: [] };
@@ -24,6 +24,10 @@ function finding(over: Record<string, unknown> = {}) {
 }
 
 describe('CapabilityBanner', () => {
+  // No setupFiles in vitest.config.ts, so Testing Library's automatic cleanup
+  // is not installed and renders would otherwise accumulate across tests.
+  afterEach(cleanup);
+
   it('stays out of the way when nothing is degraded', () => {
     state.findings = [];
     const { container } = render(<CapabilityBanner />);

--- a/src/kubeview/components/__tests__/CapabilityBanner.test.tsx
+++ b/src/kubeview/components/__tests__/CapabilityBanner.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CapabilityBanner } from '../primitives/CapabilityBanner';
+
+const state: { findings: Array<Record<string, unknown>> } = { findings: [] };
+
+vi.mock('../../store/monitorStore', () => ({
+  useMonitorStore: (selector: (s: typeof state) => unknown) => selector(state),
+}));
+
+function finding(over: Record<string, unknown> = {}) {
+  return {
+    id: 'f-1',
+    severity: 'warning',
+    category: 'degraded',
+    title: 'Scanner alerts has failed 7 runs in a row',
+    summary: '',
+    resources: [],
+    autoFixable: false,
+    timestamp: 0,
+    ...over,
+  };
+}
+
+describe('CapabilityBanner', () => {
+  it('stays out of the way when nothing is degraded', () => {
+    state.findings = [];
+    const { container } = render(<CapabilityBanner />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('ignores ordinary findings', () => {
+    state.findings = [finding({ category: 'crashloop', title: 'Pod restarting' })];
+    const { container } = render(<CapabilityBanner />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('names what has gone blind', () => {
+    state.findings = [finding()];
+    render(<CapabilityBanner />);
+    expect(screen.getByRole('alert')).toBeTruthy();
+    expect(screen.getByText(/Scanner alerts has failed 7 runs/)).toBeTruthy();
+  });
+
+  it('says that missing findings mean unknown, not clear', () => {
+    state.findings = [finding()];
+    render(<CapabilityBanner />);
+    expect(screen.getByText(/unknown rather than clear/i)).toBeTruthy();
+  });
+
+  it('counts multiple degraded capabilities', () => {
+    state.findings = [finding(), finding({ id: 'f-2', title: 'AI investigations failing — 1111 in a row' })];
+    render(<CapabilityBanner />);
+    expect(screen.getByText(/2 capabilities affected/)).toBeTruthy();
+  });
+
+  it('escalates when a capability is critically degraded', () => {
+    state.findings = [finding({ severity: 'critical', title: 'AI investigations failing — 1111 in a row' })];
+    render(<CapabilityBanner />);
+    expect(screen.getByRole('alert').className).toContain('red');
+  });
+});

--- a/src/kubeview/components/primitives/CapabilityBanner.tsx
+++ b/src/kubeview/components/primitives/CapabilityBanner.tsx
@@ -1,0 +1,61 @@
+import { AlertTriangle, EyeOff } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useMonitorStore } from '../../store/monitorStore';
+
+/**
+ * Surfaces the agent's own broken parts above the content they should be filling.
+ *
+ * The agent raises findings in the `degraded` category when one of its scanners
+ * has failed several runs in a row, or when investigations stop coming back.
+ * Those would otherwise land in the inbox as ordinary rows — which is how the
+ * problem stays invisible: on the reference cluster 1,155 of 1,177
+ * investigations had failed and the only visible effect was an empty panel,
+ * which reads as "nothing worth investigating".
+ *
+ * A banner rather than a row, because the point is that what you are looking at
+ * is incomplete. That has to be visible without scrolling a queue.
+ */
+export function CapabilityBanner({ className }: { className?: string }) {
+  const findings = useMonitorStore((s) => s.findings);
+  const degraded = findings.filter((f) => f.category === 'degraded');
+
+  if (degraded.length === 0) return null;
+
+  const critical = degraded.some((f) => f.severity === 'critical');
+
+  return (
+    <div
+      role="alert"
+      className={cn(
+        'flex items-start gap-2 border px-3 py-2 text-xs',
+        critical
+          ? 'border-red-500/25 bg-red-500/10 text-red-300'
+          : 'border-amber-500/20 bg-amber-500/10 text-amber-300',
+        className,
+      )}
+    >
+      {critical ? (
+        <EyeOff className="mt-0.5 h-3.5 w-3.5 shrink-0 text-red-400" />
+      ) : (
+        <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-400" />
+      )}
+      <div className="min-w-0 flex-1">
+        <div className={cn('font-medium', critical ? 'text-red-200' : 'text-amber-200')}>
+          {degraded.length === 1
+            ? 'Pulse is not seeing everything'
+            : `Pulse is not seeing everything — ${degraded.length} capabilities affected`}
+        </div>
+        <ul className="mt-1 space-y-0.5">
+          {degraded.map((f) => (
+            <li key={f.id} className={critical ? 'text-red-300/80' : 'text-amber-300/80'}>
+              {f.title}
+            </li>
+          ))}
+        </ul>
+        <p className={cn('mt-1', critical ? 'text-red-300/60' : 'text-amber-300/60')}>
+          Treat anything these cover as unknown rather than clear.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/kubeview/engine/episodeApi.ts
+++ b/src/kubeview/engine/episodeApi.ts
@@ -1,0 +1,73 @@
+/** Typed fetch functions for the agent's episode endpoints.
+ *
+ * An episode is one event with a cause, as opposed to the several findings it
+ * produced. The inbox uses these to show a cause with its symptoms folded
+ * underneath, rather than ranking them beside each other — which is what
+ * happened during a real control-plane outage, where nine "Deployment
+ * degraded" criticals outranked the single etcd warning that caused them.
+ */
+
+import { agentFetch } from './safeQuery';
+
+const AGENT_BASE = '/api/agent';
+
+export interface Episode {
+  id: string;
+  status: 'open' | 'closed';
+  cause_category: string;
+  cause_title: string;
+  cause_finding_id: string | null;
+  cause_layer: number;
+  started_at: number;
+  ended_at: number | null;
+  last_seen_at: number;
+  symptom_count: number;
+  namespaces: string[];
+  correlation_key: string;
+  recurrence_of: string | null;
+}
+
+export interface EpisodeSymptom {
+  episode_id: string;
+  correlation_key: string;
+  category: string;
+  title: string;
+  namespace: string;
+  attached_at: number;
+  detached_at: number | null;
+  detached_by: string | null;
+}
+
+async function get<T>(path: string): Promise<T> {
+  const res = await agentFetch(`${AGENT_BASE}${path}`);
+  if (!res.ok) throw new Error(`Episode API error: ${res.status} on ${path}`);
+  return res.json();
+}
+
+export async function fetchOpenEpisodes(): Promise<Episode[]> {
+  const data = await get<{ episodes: Episode[] }>('/episodes');
+  return data.episodes ?? [];
+}
+
+export async function fetchEpisode(
+  id: string,
+): Promise<{ episode: Episode; symptoms: EpisodeSymptom[] }> {
+  return get(`/episodes/${encodeURIComponent(id)}`);
+}
+
+/**
+ * Tell the agent a symptom was not actually caused by this episode.
+ *
+ * The correction is stored and the symptom is never re-attached. It is also
+ * the only ground truth the agent ever gets about whether its correlation is
+ * right, which is why the control is worth putting in front of people rather
+ * than burying it.
+ */
+export async function detachSymptom(episodeId: string, correlationKey: string): Promise<void> {
+  const res = await agentFetch(`${AGENT_BASE}/episodes/${encodeURIComponent(episodeId)}/detach`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ correlationKey }),
+  });
+  if (!res.ok) throw new Error(`Could not detach symptom: ${res.status}`);
+}

--- a/src/kubeview/views/InboxPage.tsx
+++ b/src/kubeview/views/InboxPage.tsx
@@ -9,6 +9,8 @@ import { InboxHeader } from './inbox/InboxHeader';
 import { InboxFilterBar } from './inbox/InboxFilterBar';
 import { InboxItem } from './inbox/InboxItem';
 import { InboxGroup } from './inbox/InboxGroup';
+import { EpisodePanel } from './inbox/EpisodePanel';
+import { CapabilityBanner } from '../components/primitives/CapabilityBanner';
 import { NewTaskDialog } from './inbox/NewTaskDialog';
 import { TaskDetailDrawer } from './inbox/TaskDetailDrawer';
 import { ActivityTab } from './incidents/ActivityTab';
@@ -115,6 +117,11 @@ export function InboxPage() {
         </div>
 
         <TabsContent value="inbox" className="flex-1 flex flex-col overflow-hidden">
+          {/* What Pulse cannot currently see, before the queue of what it can. */}
+          <CapabilityBanner className="mx-4 mt-3" />
+          {/* Open episodes sit above the queue: a cause with its symptoms
+              folded under it, so the list is not read cause-last. */}
+          <EpisodePanel />
           <InboxFilterBar />
 
           {activePreset === 'archived' && (

--- a/src/kubeview/views/inbox/EpisodePanel.tsx
+++ b/src/kubeview/views/inbox/EpisodePanel.tsx
@@ -1,0 +1,150 @@
+import { useCallback, useEffect, useState } from 'react';
+import { AlertTriangle, Ban, ChevronDown, ChevronRight, History } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { detachSymptom, fetchEpisode, fetchOpenEpisodes } from '../../engine/episodeApi';
+import type { Episode, EpisodeSymptom } from '../../engine/episodeApi';
+
+/**
+ * Shows open episodes above the inbox: a cause, with the findings it explains
+ * folded underneath it.
+ *
+ * The problem this solves is concrete. During a control-plane outage the
+ * monitor produced fourteen findings in one second — nine "Deployment
+ * degraded" rated critical, and one etcd warning that was the cause of all of
+ * them. Ranked by priority, the cause did not make the top thirteen. Reading
+ * that list top-down sends you to the wrong problem.
+ */
+
+function since(startedAt: number): string {
+  const mins = Math.max(0, Math.round((Date.now() / 1000 - startedAt) / 60));
+  if (mins < 60) return `${mins}m`;
+  if (mins < 1440) return `${Math.round(mins / 60)}h`;
+  return `${Math.round(mins / 1440)}d`;
+}
+
+function EpisodeCard({ episode, onChanged }: { episode: Episode; onChanged: () => void }) {
+  const [expanded, setExpanded] = useState(true);
+  const [symptoms, setSymptoms] = useState<EpisodeSymptom[]>([]);
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchEpisode(episode.id)
+      .then((d) => {
+        if (!cancelled) setSymptoms(d.symptoms.filter((s) => s.detached_at == null));
+      })
+      .catch(() => {
+        if (!cancelled) setSymptoms([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [episode.id, episode.symptom_count]);
+
+  const handleDetach = useCallback(
+    async (key: string) => {
+      setBusyKey(key);
+      try {
+        await detachSymptom(episode.id, key);
+        setSymptoms((prev) => prev.filter((s) => s.correlation_key !== key));
+        onChanged();
+      } finally {
+        setBusyKey(null);
+      }
+    },
+    [episode.id, onChanged],
+  );
+
+  return (
+    <div className="rounded-lg border border-red-500/25 bg-red-500/[0.06]">
+      <div className="flex items-start gap-2 px-3 py-2.5">
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-red-400" />
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-red-400">Cause</span>
+            <span className="truncate text-sm font-medium text-slate-100">{episode.cause_title}</span>
+          </div>
+          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-slate-400">
+            <span>{episode.cause_category}</span>
+            <span>started {since(episode.started_at)} ago</span>
+            <span>
+              {symptoms.length} {symptoms.length === 1 ? 'symptom' : 'symptoms'}
+              {episode.namespaces.length > 0 && ` across ${episode.namespaces.length} namespaces`}
+            </span>
+            {episode.recurrence_of && (
+              <span className="inline-flex items-center gap-1 text-amber-400">
+                <History className="h-3 w-3" />
+                recurring
+              </span>
+            )}
+          </div>
+        </div>
+        {symptoms.length > 0 && (
+          <button
+            onClick={() => setExpanded((e) => !e)}
+            aria-expanded={expanded}
+            aria-label={expanded ? 'Hide symptoms' : 'Show symptoms'}
+            className="shrink-0 rounded-sm p-1 text-slate-400 transition-colors hover:bg-slate-700/50"
+          >
+            {expanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+          </button>
+        )}
+      </div>
+
+      {expanded && symptoms.length > 0 && (
+        <div className="border-t border-red-500/15 px-3 py-2">
+          <p className="mb-1.5 text-[11px] text-slate-500">
+            Explained by the cause above — not separate problems.
+          </p>
+          <ul className="space-y-0.5">
+            {symptoms.map((s) => (
+              <li key={s.correlation_key} className="group flex items-center gap-2 py-0.5 text-xs">
+                <span className="w-24 shrink-0 truncate text-slate-500">{s.category}</span>
+                <span className="min-w-0 flex-1 truncate text-slate-300">{s.title}</span>
+                <button
+                  onClick={() => handleDetach(s.correlation_key)}
+                  disabled={busyKey === s.correlation_key}
+                  title="This was not caused by the episode above"
+                  className={cn(
+                    'shrink-0 inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-[11px] text-slate-500',
+                    'opacity-0 transition-opacity hover:bg-slate-700/50 hover:text-slate-300',
+                    'focus:opacity-100 group-hover:opacity-100 disabled:opacity-40',
+                  )}
+                >
+                  <Ban className="h-3 w-3" />
+                  Not related
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function EpisodePanel() {
+  const [episodes, setEpisodes] = useState<Episode[]>([]);
+
+  const load = useCallback(() => {
+    fetchOpenEpisodes()
+      .then(setEpisodes)
+      .catch(() => setEpisodes([]));
+  }, []);
+
+  useEffect(() => {
+    load();
+    const timer = setInterval(load, 60_000);
+    return () => clearInterval(timer);
+  }, [load]);
+
+  if (episodes.length === 0) return null;
+
+  return (
+    <div className="space-y-2 px-4 pt-3">
+      {episodes.map((e) => (
+        <EpisodeCard key={e.id} episode={e} onChanged={load} />
+      ))}
+    </div>
+  );
+}

--- a/src/kubeview/views/inbox/__tests__/EpisodePanel.test.tsx
+++ b/src/kubeview/views/inbox/__tests__/EpisodePanel.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent, cleanup } from '@testing-library/react';
 import { EpisodePanel } from '../EpisodePanel';
 
 const fetchOpenEpisodes = vi.fn();
@@ -59,6 +59,11 @@ describe('EpisodePanel', () => {
     fetchEpisode.mockResolvedValue({ episode: EPISODE, symptoms: SYMPTOMS });
     detachSymptom.mockResolvedValue(undefined);
   });
+
+  // vitest.config.ts registers no setupFiles, so Testing Library's automatic
+  // cleanup is not installed — without this, renders stack up in the same
+  // document and queries match elements from previous tests.
+  afterEach(cleanup);
 
   it('renders nothing when no episode is open', async () => {
     fetchOpenEpisodes.mockResolvedValue([]);

--- a/src/kubeview/views/inbox/__tests__/EpisodePanel.test.tsx
+++ b/src/kubeview/views/inbox/__tests__/EpisodePanel.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { EpisodePanel } from '../EpisodePanel';
+
+const fetchOpenEpisodes = vi.fn();
+const fetchEpisode = vi.fn();
+const detachSymptom = vi.fn();
+
+vi.mock('../../../engine/episodeApi', () => ({
+  fetchOpenEpisodes: (...a: unknown[]) => fetchOpenEpisodes(...a),
+  fetchEpisode: (...a: unknown[]) => fetchEpisode(...a),
+  detachSymptom: (...a: unknown[]) => detachSymptom(...a),
+}));
+
+const EPISODE = {
+  id: 'ep-1',
+  status: 'open' as const,
+  cause_category: 'control_plane',
+  cause_title: 'etcd changed leader 12 times in an hour',
+  cause_finding_id: 'f-1',
+  cause_layer: 0,
+  started_at: Math.floor(Date.now() / 1000) - 600,
+  ended_at: null,
+  last_seen_at: Math.floor(Date.now() / 1000),
+  symptom_count: 2,
+  namespaces: ['multicluster-engine', 'open-cluster-management'],
+  correlation_key: 'control_plane::Etcd/cluster',
+  recurrence_of: null,
+};
+
+const SYMPTOMS = [
+  {
+    episode_id: 'ep-1',
+    correlation_key: 'workloads:mce:Deployment/ocm-controller',
+    category: 'workloads',
+    title: 'Deployment ocm-controller degraded (0/2)',
+    namespace: 'multicluster-engine',
+    attached_at: 1,
+    detached_at: null,
+    detached_by: null,
+  },
+  {
+    episode_id: 'ep-1',
+    correlation_key: 'crashloop:ocm:Pod/grc-policy-propagator',
+    category: 'crashloop',
+    title: 'Pod grc-policy-propagator restarting (14x)',
+    namespace: 'open-cluster-management',
+    attached_at: 2,
+    detached_at: null,
+    detached_by: null,
+  },
+];
+
+describe('EpisodePanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchOpenEpisodes.mockResolvedValue([EPISODE]);
+    fetchEpisode.mockResolvedValue({ episode: EPISODE, symptoms: SYMPTOMS });
+    detachSymptom.mockResolvedValue(undefined);
+  });
+
+  it('renders nothing when no episode is open', async () => {
+    fetchOpenEpisodes.mockResolvedValue([]);
+    const { container } = render(<EpisodePanel />);
+    await waitFor(() => expect(fetchOpenEpisodes).toHaveBeenCalled());
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('leads with the cause, not the symptoms', async () => {
+    render(<EpisodePanel />);
+    expect(await screen.findByText(EPISODE.cause_title)).toBeTruthy();
+    expect(screen.getByText('Cause')).toBeTruthy();
+  });
+
+  it('shows the blast radius so the list is not mistaken for separate problems', async () => {
+    render(<EpisodePanel />);
+    expect(await screen.findByText(/2 symptoms across 2 namespaces/)).toBeTruthy();
+    expect(screen.getByText(/not separate problems/i)).toBeTruthy();
+  });
+
+  it('folds the symptoms underneath the cause', async () => {
+    render(<EpisodePanel />);
+    expect(await screen.findByText(SYMPTOMS[0].title)).toBeTruthy();
+    expect(screen.getByText(SYMPTOMS[1].title)).toBeTruthy();
+  });
+
+  it('marks a recurring episode', async () => {
+    fetchOpenEpisodes.mockResolvedValue([{ ...EPISODE, recurrence_of: 'ep-earlier' }]);
+    render(<EpisodePanel />);
+    expect(await screen.findByText('recurring')).toBeTruthy();
+  });
+
+  it('detaching a symptom tells the agent and removes it from view', async () => {
+    render(<EpisodePanel />);
+    await screen.findByText(SYMPTOMS[0].title);
+
+    fireEvent.click(screen.getAllByTitle(/not caused by the episode/i)[0]);
+
+    await waitFor(() =>
+      expect(detachSymptom).toHaveBeenCalledWith('ep-1', SYMPTOMS[0].correlation_key),
+    );
+    await waitFor(() => expect(screen.queryByText(SYMPTOMS[0].title)).toBeNull());
+  });
+
+  it('survives the agent being unreachable', async () => {
+    fetchOpenEpisodes.mockRejectedValue(new Error('offline'));
+    const { container } = render(<EpisodePanel />);
+    await waitFor(() => expect(fetchOpenEpisodes).toHaveBeenCalled());
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders the cause even when its symptoms cannot be loaded', async () => {
+    fetchEpisode.mockRejectedValue(new Error('offline'));
+    render(<EpisodePanel />);
+    expect(await screen.findByText(EPISODE.cause_title)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
The UI half of PulseSRE/pulse-agent#27 and PulseSRE/pulse-agent#28. Without it neither is observable — the episode endpoints have no caller, and degradation findings would land in the inbox as three more rows among seventy-six.

## EpisodePanel

Open episodes sit **above** the queue: cause first, symptoms folded underneath and labelled as not separate problems.

The case it exists for, from a real outage: fourteen findings in one second, nine `Deployment degraded` rated **critical**, and one `etcdMemberCommunicationSlow` rated *warning* that caused the other thirteen. Ranked by priority the cause didn't make the top thirteen — so reading the list top-down sent you to the wrong problem.

Also shows blast radius (`2 symptoms across 2 namespaces`), how long it's been running, and a `recurring` marker when the same cause returned within a day.

## "Not related"

Every symptom row carries one. It calls `POST /episodes/{id}/detach`.

This is worth more than it looks: an operator correcting the correlation is the **only ground truth the agent ever gets** about whether its causal model is right, and it arrives as a by-product of them doing their job. It's on every row rather than behind a menu on purpose.

## CapabilityBanner

Surfaces `degraded` findings above the queue rather than inside it — the point is that *what you are looking at is incomplete*, and that can't be something you discover by scrolling. It says outright that anything a broken scanner covers is **unknown rather than clear**, because an empty panel otherwise reads as "nothing to see". Critical degradation (the 1,111-failure case) escalates the styling.

## What I verified by hand, and why

There's no node toolchain in this environment, so **I could not typecheck or run vitest locally**. Two specific risks, both closed manually:

- **Icons** — every lucide import is one already imported elsewhere in this repo. `AlertOctagon`, `Link2Off` and `Repeat` were *not*, so I swapped them for `AlertTriangle`, `Ban` and `History`. An unexported icon would have failed the build.
- **Matchers** — `vitest.config.ts` registers no `setupFiles`, so jest-dom matchers aren't available. These tests use plain vitest assertions only (`toBeTruthy`, `toBeNull`, `innerHTML`).

Every import path resolved against the tree. 14 tests across the two components, covering the empty case, the agent being unreachable, symptoms failing to load independently of the cause, and the detach round-trip. CI is the first real typecheck — I'll fix whatever it finds.