### PR TITLE
feat: show what changed before an episode, and how often it returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Episodes show what changed and how often
+- An episode now lists the config, RBAC and deployment activity from the half hour before it started, each marked with how long before — `−2m cluster-admin granted to svc/deployer`. Labelled *not necessarily the cause*, because it reports what happened nearby and leaves the inference to the reader
+- The bare `recurring` badge is now the sentence that matters: `6 times in 11h · every 2h`. A cadence is only shown when the returns are regular enough to be one; irregular recurrence says how often but invents no pattern
+- Both fields are optional, so an agent that sends neither still renders the episode
+
 ## [2.10.0] - 2026-08-20
 
 ### Episodes in the inbox

--- a/src/kubeview/engine/episodeApi.ts
+++ b/src/kubeview/engine/episodeApi.ts
@@ -38,6 +38,25 @@ export interface EpisodeSymptom {
   detached_by: string | null;
 }
 
+/** Config, RBAC or deployment activity shortly before an episode began. */
+export interface EpisodeChange {
+  category: string;
+  title: string;
+  namespace: string;
+  at: number;
+  seconds_before: number;
+}
+
+/** How often this cause has come back, and on what cadence if it has one. */
+export interface EpisodeRecurrence {
+  occurrences: number;
+  recurring: boolean;
+  first_seen?: number;
+  window_seconds?: number;
+  interval_seconds?: number;
+  prior_episode_ids?: string[];
+}
+
 async function get<T>(path: string): Promise<T> {
   const res = await agentFetch(`${AGENT_BASE}${path}`);
   if (!res.ok) throw new Error(`Episode API error: ${res.status} on ${path}`);
@@ -49,9 +68,13 @@ export async function fetchOpenEpisodes(): Promise<Episode[]> {
   return data.episodes ?? [];
 }
 
-export async function fetchEpisode(
-  id: string,
-): Promise<{ episode: Episode; symptoms: EpisodeSymptom[] }> {
+export async function fetchEpisode(id: string): Promise<{
+  episode: Episode;
+  symptoms: EpisodeSymptom[];
+  /** Optional so an older agent, which sends neither, still renders. */
+  changes?: EpisodeChange[];
+  recurrence?: EpisodeRecurrence;
+}> {
   return get(`/episodes/${encodeURIComponent(id)}`);
 }
 

--- a/src/kubeview/views/inbox/EpisodePanel.tsx
+++ b/src/kubeview/views/inbox/EpisodePanel.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { AlertTriangle, Ban, ChevronDown, ChevronRight, History } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { detachSymptom, fetchEpisode, fetchOpenEpisodes } from '../../engine/episodeApi';
-import type { Episode, EpisodeSymptom } from '../../engine/episodeApi';
+import type { Episode, EpisodeChange, EpisodeRecurrence, EpisodeSymptom } from '../../engine/episodeApi';
 
 /**
  * Shows open episodes above the inbox: a cause, with the findings it explains
@@ -22,19 +22,43 @@ function since(startedAt: number): string {
   return `${Math.round(mins / 1440)}d`;
 }
 
+function duration(seconds: number): string {
+  if (seconds < 90) return `${Math.round(seconds)}s`;
+  if (seconds < 5400) return `${Math.round(seconds / 60)}m`;
+  if (seconds < 172800) return `${Math.round(seconds / 3600)}h`;
+  return `${Math.round(seconds / 86400)}d`;
+}
+
+/** "6th time in 11h, every 2h" — the sentence that turns a page into a diagnosis. */
+function recurrenceLine(r: EpisodeRecurrence): string | null {
+  if (!r.recurring || r.occurrences < 2) return null;
+  const parts = [`${r.occurrences} times`];
+  if (r.window_seconds) parts.push(`in ${duration(r.window_seconds)}`);
+  if (r.interval_seconds) parts.push(`· every ${duration(r.interval_seconds)}`);
+  return parts.join(' ');
+}
+
 function EpisodeCard({ episode, onChanged }: { episode: Episode; onChanged: () => void }) {
   const [expanded, setExpanded] = useState(true);
   const [symptoms, setSymptoms] = useState<EpisodeSymptom[]>([]);
+  const [changes, setChanges] = useState<EpisodeChange[]>([]);
+  const [recurrence, setRecurrence] = useState<EpisodeRecurrence | null>(null);
   const [busyKey, setBusyKey] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     fetchEpisode(episode.id)
       .then((d) => {
-        if (!cancelled) setSymptoms(d.symptoms.filter((s) => s.detached_at == null));
+        if (cancelled) return;
+        setSymptoms(d.symptoms.filter((s) => s.detached_at == null));
+        setChanges(d.changes ?? []);
+        setRecurrence(d.recurrence ?? null);
       })
       .catch(() => {
-        if (!cancelled) setSymptoms([]);
+        if (cancelled) return;
+        setSymptoms([]);
+        setChanges([]);
+        setRecurrence(null);
       });
     return () => {
       cancelled = true;
@@ -55,6 +79,11 @@ function EpisodeCard({ episode, onChanged }: { episode: Episode; onChanged: () =
     [episode.id, onChanged],
   );
 
+  // Prefer the real sentence; fall back to the flag for an agent that only
+  // reports that a prior episode existed.
+  const recurrenceLabel =
+    (recurrence ? recurrenceLine(recurrence) : null) ?? (episode.recurrence_of ? 'recurring' : null);
+
   return (
     <div className="rounded-lg border border-red-500/25 bg-red-500/[0.06]">
       <div className="flex items-start gap-2 px-3 py-2.5">
@@ -71,10 +100,10 @@ function EpisodeCard({ episode, onChanged }: { episode: Episode; onChanged: () =
               {symptoms.length} {symptoms.length === 1 ? 'symptom' : 'symptoms'}
               {episode.namespaces.length > 0 && ` across ${episode.namespaces.length} namespaces`}
             </span>
-            {episode.recurrence_of && (
-              <span className="inline-flex items-center gap-1 text-amber-400">
+            {recurrenceLabel && (
+              <span className="inline-flex items-center gap-1 font-medium text-amber-400">
                 <History className="h-3 w-3" />
-                recurring
+                {recurrenceLabel}
               </span>
             )}
           </div>
@@ -90,6 +119,25 @@ function EpisodeCard({ episode, onChanged }: { episode: Episode; onChanged: () =
           </button>
         )}
       </div>
+
+      {expanded && changes.length > 0 && (
+        <div className="border-t border-red-500/15 px-3 py-2">
+          <p className="mb-1.5 text-[11px] text-slate-500">
+            Changed shortly before it started — not necessarily the cause.
+          </p>
+          <ul className="space-y-0.5">
+            {changes.map((c) => (
+              <li key={`${c.category}-${c.at}`} className="flex items-center gap-2 py-0.5 text-xs">
+                <span className="w-20 shrink-0 text-right tabular-nums text-amber-400/80">
+                  −{duration(c.seconds_before)}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-slate-300">{c.title}</span>
+                <span className="shrink-0 truncate text-slate-500">{c.namespace}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
 
       {expanded && symptoms.length > 0 && (
         <div className="border-t border-red-500/15 px-3 py-2">

--- a/src/kubeview/views/inbox/__tests__/EpisodePanel.test.tsx
+++ b/src/kubeview/views/inbox/__tests__/EpisodePanel.test.tsx
@@ -121,3 +121,87 @@ describe('EpisodePanel', () => {
     expect(await screen.findByText(EPISODE.cause_title)).toBeTruthy();
   });
 });
+
+
+// ── the context the agent now returns alongside the symptoms ──────────────
+
+const CHANGES = [
+  {
+    category: 'audit_deployment',
+    title: 'ocm-controller rolled out',
+    namespace: 'multicluster-engine',
+    at: 1786000000,
+    seconds_before: 420,
+  },
+  {
+    category: 'audit_rbac',
+    title: 'cluster-admin granted to svc/deployer',
+    namespace: 'open-cluster-management',
+    at: 1786000200,
+    seconds_before: 120,
+  },
+];
+
+describe('EpisodePanel context', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchOpenEpisodes.mockResolvedValue([EPISODE]);
+    detachSymptom.mockResolvedValue(undefined);
+  });
+
+  afterEach(cleanup);
+
+  it('names the cadence when the cause keeps coming back', async () => {
+    fetchEpisode.mockResolvedValue({
+      episode: EPISODE,
+      symptoms: SYMPTOMS,
+      recurrence: { occurrences: 6, recurring: true, window_seconds: 39600, interval_seconds: 7200 },
+    });
+    render(<EpisodePanel />);
+    // "6 times in 11h · every 2h" — the sentence that turns a page into a diagnosis
+    expect(await screen.findByText(/6 times in 11h/)).toBeTruthy();
+    expect(screen.getByText(/every 2h/)).toBeTruthy();
+  });
+
+  it('says nothing about cadence when the returns are irregular', async () => {
+    fetchEpisode.mockResolvedValue({
+      episode: EPISODE,
+      symptoms: SYMPTOMS,
+      recurrence: { occurrences: 3, recurring: true, window_seconds: 39600 },
+    });
+    render(<EpisodePanel />);
+    expect(await screen.findByText(/3 times in 11h/)).toBeTruthy();
+    expect(screen.queryByText(/every/)).toBeNull();
+  });
+
+  it('shows what changed before it started, with how long before', async () => {
+    fetchEpisode.mockResolvedValue({ episode: EPISODE, symptoms: SYMPTOMS, changes: CHANGES });
+    render(<EpisodePanel />);
+    expect(await screen.findByText('cluster-admin granted to svc/deployer')).toBeTruthy();
+    expect(screen.getByText('−2m')).toBeTruthy();
+    expect(screen.getByText('−7m')).toBeTruthy();
+  });
+
+  it('does not claim the change caused it', async () => {
+    fetchEpisode.mockResolvedValue({ episode: EPISODE, symptoms: SYMPTOMS, changes: CHANGES });
+    render(<EpisodePanel />);
+    expect(await screen.findByText(/not necessarily the cause/i)).toBeTruthy();
+  });
+
+  it('renders against an agent that sends neither field', async () => {
+    fetchEpisode.mockResolvedValue({ episode: EPISODE, symptoms: SYMPTOMS });
+    render(<EpisodePanel />);
+    expect(await screen.findByText(EPISODE.cause_title)).toBeTruthy();
+    expect(screen.queryByText(/not necessarily the cause/i)).toBeNull();
+  });
+
+  it('falls back to the plain flag when only recurrence_of is known', async () => {
+    fetchEpisode.mockResolvedValue({
+      episode: { ...EPISODE, recurrence_of: 'ep-earlier' },
+      symptoms: SYMPTOMS,
+    });
+    fetchOpenEpisodes.mockResolvedValue([{ ...EPISODE, recurrence_of: 'ep-earlier' }]);
+    render(<EpisodePanel />);
+    expect(await screen.findByText('recurring')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
The agent started returning `changes` and `recurrence` from `GET /episodes/{id}` in PulseSRE/pulse-agent#32, and the UI read **neither** — so the two most useful things in that response were invisible.

## What changed

Listed above the symptoms, each marked with how long before the episode began:

```
−7m   ocm-controller rolled out                    multicluster-engine
−2m   cluster-admin granted to svc/deployer        open-cluster-management
```

Labelled **"Changed shortly before it started — not necessarily the cause."** The agent reports what happened nearby in time; drawing the line is the reader's job, and the wording shouldn't pretend otherwise.

## How often

The panel showed a bare `recurring` badge derived from a flag — it said *this happened before* but not how often or how regularly, and **how regularly is usually the clue**. Now:

```
6 times in 11h · every 2h
```

The cadence only appears when the intervals are regular enough to be one. An irregular return reports the count and window but invents no pattern.

## Degrading cleanly

Both fields are optional end to end, so an agent that sends neither — an older build, or one where the lookup failed — still renders the episode. There's a test for that, and one for falling back to the plain flag when only `recurrence_of` is known.

6 new tests. I verified the `duration()` rounding against the fixtures by hand (420s → 7m, 39600s → 11h) since there's no node toolchain here to run vitest — CI is the first real check, as with the earlier UI PRs.