### PR TITLE
fix: join kube_node_info via label_replace to stop node-metric 422s

### DIFF
--- a/src/kubeview/views/ComputeView.tsx
+++ b/src/kubeview/views/ComputeView.tsx
@@ -88,20 +88,26 @@ export default function ComputeView() {
     enabled: isHyperShift,
   });
 
-  // Per-node CPU usage from Prometheus. Tries the kube_node_info join first
-  // (gives reliable node-name matching on clusters where node-exporter's
-  // `instance` label isn't the node name), falling back to the plain
-  // by-instance query if the join errors — e.g. on clusters where
-  // kube_node_info has no `instance` label at all, which makes `on(instance)`
-  // match every node into one ambiguous group ("duplicate series for the
-  // match group") and Thanos rejects the query outright (422). safeQuery only
-  // swallows 404s, so that failure must be caught here or the plain query
-  // never runs and the UI shows no data.
+  // Per-node CPU usage from Prometheus, joined against kube_node_info to get
+  // a reliable `node` label. kube_node_info (from kube-state-metrics) has no
+  // `instance` label of its own — only `node` — so `on(instance)` against the
+  // bare metric gives every series the same empty match key `{}` and Thanos
+  // rejects the query outright with a 422 ("found duplicate series for the
+  // match group {} ... many-to-many matching not allowed"). label_replace
+  // projects kube_node_info's `node` label onto a synthetic `instance` label
+  // first, so the match key is unique per node and the join succeeds. This
+  // relies on node-exporter's `instance` label already being the Kubernetes
+  // node name, which OpenShift's cluster-monitoring-operator guarantees via a
+  // relabeling rule on the node-exporter ServiceMonitor
+  // (`__meta_kubernetes_pod_node_name` -> `instance`). The plain by-instance
+  // query remains as a defensive fallback in case that relabeling assumption
+  // ever doesn't hold; safeQuery only swallows 404s, so a non-404 failure
+  // (like the 422 above) must still be caught here or the fallback never runs.
   const { data: nodeCpuMetrics = [] } = useQuery({
     queryKey: ['compute', 'node-cpu'],
     queryFn: async () => {
       try {
-        return await queryInstant('sum(rate(node_cpu_seconds_total{mode!="idle"}[5m])) by (instance) * on(instance) group_left(node) kube_node_info');
+        return await queryInstant('sum(rate(node_cpu_seconds_total{mode!="idle"}[5m])) by (instance) * on(instance) group_left(node) label_replace(kube_node_info, "instance", "$1", "node", "(.+)")');
       } catch {
         return (await safeQuery(() => queryInstant('sum(rate(node_cpu_seconds_total{mode!="idle"}[5m])) by (instance)'))) ?? [];
       }
@@ -114,7 +120,7 @@ export default function ComputeView() {
     queryKey: ['compute', 'node-mem'],
     queryFn: async () => {
       try {
-        return await queryInstant('(1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100 * on(instance) group_left(node) kube_node_info');
+        return await queryInstant('(1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100 * on(instance) group_left(node) label_replace(kube_node_info, "instance", "$1", "node", "(.+)")');
       } catch {
         return (await safeQuery(() => queryInstant('(1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100'))) ?? [];
       }

--- a/src/kubeview/views/__tests__/ComputeView.test.tsx
+++ b/src/kubeview/views/__tests__/ComputeView.test.tsx
@@ -71,13 +71,38 @@ describe('ComputeView', () => {
     expect(screen.getByText('Nodes')).toBeTruthy();
   });
 
-  // Regression: on clusters where kube_node_info has no `instance` label,
-  // `on(instance) group_left(node) kube_node_info` makes Thanos collapse every
-  // node into one ambiguous match group and reject the query with a
-  // non-404 error (422 "duplicate series for the match group"). safeQuery only
-  // swallows 404s, so the plain by-instance fallback query must be tried
-  // explicitly — otherwise the hex map/table show "—" for every node's
-  // CPU/memory forever, even though Prometheus itself is reachable and healthy.
+  // Regression: kube_node_info (kube-state-metrics) never has an `instance`
+  // label of its own — only `node` — so joining on it with bare
+  // `on(instance) group_left(node) kube_node_info` gives every node's series
+  // the same empty match key `{}` and Thanos rejects the query with a 422
+  // ("duplicate series for the match group"). The query must project
+  // kube_node_info's `node` label onto a synthetic `instance` label via
+  // `label_replace(...)` before joining so the match key is unique per node.
+  it('joins kube_node_info via label_replace(node -> instance) to avoid the ambiguous-match 422', async () => {
+    const { queryInstant } = await import('../../components/metrics/prometheus');
+    const seenQueries: string[] = [];
+    (queryInstant as any).mockImplementation((query: string) => {
+      seenQueries.push(query);
+      return Promise.resolve([]);
+    });
+
+    renderView();
+
+    await screen.findByText('Compute');
+
+    const cpuQuery = seenQueries.find((q) => q.includes('node_cpu_seconds_total'));
+    const memQuery = seenQueries.find((q) => q.includes('node_memory_MemAvailable_bytes') && q.includes('kube_node_info'));
+
+    expect(cpuQuery).toContain('label_replace(kube_node_info, "instance", "$1", "node", "(.+)")');
+    expect(cpuQuery).not.toMatch(/on\(instance\)\s+group_left\(node\)\s+kube_node_info\b/);
+    expect(memQuery).toContain('label_replace(kube_node_info, "instance", "$1", "node", "(.+)")');
+  });
+
+  // Defensive fallback: safeQuery only swallows 404s, so any other failure
+  // (e.g. a cluster where the label_replace assumption somehow still doesn't
+  // hold) must be caught explicitly and retried as a plain by-instance query
+  // — otherwise the hex map/table show "—" for every node's CPU/memory
+  // forever, even though Prometheus itself is reachable and healthy.
   it('falls back to the plain per-node query and still shows CPU/memory when the kube_node_info join errors', async () => {
     const { queryInstant } = await import('../../components/metrics/prometheus');
     (queryInstant as any).mockImplementation((query: string) => {


### PR DESCRIPTION
## Problem

The browser console on the live Pulse UI showed two recurring `422 Unprocessable Entity` errors from `/api/prometheus/api/v1/query`, for the per-node CPU and memory queries in `ComputeView`:

```
sum(rate(node_cpu_seconds_total{mode!="idle"}[5m])) by (instance) * on(instance) group_left(node) kube_node_info

(1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100 * on(instance) group_left(node) kube_node_info
```

## Root cause (verified against the live cluster's thanos-querier)

This is **not** a PromQL syntax/precedence bug — both queries parse fine. Querying the live `thanos-querier` directly with a `cluster-monitoring-view` service account token reproduces the exact 422, with Thanos returning an `"execution"` error:

```
found duplicate series for the match group {} on the right hand-side of the operation: [...6 kube_node_info series...];
many-to-many matching not allowed: matching labels must be unique on one side
```

`kube_node_info` (from kube-state-metrics) has **no `instance` label at all** — only `node`. So `on(instance)` computes the same empty match key `{}` for every one of the 6 nodes' `kube_node_info` series, and Thanos rejects the ambiguous many-to-many join. This isn't cluster-specific — it reproduces on every real OpenShift cluster, since kube-state-metrics never emits an `instance` label on `kube_node_info`.

(There's already a defensive try/catch around this query from a prior fix, PR #42, which falls back to a plain by-instance query on failure — so the UI itself doesn't show blank data, but the initial doomed request still fires and still logs the 422 to the console on every page load/refetch.)

## Fix

Project `kube_node_info`'s `node` label onto a synthetic `instance` label with `label_replace(...)` before joining, so the match key is unique per node:

```diff
- sum(rate(node_cpu_seconds_total{mode!="idle"}[5m])) by (instance) * on(instance) group_left(node) kube_node_info
+ sum(rate(node_cpu_seconds_total{mode!="idle"}[5m])) by (instance) * on(instance) group_left(node) label_replace(kube_node_info, "instance", "$1", "node", "(.+)")

- (1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100 * on(instance) group_left(node) kube_node_info
+ (1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100 * on(instance) group_left(node) label_replace(kube_node_info, "instance", "$1", "node", "(.+)")
```

This relies on node-exporter's `instance` label already being the Kubernetes node name, which OpenShift's `cluster-monitoring-operator` guarantees via a relabeling rule on the `node-exporter` ServiceMonitor (`__meta_kubernetes_pod_node_name` → `instance` — confirmed by inspecting the live ServiceMonitor). The plain by-instance fallback stays in place defensively in case that assumption ever doesn't hold on some cluster.

### Live verification

Ran both the before and after query strings directly against the live cluster's `thanos-querier` route:

| Query | Before | After |
|---|---|---|
| CPU join | `422` — duplicate series for match group `{}` | `200` — 6 series, each with a distinct `node` label |
| Memory join | `422` — duplicate series for match group `{}` | `200` — 6 series, each with a distinct `node` label |

## Tests

- Updated `ComputeView.test.tsx`'s regression comment/test for the fallback path.
- Added a new test asserting the CPU and memory queries sent to `queryInstant` use `label_replace(kube_node_info, "instance", "$1", "node", "(.+)")` instead of the bare `kube_node_info` join that always 422s.
- `pnpm run type-check`, `pnpm run lint`, `pnpm run test` (2117/2117 passing), and `pnpm run build` all pass locally.

## Scope

Client-side query-construction fix only in `pulse-ui`; no changes to `pulse-operator`'s nginx proxy config — the live Thanos test confirmed the proxy passes the query through untouched and the 422 originates from Thanos's query engine, not the proxy.

Made with [Cursor](https://cursor.com)