### PR TITLE
feat: reset the inbox to count from now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Reset the inbox: count from now, keep the history
+- A **Reset** control in the inbox header. It archives everything open, re-baselines every counting scanner and rescans, so what comes back is what is happening rather than what has ever happened. Nothing is deleted — archived items keep their rows and their history
+- The confirmation names what it is about to take — "Archive 33 open items and count from now" — including pinned and claimed work, rather than asking a generic "are you sure?"
+- Afterwards it says what it did: items archived, episodes closed, and whether the rescan ran. A reset whose rescan failed says so instead of handing back a blank page that reads as data loss
+
 ## [2.12.0] - 2026-08-20
 
 ### The episode card shows the work already done, and can be cleared

--- a/src/kubeview/engine/inboxApi.ts
+++ b/src/kubeview/engine/inboxApi.ts
@@ -142,6 +142,22 @@ export async function escalateInboxItem(id: string): Promise<{ finding_id: strin
   return _fetch(`${AGENT_BASE}/inbox/${id}/escalate`, { method: 'POST' });
 }
 
+export interface InboxResetResult {
+  reset_at: number;
+  reset_by: string;
+  items_archived: number;
+  pinned_archived: number;
+  claimed_archived: number;
+  episodes_closed: number;
+  containers_baselined: number;
+  rescanned: boolean;
+  rescan_error?: string;
+}
+
+export async function resetInbox(): Promise<InboxResetResult> {
+  return _fetch(`${AGENT_BASE}/inbox/reset`, { method: 'POST' });
+}
+
 export async function pinInboxItem(id: string): Promise<void> {
   await _fetch(`${AGENT_BASE}/inbox/${id}/pin`, { method: 'POST' });
 }

--- a/src/kubeview/views/inbox/InboxHeader.tsx
+++ b/src/kubeview/views/inbox/InboxHeader.tsx
@@ -3,6 +3,7 @@ import { cn } from '@/lib/utils';
 import { Badge } from '../../components/primitives/Badge';
 import { Button } from '../../components/primitives/Button';
 import { useInboxStore } from '../../store/inboxStore';
+import { InboxResetButton } from './InboxResetButton';
 
 type Preset = 'needs_attention' | 'agent_cleared' | 'my_items' | 'archived' | 'all';
 
@@ -76,10 +77,13 @@ export function InboxHeader({
             </div>
           )}
         </div>
-        <Button size="sm" onClick={onNewTask}>
-          <Plus className="w-4 h-4 mr-1" />
-          New Task
-        </Button>
+        <div className="flex items-center gap-2">
+          <InboxResetButton />
+          <Button size="sm" onClick={onNewTask}>
+            <Plus className="w-4 h-4 mr-1" />
+            New Task
+          </Button>
+        </div>
       </div>
 
       <div className="flex items-center gap-2" role="group" aria-label="Quick filters">

