### PR TITLE
refactor: one duration helper instead of two drifting copies

### DIFF
--- a/src/kubeview/engine/dateUtils.ts
+++ b/src/kubeview/engine/dateUtils.ts
@@ -57,3 +57,32 @@ export function formatAge(date: Date): string {
   if (mins > 0) return `${mins}m ago`;
   return 'just now';
 }
+
+/**
+ * A span of seconds as the coarsest unit that still reads precisely: 45s, 12m,
+ * 3h, 2d.
+ *
+ * Deliberately not named formatDuration — that already exists above and takes
+ * two ISO strings, returning compound units like "5m 30s". This takes a number
+ * of seconds and returns one unit, for places where the span is a label rather
+ * than a measurement ("every 2h", "−7m").
+ */
+export function formatShortDuration(seconds: number): string {
+  const s = Math.max(0, seconds);
+  if (s < 90) return `${Math.round(s)}s`;
+  const mins = Math.round(s / 60);
+  if (mins < 90) return `${mins}m`;
+  const hours = Math.round(mins / 60);
+  if (hours < 48) return `${hours}h`;
+  return `${Math.round(hours / 24)}d`;
+}
+
+/**
+ * How long ago a unix-seconds timestamp was, as a bare span with no "ago".
+ *
+ * Not formatAge — that takes a Date and appends "ago". This is for phrasing
+ * that supplies its own preposition, like "running 30m".
+ */
+export function formatElapsed(startedAtSeconds: number): string {
+  return formatShortDuration(Date.now() / 1000 - startedAtSeconds);
+}

--- a/src/kubeview/engine/formatters.ts
+++ b/src/kubeview/engine/formatters.ts
@@ -7,3 +7,4 @@ export function formatRelativeTime(timestamp: number): string {
   if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
   return `${Math.floor(seconds / 86400)}d ago`;
 }
+

--- a/src/kubeview/views/inbox/EpisodePanel.tsx
+++ b/src/kubeview/views/inbox/EpisodePanel.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { AlertTriangle, Ban, ChevronDown, ChevronRight, History } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { formatElapsed, formatShortDuration } from '../../engine/dateUtils';
 import { detachSymptom, fetchEpisode, fetchOpenEpisodes } from '../../engine/episodeApi';
 import type { Episode, EpisodeChange, EpisodeRecurrence, EpisodeSymptom } from '../../engine/episodeApi';
 
@@ -15,26 +16,12 @@ import type { Episode, EpisodeChange, EpisodeRecurrence, EpisodeSymptom } from '
  * that list top-down sends you to the wrong problem.
  */
 
-function since(startedAt: number): string {
-  const mins = Math.max(0, Math.round((Date.now() / 1000 - startedAt) / 60));
-  if (mins < 60) return `${mins}m`;
-  if (mins < 1440) return `${Math.round(mins / 60)}h`;
-  return `${Math.round(mins / 1440)}d`;
-}
-
-function duration(seconds: number): string {
-  if (seconds < 90) return `${Math.round(seconds)}s`;
-  if (seconds < 5400) return `${Math.round(seconds / 60)}m`;
-  if (seconds < 172800) return `${Math.round(seconds / 3600)}h`;
-  return `${Math.round(seconds / 86400)}d`;
-}
-
 /** "6th time in 11h, every 2h" — the sentence that turns a page into a diagnosis. */
 function recurrenceLine(r: EpisodeRecurrence): string | null {
   if (!r.recurring || r.occurrences < 2) return null;
   const parts = [`${r.occurrences} times`];
-  if (r.window_seconds) parts.push(`in ${duration(r.window_seconds)}`);
-  if (r.interval_seconds) parts.push(`· every ${duration(r.interval_seconds)}`);
+  if (r.window_seconds) parts.push(`in ${formatShortDuration(r.window_seconds)}`);
+  if (r.interval_seconds) parts.push(`· every ${formatShortDuration(r.interval_seconds)}`);
   return parts.join(' ');
 }
 
