### PR TITLE
feat: being unreachable is not the same as being blind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Being unreachable is not the same as being blind
+- The capability banner said "Pulse is not seeing everything" for every degraded capability. That is right for a scanner that has stopped reporting and wrong for a missing notification channel, where the picture is complete and nobody will ever be shown it — an operator reading the old wording would go hunting a broken scanner. It now says **"Pulse cannot reach anyone"**, or names both when both are true
+
 ## [2.15.0] - 2026-08-21
 
 ### Approve a fix the agent proposed while you were asleep

--- a/src/kubeview/components/__tests__/CapabilityBanner.test.tsx
+++ b/src/kubeview/components/__tests__/CapabilityBanner.test.tsx
@@ -65,3 +65,34 @@ describe('CapabilityBanner', () => {
     expect(screen.getByRole('alert').className).toContain('red');
   });
 });
+
+describe('CapabilityBanner — being unreachable is not the same as being blind', () => {
+  afterEach(cleanup);
+
+  const NOTIFICATIONS = finding({
+    id: 'f-notify',
+    title: 'Nothing Pulse finds will reach anyone',
+    resources: [{ kind: 'Agent', name: 'notifications' }],
+  });
+
+  it('a blind scanner still reads as not seeing everything', () => {
+    state.findings = [finding()];
+    render(<CapabilityBanner />);
+    expect(screen.getByText(/Pulse is not seeing everything/)).toBeDefined();
+    expect(screen.getByText(/unknown rather than clear/)).toBeDefined();
+  });
+
+  it('no notification channel reads as cannot reach anyone', () => {
+    state.findings = [NOTIFICATIONS];
+    render(<CapabilityBanner />);
+    expect(screen.getByText(/Pulse cannot reach anyone/)).toBeDefined();
+    // An operator told "not seeing everything" would go hunting a broken scanner.
+    expect(screen.queryByText(/unknown rather than clear/)).toBeNull();
+  });
+
+  it('both at once says both', () => {
+    state.findings = [finding(), NOTIFICATIONS];
+    render(<CapabilityBanner />);
+    expect(screen.getByText(/not seeing everything, and cannot reach anyone/)).toBeDefined();
+  });
+});

--- a/src/kubeview/components/primitives/CapabilityBanner.tsx
+++ b/src/kubeview/components/primitives/CapabilityBanner.tsx
@@ -23,6 +23,19 @@ export function CapabilityBanner({ className }: { className?: string }) {
 
   const critical = degraded.some((f) => f.severity === 'critical');
 
+  // Two different kinds of degraded, and calling both "not seeing everything"
+  // gets one of them wrong. A blind scanner means the picture is incomplete; no
+  // notification channel means the picture is fine and nobody will ever be
+  // shown it. An operator reading "not seeing everything" about the second
+  // would go looking for a broken scanner.
+  const reachable = degraded.filter((f) => f.resources?.[0]?.name !== 'notifications');
+  const blindOnly = reachable.length === degraded.length;
+  const headline = blindOnly
+    ? 'Pulse is not seeing everything'
+    : reachable.length === 0
+      ? 'Pulse cannot reach anyone'
+      : 'Pulse is not seeing everything, and cannot reach anyone';
+
   return (
     <div
       role="alert"
@@ -42,8 +55,8 @@ export function CapabilityBanner({ className }: { className?: string }) {
       <div className="min-w-0 flex-1">
         <div className={cn('font-medium', critical ? 'text-red-200' : 'text-amber-200')}>
           {degraded.length === 1
-            ? 'Pulse is not seeing everything'
-            : `Pulse is not seeing everything — ${degraded.length} capabilities affected`}
+            ? headline
+            : `${headline} — ${degraded.length} capabilities affected`}
         </div>
         <ul className="mt-1 space-y-0.5">
           {degraded.map((f) => (
@@ -53,7 +66,9 @@ export function CapabilityBanner({ className }: { className?: string }) {
           ))}
         </ul>
         <p className={cn('mt-1', critical ? 'text-red-300/60' : 'text-amber-300/60')}>
-          Treat anything these cover as unknown rather than clear.
+          {blindOnly
+            ? 'Treat anything these cover as unknown rather than clear.'
+            : 'What Pulse knows is not reaching anyone who is not looking at this screen.'}
         </p>
       </div>
     </div>


### PR DESCRIPTION
UI for PulseSRE/pulse-agent#53.

The capability banner said **"Pulse is not seeing everything"** for every degraded capability. That is right for a scanner that has stopped reporting, and wrong for a missing notification channel — there the picture is complete and nobody will ever be shown it. An operator reading the old wording would go hunting a broken scanner that does not exist.

| what is degraded | headline |
|---|---|
| a scanner | Pulse is not seeing everything |
| notifications | **Pulse cannot reach anyone** |
| both | Pulse is not seeing everything, and cannot reach anyone |

The footer changes with it: *"treat anything these cover as unknown"* is advice about a blind spot, not about an undelivered message.

3 new tests covering all three cases, including that the blind-spot advice is **absent** when only notifications are degraded. Suite **2,128 passing across 175 files**, `tsc --noEmit` clean.