### PR TITLE
feat: account for the items an episode folded away, and describe two scanners

### DIFF
--- a/src/kubeview/engine/inboxApi.ts
+++ b/src/kubeview/engine/inboxApi.ts
@@ -49,6 +49,8 @@ export interface InboxResponse {
   groups: InboxGroup[];
   stats: Record<string, number>;
   total: number;
+  /** How many items an open episode already explains, and so were left out. */
+  collapsedIntoEpisodes?: number;
   current_user?: string;
 }
 

--- a/src/kubeview/store/__tests__/inboxStore-episodes.test.ts
+++ b/src/kubeview/store/__tests__/inboxStore-episodes.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * When an open episode explains some inbox items, the agent leaves them out of
+ * the list and reports how many. The UI shows that count, because items
+ * disappearing from a work queue with no explanation is its own way of losing
+ * someone's trust — so the number has to survive the trip from API to store.
+ */
+
+const fetchInbox = vi.fn();
+
+vi.mock('../../engine/inboxApi', () => ({
+  fetchInbox: (...a: unknown[]) => fetchInbox(...a),
+  fetchInboxStats: vi.fn().mockResolvedValue({ new: 0, total: 0 }),
+  acknowledgeInboxItem: vi.fn(),
+  claimInboxItem: vi.fn(),
+  unclaimInboxItem: vi.fn(),
+  snoozeInboxItem: vi.fn(),
+  dismissInboxItem: vi.fn(),
+  resolveInboxItem: vi.fn(),
+  pinInboxItem: vi.fn(),
+  createInboxTask: vi.fn(),
+  restoreInboxItem: vi.fn(),
+}));
+vi.mock('../../engine/auth', () => ({ handleAuthError: vi.fn() }));
+vi.mock('../uiStore', () => ({ useUIStore: { getState: () => ({ addToast: vi.fn() }) } }));
+
+import { useInboxStore } from '../inboxStore';
+
+function response(over: Record<string, unknown> = {}) {
+  return { items: [], groups: [], stats: {}, total: 0, ...over };
+}
+
+describe('inboxStore — episode collapse count', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useInboxStore.setState({ collapsedIntoEpisodes: 0 });
+  });
+
+  it('starts at zero', () => {
+    expect(useInboxStore.getState().collapsedIntoEpisodes).toBe(0);
+  });
+
+  it('carries the count from the agent', async () => {
+    fetchInbox.mockResolvedValue(response({ collapsedIntoEpisodes: 12 }));
+    await useInboxStore.getState().refresh();
+    expect(useInboxStore.getState().collapsedIntoEpisodes).toBe(12);
+  });
+
+  it('treats an agent that does not send the field as nothing collapsed', async () => {
+    // An older agent, or one where episodes could not be read.
+    fetchInbox.mockResolvedValue(response());
+    await useInboxStore.getState().refresh();
+    expect(useInboxStore.getState().collapsedIntoEpisodes).toBe(0);
+  });
+
+  it('clears the count when a later refresh collapses nothing', async () => {
+    fetchInbox.mockResolvedValue(response({ collapsedIntoEpisodes: 5 }));
+    await useInboxStore.getState().refresh();
+    expect(useInboxStore.getState().collapsedIntoEpisodes).toBe(5);
+
+    fetchInbox.mockResolvedValue(response({ collapsedIntoEpisodes: 0 }));
+    await useInboxStore.getState().refresh();
+    expect(useInboxStore.getState().collapsedIntoEpisodes).toBe(0);
+  });
+});

