### PR TITLE
feat: show the investigation, ask a follow-up, and dismiss the card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### The episode card shows the work already done, and can be cleared
+- The card now shows the investigation the agent already ran against the cause — suspected cause and recommended fix, or the error if it failed. A failed attempt is shown rather than hidden: an empty panel reads as "nothing worth investigating", which is the opposite of what happened
+- Ask a follow-up without re-explaining anything. The prompt carries the cause, blast radius, recurrence and what changed just before, so the agent answers the one question the deterministic layer cannot — what to do about it — rather than re-deriving what the card already says
+- A **Dismiss** control, because until now the only way an episode ended was its cause resolving. If the cause returns it opens a new episode, so dismissing cannot hide a problem that comes back
+
 ## [2.11.0] - 2026-08-20
 
 ### Episodes show what changed and how often

--- a/src/kubeview/engine/episodeApi.ts
+++ b/src/kubeview/engine/episodeApi.ts
@@ -57,6 +57,19 @@ export interface EpisodeRecurrence {
   prior_episode_ids?: string[];
 }
 
+/** The investigation the agent already ran against this episode's cause. */
+export interface EpisodeInvestigation {
+  id: string;
+  status: string;
+  summary: string | null;
+  suspected_cause: string | null;
+  recommended_fix: string | null;
+  confidence: number | null;
+  error: string | null;
+  timestamp: number;
+  failed: boolean;
+}
+
 async function get<T>(path: string): Promise<T> {
   const res = await agentFetch(`${AGENT_BASE}${path}`);
   if (!res.ok) throw new Error(`Episode API error: ${res.status} on ${path}`);
@@ -74,6 +87,7 @@ export async function fetchEpisode(id: string): Promise<{
   /** Optional so an older agent, which sends neither, still renders. */
   changes?: EpisodeChange[];
   recurrence?: EpisodeRecurrence;
+  investigation?: EpisodeInvestigation | null;
 }> {
   return get(`/episodes/${encodeURIComponent(id)}`);
 }
@@ -93,4 +107,17 @@ export async function detachSymptom(episodeId: string, correlationKey: string): 
     body: JSON.stringify({ correlationKey }),
   });
   if (!res.ok) throw new Error(`Could not detach symptom: ${res.status}`);
+}
+
+/**
+ * Close an episode an operator says is over.
+ *
+ * The cause re-firing later opens a new episode rather than reviving this one,
+ * so dismissing cannot hide a problem that comes back.
+ */
+export async function dismissEpisode(episodeId: string): Promise<void> {
+  const res = await agentFetch(`${AGENT_BASE}/episodes/${encodeURIComponent(episodeId)}/dismiss`, {
+    method: 'POST',
+  });
+  if (!res.ok) throw new Error(`Could not dismiss episode: ${res.status}`);
 }

--- a/src/kubeview/views/inbox/EpisodePanel.tsx
+++ b/src/kubeview/views/inbox/EpisodePanel.tsx
@@ -1,9 +1,16 @@
 import { useCallback, useEffect, useState } from 'react';
-import { AlertTriangle, Ban, ChevronDown, ChevronRight, History } from 'lucide-react';
+import { AlertTriangle, Ban, Check, ChevronDown, ChevronRight, History } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { InlineAgent } from '../../components/agent/InlineAgent';
 import { formatElapsed, formatShortDuration } from '../../engine/dateUtils';
