### PR TITLE
feat: approve a fix the agent proposed while you were asleep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Approve a fix the agent proposed while you were asleep
+- A **fixes waiting on you** strip above the inbox, listing what the agent proposed and nobody has answered. Trust level 2 means ask first, and the question used to be asked over a WebSocket with 120 seconds to reply — at 03:00 it was never answered, and the agent took no action at all. Proposals now outlive the moment, which only helps if there is somewhere to see them
+- Above the inbox rather than inside it: an unanswered proposal is the one thing on the screen waiting on a *person*, and everything below it is waiting on the cluster
+- Each row says what would be done and to what, then gets out of the way once answered. A fix that ran and failed says so rather than reading as success
+- A refusal is shown as the agent worded it — the condition cleared, somebody else approved it first, no automated fix applies any more. Those are answers, not errors, and it re-reads the list rather than trusting what it had
+
 ## [2.14.0] - 2026-08-20
 
 ### Tracks pulse-agent v2.14.0

--- a/src/kubeview/engine/fixHistory.ts
+++ b/src/kubeview/engine/fixHistory.ts
@@ -93,6 +93,26 @@ export async function fetchBriefing(hours = 12): Promise<BriefingResponse> {
   return res.json();
 }
 
+/**
+ * Approve a fix the agent proposed while nobody was connected to answer it.
+ *
+ * The agent re-derives the plan from the finding as it stands now rather than
+ * replaying what it proposed earlier, so this can be refused: a 409 means the
+ * condition cleared, somebody else approved it first, or no automated fix
+ * applies any more. Those are answers, not errors — surface the message.
+ */
+export async function approveFix(actionId: string): Promise<ActionRecord> {
+  const res = await agentFetch(
+    `${AGENT_BASE}/fix-history/${encodeURIComponent(actionId)}/approve`,
+    { method: 'POST' },
+  );
+  const body = await res.json().catch(() => null);
+  if (!res.ok) {
+    throw new Error(body?.error || `Failed to approve fix: ${res.status} ${res.statusText}`);
+  }
+  return body as ActionRecord;
+}
+
 /** Request a rollback for a completed action. */
 export async function requestRollback(actionId: string): Promise<void> {
   const res = await agentFetch(

--- a/src/kubeview/views/InboxPage.tsx
+++ b/src/kubeview/views/InboxPage.tsx
@@ -10,6 +10,7 @@ import { InboxFilterBar } from './inbox/InboxFilterBar';
 import { InboxItem } from './inbox/InboxItem';
 import { InboxGroup } from './inbox/InboxGroup';
 import { EpisodePanel } from './inbox/EpisodePanel';
+import { ProposedFixes } from './inbox/ProposedFixes';
 import { CapabilityBanner } from '../components/primitives/CapabilityBanner';
 import { NewTaskDialog } from './inbox/NewTaskDialog';
 import { TaskDetailDrawer } from './inbox/TaskDetailDrawer';
@@ -108,6 +109,7 @@ export function InboxPage() {
   return (
     <div className="flex flex-col h-full">
       <InboxHeader onNewTask={() => setNewTaskOpen(true)} />
+      <ProposedFixes />
 
       <Tabs value={activeTab} onValueChange={handleTabChange}>
         <div className="px-4 py-2 border-b border-slate-800">

--- a/src/kubeview/views/inbox/ProposedFixes.tsx
+++ b/src/kubeview/views/inbox/ProposedFixes.tsx
@@ -1,0 +1,107 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Check, Loader2, Wrench } from 'lucide-react';
+import { Button } from '../../components/primitives/Button';
+import { approveFix, fetchFixHistory, type ActionRecord } from '../../engine/fixHistory';
+import { formatElapsed } from '../../engine/dateUtils';
+
+/**
+ * Fixes the agent proposed and nobody has answered.
+ *
+ * Trust level 2 means ask first, and the question used to be asked over a
+ * WebSocket with 120 seconds to reply — so at 03:00 it was never answered and
+ * the agent took no action at all. Proposals now outlive the moment, which
+ * only helps if there is somewhere to see them.
+ *
+ * Above the inbox rather than inside it: an unanswered proposal is the one
+ * thing on this screen that is waiting on a person, and everything below it is
+ * waiting on the cluster.
+ */
+export function ProposedFixes() {
+  const [proposals, setProposals] = useState<ActionRecord[]>([]);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [done, setDone] = useState<Record<string, string>>({});
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetchFixHistory({ filters: { status: 'proposed' } });
+      setProposals(res.actions ?? []);
+    } catch {
+      // A proposal list that cannot load is not worth an error banner over the
+      // inbox — the inbox itself is the thing the operator came for.
+      setProposals([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+    const timer = setInterval(load, 60_000);
+    return () => clearInterval(timer);
+  }, [load]);
+
+  async function approve(action: ActionRecord) {
+    setBusy(action.id);
+    setErrors((e) => ({ ...e, [action.id]: '' }));
+    try {
+      const result = await approveFix(action.id);
+      setDone((d) => ({
+        ...d,
+        [action.id]:
+          result.status === 'completed'
+            ? `Ran ${result.tool || 'the fix'}`
+            : `Failed: ${result.error ?? 'unknown error'}`,
+      }));
+      setProposals((p) => p.filter((a) => a.id !== action.id));
+    } catch (e) {
+      // The agent refuses on purpose — the condition cleared, somebody else
+      // approved it, no strategy applies. Show what it said.
+      setErrors((err) => ({ ...err, [action.id]: e instanceof Error ? e.message : 'Approve failed' }));
+      load();
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  const finished = Object.entries(done);
+  if (proposals.length === 0 && finished.length === 0) return null;
+
+  return (
+    <div className="mx-4 mt-3 rounded-md border border-amber-700/40 bg-amber-500/5">
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-amber-700/30">
+        <Wrench className="w-4 h-4 text-amber-400" />
+        <span className="text-xs font-medium text-amber-200">
+          {proposals.length > 0
+            ? `${proposals.length} fix${proposals.length === 1 ? '' : 'es'} waiting on you`
+            : 'Fixes applied'}
+        </span>
+      </div>
+
+      <ul className="divide-y divide-amber-700/20">
+        {proposals.map((action) => (
+          <li key={action.id} className="flex items-start gap-3 px-3 py-2">
+            <div className="min-w-0 flex-1">
+              <div className="text-sm text-slate-200 truncate">
+                {action.reasoning || action.tool || action.category}
+              </div>
+              <div className="text-xs text-slate-500">
+                {action.resources?.[0] ? `${action.resources[0].kind} ${action.resources[0].name}` : action.category}
+                {action.timestamp ? ` · proposed ${formatElapsed(Math.floor(action.timestamp / 1000))} ago` : ''}
+              </div>
+              {errors[action.id] && <div className="text-xs text-red-400 mt-1">{errors[action.id]}</div>}
+            </div>
+            <Button size="sm" onClick={() => approve(action)} disabled={busy === action.id}>
+              {busy === action.id ? <Loader2 className="w-4 h-4 animate-spin" /> : 'Approve'}
+            </Button>
+          </li>
+        ))}
+      </ul>
+
+      {finished.map(([id, message]) => (
+        <div key={id} className="flex items-center gap-2 px-3 py-2 text-xs text-slate-400">
+          <Check className="w-3.5 h-3.5 text-emerald-400" />
+          {message}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/kubeview/views/inbox/__tests__/ProposedFixes.test.tsx
+++ b/src/kubeview/views/inbox/__tests__/ProposedFixes.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { ProposedFixes } from '../ProposedFixes';
+import { approveFix, fetchFixHistory } from '../../../engine/fixHistory';
+
+vi.mock('../../../engine/fixHistory', () => ({
+  fetchFixHistory: vi.fn(),
+  approveFix: vi.fn(),
+}));
+
+const PROPOSAL = {
+  id: 'a-1',
+  findingId: 'f-1',
+  timestamp: Date.now(),
+  category: 'crashloop',
+  tool: '',
+  input: {},
+  status: 'proposed' as const,
+  beforeState: '',
+  afterState: '',
+  reasoning: 'Auto-fix for crashloop: Pod api-7f9 restarting (12x)',
+  durationMs: 0,
+  rollbackAvailable: false,
+  resources: [{ kind: 'Pod', name: 'api-7f9', namespace: 'prod' }],
+};
+
+describe('ProposedFixes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fetchFixHistory).mockResolvedValue({ actions: [PROPOSAL], total: 1, page: 1, pageSize: 20 });
+    vi.mocked(approveFix).mockResolvedValue({ ...PROPOSAL, status: 'completed', tool: 'delete_pod' });
+  });
+
+  afterEach(cleanup);
+
+  it('shows nothing at all when no fix is waiting', async () => {
+    vi.mocked(fetchFixHistory).mockResolvedValue({ actions: [], total: 0, page: 1, pageSize: 20 });
+    const { container } = render(<ProposedFixes />);
+    await waitFor(() => expect(fetchFixHistory).toHaveBeenCalled());
+    expect(container.textContent).toBe('');
+  });
+
+  it('asks only for proposals, not the whole fix history', async () => {
+    render(<ProposedFixes />);
+    await waitFor(() => expect(fetchFixHistory).toHaveBeenCalled());
+    expect(vi.mocked(fetchFixHistory).mock.calls[0][0]).toEqual({ filters: { status: 'proposed' } });
+  });
+
+  it('says how many are waiting on a person', async () => {
+    render(<ProposedFixes />);
+    await waitFor(() => expect(screen.getByText(/1 fix waiting on you/)).toBeDefined());
+    // What it would do, and what it would do it to.
+    expect(screen.getByText(/Auto-fix for crashloop/)).toBeDefined();
+    expect(screen.getByText(/Pod api-7f9 · proposed/)).toBeDefined();
+  });
+
+  it('approving runs the fix and takes it off the list', async () => {
+    render(<ProposedFixes />);
+    await waitFor(() => expect(screen.getByText('Approve')).toBeDefined());
+    fireEvent.click(screen.getByText('Approve'));
+    await waitFor(() => expect(approveFix).toHaveBeenCalledWith('a-1'));
+    await waitFor(() => expect(screen.getByText(/Ran delete_pod/)).toBeDefined());
+    expect(screen.queryByText('Approve')).toBeNull();
+  });
+
+  it('a fix that ran and failed says so rather than reading as success', async () => {
+    vi.mocked(approveFix).mockResolvedValue({
+      ...PROPOSAL,
+      status: 'failed',
+      error: 'api server said no',
+    });
+    render(<ProposedFixes />);
+    await waitFor(() => expect(screen.getByText('Approve')).toBeDefined());
+    fireEvent.click(screen.getByText('Approve'));
+    await waitFor(() => expect(screen.getByText(/Failed: api server said no/)).toBeDefined());
+  });
+
+  it('surfaces a refusal, because the agent refuses on purpose', async () => {
+    vi.mocked(approveFix).mockRejectedValue(
+      new Error('The condition this was proposed for is no longer being reported — nothing to fix'),
+    );
+    render(<ProposedFixes />);
+    await waitFor(() => expect(screen.getByText('Approve')).toBeDefined());
+    fireEvent.click(screen.getByText('Approve'));
+    await waitFor(() => expect(screen.getByText(/no longer being reported/)).toBeDefined());
+  });
+
+  it('a refusal re-reads the list rather than trusting stale state', async () => {
+    vi.mocked(approveFix).mockRejectedValue(new Error('Somebody else just approved this'));
+    render(<ProposedFixes />);
+    await waitFor(() => expect(screen.getByText('Approve')).toBeDefined());
+    fireEvent.click(screen.getByText('Approve'));
+    await waitFor(() => expect(vi.mocked(fetchFixHistory).mock.calls.length).toBeGreaterThan(1));
+  });
+
+  it('a list that will not load stays quiet instead of shouting over the inbox', async () => {
+    vi.mocked(fetchFixHistory).mockRejectedValue(new Error('network'));
+    const { container } = render(<ProposedFixes />);
+    await waitFor(() => expect(fetchFixHistory).toHaveBeenCalled());
+    expect(container.textContent).toBe('');
+  });
+});


### PR DESCRIPTION
UI for PulseSRE/pulse-agent#49. The endpoint existed; there was nowhere to press it.

## Why here

Trust level 2 means *ask first*, and the question used to be asked over a WebSocket with **120 seconds** to reply. At 03:00 it was never answered, and the agent took no action at all — 2,528 investigations, `total_actions: 0` on the reference cluster. Proposals now outlive the moment, which only helps if there is somewhere to see them.

**Above the inbox, not inside it.** An unanswered proposal is the one thing on that screen waiting on a *person*; everything below it is waiting on the cluster.

## What a row says

> Auto-fix for crashloop: Pod api-7f9 restarting (12x)
> Pod api-7f9 · proposed 3h ago                                    **[ Approve ]**

Then it gets out of the way. A fix that ran and **failed says so** rather than disappearing and reading as success.

## Refusals are answers

The agent declines on purpose — the condition cleared, somebody else approved it first, no automated fix applies any more. Those come back as 409s with a sentence meant for a person, and the strip shows that sentence rather than "something went wrong". It then re-reads the list instead of trusting what it had, because a refusal usually means the world moved.

A list that will not load renders **nothing at all**. The inbox is what the operator came for; a broken side-panel should not shout over it.

## Verification

8 new tests, run locally: the empty case renders nothing, only proposals are requested (not the whole fix history), approving calls through and clears the row, a failed run is distinguished from a successful one, a refusal is surfaced verbatim, a refusal triggers a re-read, and a failed load stays quiet.

Full suite **2,125 passing across 175 files**, `tsc --noEmit` clean.