--- a/src/kubeview/store/inboxStore.ts
+++ b/src/kubeview/store/inboxStore.ts
@@ -44,6 +44,7 @@ interface InboxState {
   groups: InboxGroup[];
   stats: Record<string, number>;
   total: number;
+  collapsedIntoEpisodes: number;
   filters: InboxFilters;
   activePreset: Preset;
   groupBy: string | null;
@@ -76,6 +77,7 @@ export const useInboxStore = create<InboxState>((set, get) => ({
   groups: [],
   stats: {},
   total: 0,
+  collapsedIntoEpisodes: 0,
   filters: { status: '__needs_attention__' },
   activePreset: 'needs_attention',
   groupBy: null,
@@ -120,6 +122,7 @@ export const useInboxStore = create<InboxState>((set, get) => ({
         groups: data.groups,
         stats: globalStats,
         total: data.total,
+        collapsedIntoEpisodes: data.collapsedIntoEpisodes ?? 0,
         currentUser: data.current_user ?? null,
         loading: false,
       });

--- a/src/kubeview/views/InboxPage.tsx
+++ b/src/kubeview/views/InboxPage.tsx
@@ -33,6 +33,7 @@ export function InboxPage() {
   const refresh = useInboxStore((s) => s.refresh);
   const filters = useInboxStore((s) => s.filters);
   const activePreset = useInboxStore((s) => s.activePreset);
+  const collapsedIntoEpisodes = useInboxStore((s) => s.collapsedIntoEpisodes);
 
   useEffect(() => {
     refresh();
@@ -122,6 +123,12 @@ export function InboxPage() {
           {/* Open episodes sit above the queue: a cause with its symptoms
               folded under it, so the list is not read cause-last. */}
           <EpisodePanel />
+          {collapsedIntoEpisodes > 0 && (
+            <p className="px-4 pt-2 text-xs text-slate-500">
+              {collapsedIntoEpisodes} {collapsedIntoEpisodes === 1 ? 'item is' : 'items are'} explained by an
+              open episode above and left out of the list below.
+            </p>
+          )}
           <InboxFilterBar />
 
           {activePreset === 'archived' && (

--- a/src/kubeview/views/mission-control/ScannerDrawer.tsx
+++ b/src/kubeview/views/mission-control/ScannerDrawer.tsx
@@ -24,6 +24,8 @@ const SCANNER_INFO: Record<string, { description: string; autoFixable?: boolean;
   audit_events: { description: 'High-frequency Warning events that may indicate emerging issues', severity: 'info' },
   audit_auth: { description: 'Auth anomalies — kubeadmin usage, login failures, service account token creation', severity: 'info' },
   security_posture: { description: 'Pod security violations — privileged containers, host networking, missing security contexts', severity: 'warning' },
+  control_plane: { description: 'etcd and API server degradation — leader changes, refused writes, peer and disk latency, request latency, cluster-wide LIST rate', severity: 'critical' },
+  degraded: { description: "Pulse's own failing scanners and backends, so an empty result is never mistaken for a clean cluster", severity: 'warning' },
   stuck: { description: 'Deletions that never completed — namespaces, pods, PVCs, or CRDs held open by a finalizer', severity: 'critical' },
   hot_loop: { description: 'Controllers burning API server capacity without making progress — sustained work-queue retries or write amplification', severity: 'warning' },
 };


### PR DESCRIPTION
UI half of PulseSRE/pulse-agent#30. Merge that first — this reads the field it adds.

## The count line

The agent now leaves symptoms of an open episode out of the inbox list, since they're already shown under their cause. This surfaces how many:

> 12 items are explained by an open episode above and left out of the list below.

Collapse rather than demote, as agreed — demoting still leaves fourteen rows to scroll past. But items vanishing from a work queue with no explanation is its own way of losing trust, hence the line.

The field is optional end to end, so an agent that doesn't send it — an older build, or one where episodes couldn't be read — reads as *nothing collapsed* rather than as an error.

## Scanner drawer

`control_plane` and `degraded` were added after the last pass and would have rendered as bare toggles with no description. Now described.

## A note on the tests

I first wrote this as a render test of `InboxPage` and found myself mocking **eight modules to assert one line of text** — which is a smell, and brittle in a way that fails later for reasons unrelated to the feature.

The part that can actually break is the plumbing from API response → store. That's what the four tests cover, in the style the existing `inboxStore` test already uses. The JSX is a conditional on a number, and the typecheck covers that.

Includes the case of an agent that omits the field, and the count clearing on a later refresh.