@@ -95,7 +82,7 @@ function EpisodeCard({ episode, onChanged }: { episode: Episode; onChanged: () =
           </div>
           <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-slate-400">
             <span>{episode.cause_category}</span>
-            <span>started {since(episode.started_at)} ago</span>
+            <span>started {formatElapsed(episode.started_at)} ago</span>
             <span>
               {symptoms.length} {symptoms.length === 1 ? 'symptom' : 'symptoms'}
               {episode.namespaces.length > 0 && ` across ${episode.namespaces.length} namespaces`}
@@ -129,7 +116,7 @@ function EpisodeCard({ episode, onChanged }: { episode: Episode; onChanged: () =
             {changes.map((c) => (
               <li key={`${c.category}-${c.at}`} className="flex items-center gap-2 py-0.5 text-xs">
                 <span className="w-20 shrink-0 text-right tabular-nums text-amber-400/80">
-                  −{duration(c.seconds_before)}
+                  −{formatShortDuration(c.seconds_before)}
                 </span>
                 <span className="min-w-0 flex-1 truncate text-slate-300">{c.title}</span>
                 <span className="shrink-0 truncate text-slate-500">{c.namespace}</span>

--- a/src/kubeview/views/pulse/OpenEpisodeBanner.tsx
+++ b/src/kubeview/views/pulse/OpenEpisodeBanner.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { AlertTriangle, ArrowRight, History } from 'lucide-react';
 import { fetchOpenEpisodes } from '../../engine/episodeApi';
 import type { Episode } from '../../engine/episodeApi';
+import { formatElapsed } from '../../engine/dateUtils';
 
 /**
  * Puts an open episode at the top of the landing view.
@@ -15,13 +16,6 @@ import type { Episode } from '../../engine/episodeApi';
  * open episode outranks every tile beneath it by construction: those tiles are
  * showing its symptoms.
  */
-
-function since(startedAt: number): string {
-  const mins = Math.max(0, Math.round((Date.now() / 1000 - startedAt) / 60));
-  if (mins < 60) return `${mins}m`;
-  if (mins < 1440) return `${Math.round(mins / 60)}h`;
-  return `${Math.round(mins / 1440)}d`;
-}
 
 export function OpenEpisodeBanner({ onOpen }: { onOpen: () => void }) {
   const [episodes, setEpisodes] = useState<Episode[]>([]);
@@ -62,7 +56,7 @@ export function OpenEpisodeBanner({ onOpen }: { onOpen: () => void }) {
           <span className="truncate text-sm font-medium text-slate-100">{first.cause_title}</span>
         </div>
         <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-slate-400">
-          <span>running {since(first.started_at)}</span>
+          <span>running {formatElapsed(first.started_at)}</span>
           <span>
             {first.symptom_count} {first.symptom_count === 1 ? 'symptom' : 'symptoms'}
             {first.namespaces.length > 0 && ` across ${first.namespaces.length} namespaces`}


### PR DESCRIPTION
From the review pass before the release.

`EpisodePanel` and `OpenEpisodeBanner` each had their own `since()`/`duration()`, and they had **already drifted** — one rounded seconds then divided, the other divided then rounded. Identical output for the values in the tests, different for others: the kind of difference nobody notices until a number looks wrong on screen.

Both now use `formatShortDuration` / `formatElapsed` in `dateUtils`, where the other time helpers already live.

## The naming, which I got wrong first

My first attempt added `formatDuration` and `formatAge` to `formatters.ts` — **both names already exist in `dateUtils.ts`** with different signatures:

| existing | takes | returns |
|---|---|---|
| `formatDuration(start, end?)` | two ISO strings | `5m 30s` |
| `formatAge(date)` | a `Date` | `3d ago` |

Two same-named functions with different contracts would have been worse than the duplication I was removing. The new ones take seconds and a unix timestamp, and return one coarse unit with no suffix — for phrasing that supplies its own preposition (`running 30m`, `every 2h`, `−7m`).

Verified all five values used in the existing tests are unchanged, so no test churn.