--- a/src/kubeview/views/inbox/InboxResetButton.tsx
+++ b/src/kubeview/views/inbox/InboxResetButton.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react';
+import { AlertTriangle, Loader2, RotateCcw } from 'lucide-react';
+import { Button } from '../../components/primitives/Button';
+import { resetInbox, type InboxResetResult } from '../../engine/inboxApi';
+import { useInboxStore } from '../../store/inboxStore';
+
+/**
+ * Re-baseline the inbox: archive what is open, then count from now.
+ *
+ * The confirmation names what it is about to take rather than asking a generic
+ * "are you sure?". Pinned and claimed items go too — that is what a reset
+ * means — but taking somebody's marked work silently is not the same as taking
+ * it with their agreement.
+ */
+export function InboxResetButton() {
+  const stats = useInboxStore((s) => s.stats);
+  const refresh = useInboxStore((s) => s.refresh);
+  const [confirming, setConfirming] = useState(false);
+  const [running, setRunning] = useState(false);
+  const [result, setResult] = useState<InboxResetResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const openCount = stats.needs_attention ?? 0;
+
+  async function run() {
+    setRunning(true);
+    setError(null);
+    try {
+      const outcome = await resetInbox();
+      setResult(outcome);
+      setConfirming(false);
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Reset failed');
+    } finally {
+      setRunning(false);
+    }
+  }
+
+  if (result) {
+    return (
+      <div className="flex items-center gap-2 text-xs text-slate-400" role="status">
+        <span>
+          Counting from now — {result.items_archived} item{result.items_archived === 1 ? '' : 's'} archived
+          {result.episodes_closed > 0 && `, ${result.episodes_closed} episode${result.episodes_closed === 1 ? '' : 's'} closed`}
+          {result.rescanned ? '. Rescanned.' : '. Rescan failed, next cycle will refill.'}
+        </span>
+        <button onClick={() => setResult(null)} className="text-slate-500 hover:text-slate-300 underline">
+          Dismiss
+        </button>
+      </div>
+    );
+  }
+
+  if (confirming) {
+    return (
+      <div className="flex items-center gap-3 px-3 py-2 rounded-md bg-slate-800 border border-slate-700">
+        <AlertTriangle className="w-4 h-4 text-yellow-400 shrink-0" />
+        <div className="text-xs text-slate-300">
+          <div>
+            Archive {openCount} open item{openCount === 1 ? '' : 's'} and count from now.
+          </div>
+          <div className="text-slate-500">
+            Nothing is deleted — archived items keep their history. Anything still wrong comes straight back
+            on the rescan.
+          </div>
+          {error && <div className="text-red-400 mt-1">{error}</div>}
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <Button size="sm" onClick={run} disabled={running}>
+            {running ? <Loader2 className="w-4 h-4 animate-spin" /> : 'Reset'}
+          </Button>
+          <button
+            onClick={() => setConfirming(false)}
+            disabled={running}
+            className="text-xs text-slate-400 hover:text-slate-200"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      {error && <span className="text-xs text-red-400">{error}</span>}
+      <Button
+        size="sm"
+        variant="ghost"
+        onClick={() => setConfirming(true)}
+        title="Archive everything open and count from now"
+      >
+        <RotateCcw className="w-4 h-4 mr-1" />
+        Reset
+      </Button>
+    </div>
+  );
+}

--- a/src/kubeview/views/inbox/__tests__/InboxResetButton.test.tsx
+++ b/src/kubeview/views/inbox/__tests__/InboxResetButton.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { InboxResetButton } from '../InboxResetButton';
+import { resetInbox } from '../../../engine/inboxApi';
+
+vi.mock('../../../engine/inboxApi', () => ({
+  resetInbox: vi.fn(),
+}));
+
+const refresh = vi.fn();
+
+vi.mock('../../../store/inboxStore', () => ({
+  useInboxStore: vi.fn((selector) =>
+    selector({
+      stats: { needs_attention: 33, total: 339 },
+      refresh,
+    }),
+  ),
+}));
+
+const OUTCOME = {
+  reset_at: 1_700_000_000,
+  reset_by: 'sre@example.com',
+  items_archived: 33,
+  pinned_archived: 1,
+  claimed_archived: 2,
+  episodes_closed: 1,
+  containers_baselined: 412,
+  rescanned: true,
+};
+
+describe('InboxResetButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(resetInbox).mockResolvedValue(OUTCOME);
+  });
+
+  afterEach(cleanup);
+
+  it('does not reset on the first click — it asks first', () => {
+    render(<InboxResetButton />);
+    fireEvent.click(screen.getByText('Reset'));
+    expect(resetInbox).not.toHaveBeenCalled();
+  });
+
+  it('says how many items it is about to take, and that nothing is deleted', () => {
+    render(<InboxResetButton />);
+    fireEvent.click(screen.getByText('Reset'));
+    expect(screen.getByText(/Archive 33 open items/)).toBeDefined();
+    expect(screen.getByText(/Nothing is deleted/)).toBeDefined();
+    expect(screen.getByText(/comes straight back/)).toBeDefined();
+  });
+
+  it('cancelling leaves the inbox alone', () => {
+    render(<InboxResetButton />);
+    fireEvent.click(screen.getByText('Reset'));
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(resetInbox).not.toHaveBeenCalled();
+    expect(screen.getByText('Reset')).toBeDefined();
+  });
+
+  it('confirming resets and reloads the list', async () => {
+    render(<InboxResetButton />);
+    fireEvent.click(screen.getByText('Reset'));
+    fireEvent.click(screen.getAllByText('Reset')[0]);
+    await waitFor(() => expect(resetInbox).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(refresh).toHaveBeenCalled());
+  });
+
+  it('reports what it did rather than just closing', async () => {
+    render(<InboxResetButton />);
+    fireEvent.click(screen.getByText('Reset'));
+    fireEvent.click(screen.getAllByText('Reset')[0]);
+    await waitFor(() => expect(screen.getByRole('status')).toBeDefined());
+    const status = screen.getByRole('status').textContent ?? '';
+    expect(status).toContain('33 items archived');
+    expect(status).toContain('1 episode closed');
+    expect(status).toContain('Rescanned');
+  });
+
+  it('says so when the rescan failed but the reset stood', async () => {
+    vi.mocked(resetInbox).mockResolvedValue({ ...OUTCOME, rescanned: false, rescan_error: 'API down' });
+    render(<InboxResetButton />);
+    fireEvent.click(screen.getByText('Reset'));
+    fireEvent.click(screen.getAllByText('Reset')[0]);
+    await waitFor(() => expect(screen.getByRole('status')).toBeDefined());
+    expect(screen.getByRole('status').textContent).toContain('Rescan failed');
+  });
+
+  it('surfaces a failure instead of pretending it worked', async () => {
+    vi.mocked(resetInbox).mockRejectedValue(new Error('403 Administrator access required'));
+    render(<InboxResetButton />);
+    fireEvent.click(screen.getByText('Reset'));
+    fireEvent.click(screen.getAllByText('Reset')[0]);
+    await waitFor(() => expect(screen.getByText(/Administrator access required/)).toBeDefined());
+    expect(refresh).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
UI half of the inbox reset. Agent side: PulseSRE/pulse-agent (linked below once open).

## Why

From the live cluster, right now: **339 items, 306 resolved, 33 needing attention** — and a critical item reading *"Pod promoter-controller-manager restarting (122x)"* for a container whose lifetime counter had been climbing for days. The number was true and useless.

## What it does

Archives everything open, re-baselines the counting scanners, rescans. **Nothing is deleted** — archived items keep their rows and their history.

The confirmation says what it is about to take:

> Archive 33 open items and count from now.
> Nothing is deleted — archived items keep their history. Anything still wrong comes straight back on the rescan.

Pinned and claimed items go too. That is what a reset means, but taking somebody's marked work silently is not the same as taking it with their agreement.

Afterwards it reports instead of just closing — items archived, episodes closed, whether the rescan ran. A reset whose rescan failed says so, rather than handing back a blank page that reads as data loss.

## Verification

7 new tests, run locally rather than left to CI: first click asks and does not reset, cancel leaves it alone, confirm resets and reloads, the outcome is reported, a failed rescan is distinguished from a failed reset, and a 403 surfaces instead of a silent no-op.

Full suite local: **2,116 passing across 174 files**, `tsc --noEmit` clean.