-import { detachSymptom, fetchEpisode, fetchOpenEpisodes } from '../../engine/episodeApi';
-import type { Episode, EpisodeChange, EpisodeRecurrence, EpisodeSymptom } from '../../engine/episodeApi';
+import { detachSymptom, dismissEpisode, fetchEpisode, fetchOpenEpisodes } from '../../engine/episodeApi';
+import type {
+  Episode,
+  EpisodeChange,
+  EpisodeInvestigation,
+  EpisodeRecurrence,
+  EpisodeSymptom,
+} from '../../engine/episodeApi';
 
 /**
  * Shows open episodes above the inbox: a cause, with the findings it explains
@@ -30,6 +37,7 @@ function EpisodeCard({ episode, onChanged }: { episode: Episode; onChanged: () =
   const [symptoms, setSymptoms] = useState<EpisodeSymptom[]>([]);
   const [changes, setChanges] = useState<EpisodeChange[]>([]);
   const [recurrence, setRecurrence] = useState<EpisodeRecurrence | null>(null);
+  const [investigation, setInvestigation] = useState<EpisodeInvestigation | null>(null);
   const [busyKey, setBusyKey] = useState<string | null>(null);
 
   useEffect(() => {
@@ -40,12 +48,14 @@ function EpisodeCard({ episode, onChanged }: { episode: Episode; onChanged: () =
         setSymptoms(d.symptoms.filter((s) => s.detached_at == null));
         setChanges(d.changes ?? []);
         setRecurrence(d.recurrence ?? null);
+        setInvestigation(d.investigation ?? null);
       })
       .catch(() => {
         if (cancelled) return;
         setSymptoms([]);
         setChanges([]);
         setRecurrence(null);
+        setInvestigation(null);
       });
     return () => {
       cancelled = true;
@@ -71,6 +81,22 @@ function EpisodeCard({ episode, onChanged }: { episode: Episode; onChanged: () =
   const recurrenceLabel =
     (recurrence ? recurrenceLine(recurrence) : null) ?? (episode.recurrence_of ? 'recurring' : null);
 
+  const handleDismiss = useCallback(async () => {
+    await dismissEpisode(episode.id);
+    onChanged();
+  }, [episode.id, onChanged]);
+
+  /** Everything the card knows, so the agent is not asked to re-derive it. */
+  const askPrompt = [
+    `${episode.cause_title}.`,
+    symptoms.length ? `${symptoms.length} symptoms across ${episode.namespaces.length} namespaces.` : '',
+    recurrenceLabel ? `Recurring: ${recurrenceLabel}.` : '',
+    changes.length ? `Changed just before: ${changes.map((c) => c.title).join('; ')}.` : '',
+    'What should I do about it?',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
   return (
     <div className="rounded-lg border border-red-500/25 bg-red-500/[0.06]">
       <div className="flex items-start gap-2 px-3 py-2.5">
@@ -95,6 +121,14 @@ function EpisodeCard({ episode, onChanged }: { episode: Episode; onChanged: () =
             )}
           </div>
         </div>
+        <button
+          onClick={handleDismiss}
+          title="Close this episode — the cause reopens a new one if it returns"
+          className="shrink-0 inline-flex items-center gap-1 rounded-sm px-1.5 py-1 text-[11px] text-slate-400 transition-colors hover:bg-slate-700/50 hover:text-slate-200"
+        >
+          <Check className="h-3 w-3" />
+          Dismiss
+        </button>
         {symptoms.length > 0 && (
           <button
             onClick={() => setExpanded((e) => !e)}
@@ -106,6 +140,49 @@ function EpisodeCard({ episode, onChanged }: { episode: Episode; onChanged: () =
           </button>
         )}
       </div>
+
+      {expanded && investigation && (
+        <div className="border-t border-red-500/15 px-3 py-2">
+          <p className="mb-1.5 text-[11px] text-slate-500">
+            {investigation.failed ? 'The agent tried to investigate and could not' : 'Investigated by the agent'}
+          </p>
+          {investigation.failed ? (
+            <p className="text-xs text-amber-300/80">
+              {investigation.error || 'The investigation failed.'} Findings below reached you without
+              root-cause analysis behind them.
+            </p>
+          ) : (
+            <div className="space-y-1 text-xs text-slate-300">
+              {investigation.suspected_cause && (
+                <p>
+                  <span className="text-slate-500">Suspected cause </span>
+                  {investigation.suspected_cause}
+                </p>
+              )}
+              {investigation.recommended_fix && (
+                <p>
+                  <span className="text-slate-500">Recommended </span>
+                  {investigation.recommended_fix}
+                </p>
+              )}
+            </div>
+          )}
+          {/* The prompt carries everything the card already knows, so the
+              agent is not paid to re-derive the cause, the blast radius and
+              the recent changes before answering the only question the
+              deterministic layer cannot: what to do about it. */}
+          <InlineAgent
+            className="mt-2"
+            context={{ kind: 'Episode', name: episode.id, namespace: episode.namespaces[0] }}
+            initialPrompt={askPrompt}
+            quickPrompts={[
+              'What should I do about this?',
+              'Is this safe to ignore?',
+              'What would confirm the cause?',
+            ]}
+          />
+        </div>
+      )}
 
       {expanded && changes.length > 0 && (
         <div className="border-t border-red-500/15 px-3 py-2">

--- a/src/kubeview/views/inbox/__tests__/EpisodePanel.test.tsx
+++ b/src/kubeview/views/inbox/__tests__/EpisodePanel.test.tsx
@@ -7,10 +7,20 @@ const fetchOpenEpisodes = vi.fn();
 const fetchEpisode = vi.fn();
 const detachSymptom = vi.fn();
 
+const dismissEpisode = vi.fn();
+
 vi.mock('../../../engine/episodeApi', () => ({
   fetchOpenEpisodes: (...a: unknown[]) => fetchOpenEpisodes(...a),
   fetchEpisode: (...a: unknown[]) => fetchEpisode(...a),
   detachSymptom: (...a: unknown[]) => detachSymptom(...a),
+  dismissEpisode: (...a: unknown[]) => dismissEpisode(...a),
+}));
+
+// The agent panel opens a WebSocket; not what these tests are about.
+vi.mock('../../../components/agent/InlineAgent', () => ({
+  InlineAgent: ({ initialPrompt }: { initialPrompt?: string }) => (
+    <div data-testid="inline-agent">{initialPrompt}</div>
+  ),
 }));
 
 const EPISODE = {
@@ -203,5 +213,81 @@ describe('EpisodePanel context', () => {
     fetchOpenEpisodes.mockResolvedValue([{ ...EPISODE, recurrence_of: 'ep-earlier' }]);
     render(<EpisodePanel />);
     expect(await screen.findByText('recurring')).toBeTruthy();
+  });
+});
+
+
+// ── the work already done, and the ways out ───────────────────────────────
+
+describe('EpisodePanel investigation and dismissal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchOpenEpisodes.mockResolvedValue([EPISODE]);
+    dismissEpisode.mockResolvedValue(undefined);
+  });
+
+  afterEach(cleanup);
+
+  it('shows what the agent already concluded', async () => {
+    fetchEpisode.mockResolvedValue({
+      episode: EPISODE,
+      symptoms: SYMPTOMS,
+      investigation: {
+        id: 'inv-1', status: 'completed', summary: 's', suspected_cause: 'peer latency',
+        recommended_fix: 'check the network path', confidence: 0.8, error: null,
+        timestamp: 1, failed: false,
+      },
+    });
+    render(<EpisodePanel />);
+    expect(await screen.findByText(/peer latency/)).toBeTruthy();
+    expect(screen.getByText(/check the network path/)).toBeTruthy();
+  });
+
+  it('says the investigation failed rather than showing nothing', async () => {
+    fetchEpisode.mockResolvedValue({
+      episode: EPISODE,
+      symptoms: SYMPTOMS,
+      investigation: {
+        id: 'inv-1', status: 'failed', summary: null, suspected_cause: null,
+        recommended_fix: null, confidence: null, error: 'Connection error.',
+        timestamp: 1, failed: true,
+      },
+    });
+    render(<EpisodePanel />);
+    expect(await screen.findByText(/Connection error/)).toBeTruthy();
+    expect(screen.getByText(/without\s+root-cause analysis/)).toBeTruthy();
+  });
+
+  it('hands the agent everything the card already knows', async () => {
+    fetchEpisode.mockResolvedValue({
+      episode: EPISODE,
+      symptoms: SYMPTOMS,
+      investigation: {
+        id: 'inv-1', status: 'completed', summary: null, suspected_cause: 'x',
+        recommended_fix: null, confidence: null, error: null, timestamp: 1, failed: false,
+      },
+      recurrence: { occurrences: 6, recurring: true, window_seconds: 39600, interval_seconds: 7200 },
+      changes: [{ category: 'audit_rbac', title: 'cluster-admin granted', namespace: 'ns', at: 1, seconds_before: 120 }],
+    });
+    render(<EpisodePanel />);
+    const prompt = (await screen.findByTestId('inline-agent')).textContent || '';
+    expect(prompt).toContain(EPISODE.cause_title);
+    expect(prompt).toContain('cluster-admin granted');
+    expect(prompt).toContain('6 times');
+    expect(prompt).toContain('What should I do about it?');
+  });
+
+  it('an operator can dismiss the episode', async () => {
+    fetchEpisode.mockResolvedValue({ episode: EPISODE, symptoms: SYMPTOMS });
+    render(<EpisodePanel />);
+    fireEvent.click(await screen.findByText('Dismiss'));
+    await waitFor(() => expect(dismissEpisode).toHaveBeenCalledWith('ep-1'));
+  });
+
+  it('renders against an agent that returns no investigation', async () => {
+    fetchEpisode.mockResolvedValue({ episode: EPISODE, symptoms: SYMPTOMS });
+    render(<EpisodePanel />);
+    expect(await screen.findByText(EPISODE.cause_title)).toBeTruthy();
+    expect(screen.queryByTestId('inline-agent')).toBeNull();
   });
 });


### PR DESCRIPTION
UI half of PulseSRE/pulse-agent#39 and the dismiss endpoint from #38.

## The investigation that already ran

Episode causes are auto-investigated, so the work has usually been attempted before anyone opens the card — **22 attempts on the reference cluster, all failed**. The card now shows it: suspected cause and recommended fix, or the error.

**Failed attempts are shown, not hidden.** An empty panel reads as *"nothing worth investigating"*, which is the opposite of what happened.

## Ask a follow-up

The prompt carries the cause, blast radius, recurrence and what changed just before:

> *etcd changed leader 12 times in an hour. 8 symptoms across 2 namespaces. Recurring: 6 times in 11h · every 2h. Changed just before: cluster-admin granted. What should I do about it?*

The agent answers the question the deterministic layer **can't** — what to do — rather than being paid to re-derive what the card already says.

Built on the existing `InlineAgent`, which is designed for this and already used on detail pages. My first attempt invented a `sendToChat` helper that doesn't exist; caught before pushing.

## Dismiss

Until now the only way an episode ended was its cause resolving. A returning cause opens a **new** episode, so dismissing can't hide a problem that comes back.

## Verification

5 new tests: the completed investigation, the failed one, the prompt carrying all four context pieces, the dismiss round-trip, and rendering against an agent that returns no investigation at all. `InlineAgent` is mocked — it opens a WebSocket and isn't what these test.

Every lucide icon checked against existing imports in this repo, every path resolved. No node toolchain here, so CI is the first typecheck.