### PR TITLE
fix: measure "started" from the cause's own onset, not the episode's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.16.1] - 2026-08-21
+
+### "Started" now means when the condition began, not when Pulse noticed it again
+- The episode banner and the inbox's cause card both measured "started"/"running" from `started_at` -- the moment Pulse opened *this* episode row, not the moment the condition itself began. Observed live: two alerts that had been firing for two days and two-and-a-half hours respectively both read "started 7s ago," because each had just reopened a fresh episode after a gap. A cause that has been happening for two days looked brand new
+- Both now read `cause_started_at` when the agent reports it (from Prometheus, for firing alerts) and fall back to `started_at` for causes that don't -- matching the fallback the agent's own "what changed before this started" panel has used since v2.15.0
+
 ## [2.16.0] - 2026-08-21
 
 ### Being unreachable is not the same as being blind

--- a/src/kubeview/engine/episodeApi.ts
+++ b/src/kubeview/engine/episodeApi.ts
@@ -19,6 +19,14 @@ export interface Episode {
   cause_finding_id: string | null;
   cause_layer: number;
   started_at: number;
+  /**
+   * When the condition itself began, if the cause reported its own onset
+   * (firing alerts, from Prometheus). Null for causes that don't -- fall
+   * back to started_at for those. Distinct from started_at, which is only
+   * when Pulse got around to opening an episode for it: a cause firing for
+   * days looks freshly-started every time its episode reopens after a gap.
+   */
+  cause_started_at: number | null;
   ended_at: number | null;
   last_seen_at: number;
   symptom_count: number;

--- a/src/kubeview/views/inbox/EpisodePanel.tsx
+++ b/src/kubeview/views/inbox/EpisodePanel.tsx
@@ -108,7 +108,7 @@ function EpisodeCard({ episode, onChanged }: { episode: Episode; onChanged: () =
           </div>
           <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-slate-400">
             <span>{episode.cause_category}</span>
-            <span>started {formatElapsed(episode.started_at)} ago</span>
+            <span>started {formatElapsed(episode.cause_started_at ?? episode.started_at)} ago</span>
             <span>
               {symptoms.length} {symptoms.length === 1 ? 'symptom' : 'symptoms'}
               {episode.namespaces.length > 0 && ` across ${episode.namespaces.length} namespaces`}

--- a/src/kubeview/views/inbox/__tests__/EpisodePanel.test.tsx
+++ b/src/kubeview/views/inbox/__tests__/EpisodePanel.test.tsx
@@ -31,6 +31,7 @@ const EPISODE = {
   cause_finding_id: 'f-1',
   cause_layer: 0,
   started_at: Math.floor(Date.now() / 1000) - 600,
+  cause_started_at: null,
   ended_at: null,
   last_seen_at: Math.floor(Date.now() / 1000),
   symptom_count: 2,
@@ -86,6 +87,27 @@ describe('EpisodePanel', () => {
     render(<EpisodePanel />);
     expect(await screen.findByText(EPISODE.cause_title)).toBeTruthy();
     expect(screen.getByText('Cause')).toBeTruthy();
+  });
+
+  it('measures "started" from the episode when the cause reports no onset of its own', async () => {
+    fetchOpenEpisodes.mockResolvedValue([{ ...EPISODE, started_at: Math.floor(Date.now() / 1000) - 600 }]);
+    render(<EpisodePanel />);
+    expect(await screen.findByText(/started 10m ago/)).toBeTruthy();
+  });
+
+  it('measures "started" from the cause\'s own onset, not from when Pulse opened the episode', async () => {
+    // Observed live: a cause firing for two days, an episode reopened seconds
+    // ago after a gap -- "started 7s ago" for a condition nowhere near new.
+    fetchOpenEpisodes.mockResolvedValue([
+      {
+        ...EPISODE,
+        started_at: Math.floor(Date.now() / 1000) - 7,
+        cause_started_at: Math.floor(Date.now() / 1000) - 2 * 86400,
+      },
+    ]);
+    render(<EpisodePanel />);
+    expect(await screen.findByText(/started 2d ago/)).toBeTruthy();
+    expect(screen.queryByText(/started 7s ago/)).toBeNull();
   });
 
   it('shows the blast radius so the list is not mistaken for separate problems', async () => {

--- a/src/kubeview/views/pulse/OpenEpisodeBanner.tsx
+++ b/src/kubeview/views/pulse/OpenEpisodeBanner.tsx
@@ -56,7 +56,7 @@ export function OpenEpisodeBanner({ onOpen }: { onOpen: () => void }) {
           <span className="truncate text-sm font-medium text-slate-100">{first.cause_title}</span>
         </div>
         <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-slate-400">
-          <span>running {formatElapsed(first.started_at)}</span>
+          <span>running {formatElapsed(first.cause_started_at ?? first.started_at)}</span>
           <span>
             {first.symptom_count} {first.symptom_count === 1 ? 'symptom' : 'symptoms'}
             {first.namespaces.length > 0 && ` across ${first.namespaces.length} namespaces`}

--- a/src/kubeview/views/pulse/__tests__/OpenEpisodeBanner.test.tsx
+++ b/src/kubeview/views/pulse/__tests__/OpenEpisodeBanner.test.tsx
@@ -24,6 +24,7 @@ const EPISODE = {
   cause_finding_id: 'f-1',
   cause_layer: 0,
   started_at: Math.floor(Date.now() / 1000) - 1800,
+  cause_started_at: null,
   ended_at: null,
   last_seen_at: Math.floor(Date.now() / 1000),
   symptom_count: 8,
@@ -57,6 +58,21 @@ describe('OpenEpisodeBanner', () => {
     render(<OpenEpisodeBanner onOpen={vi.fn()} />);
     expect(await screen.findByText(/running 30m/)).toBeTruthy();
     expect(screen.getByText(/8 symptoms across 2 namespaces/)).toBeTruthy();
+  });
+
+  it('measures "running" from the cause\'s own onset, not from when the episode reopened', async () => {
+    // Observed live: a cause firing for two days, an episode reopened seconds
+    // ago after a gap -- "running 7s" for a condition nowhere near new.
+    fetchOpenEpisodes.mockResolvedValue([
+      {
+        ...EPISODE,
+        started_at: Math.floor(Date.now() / 1000) - 7,
+        cause_started_at: Math.floor(Date.now() / 1000) - 2 * 86400,
+      },
+    ]);
+    render(<OpenEpisodeBanner onOpen={vi.fn()} />);
+    expect(await screen.findByText(/running 2d/)).toBeTruthy();
+    expect(screen.queryByText(/running 7s/)).toBeNull();
   });
 
   it('takes you to the incident in one click', async () => {


### PR DESCRIPTION
## Summary

The episode banner (`OpenEpisodeBanner`) and the inbox's cause card (`EpisodePanel`) both showed "started X ago" / "running X" computed from `episode.started_at` — the moment Pulse opened *that specific episode row*, not the moment the underlying condition actually began. `open_or_touch()` on the agent side opens a fresh episode (fresh `started_at`) every time a recurring cause reopens after a gap, even when the condition itself has been firing continuously the whole time.

Confirmed live on the reference cluster (matching the attached screenshot): `HighOverallControlPlaneMemory` and `ControlPlaneNodeMemoryHigh` both displayed **"started 7s ago"** because both episodes had just reopened in the same scan cycle (`started_at` = same second for both, `1787325364`). Querying the episodes table directly:

| | `started_at` (shown) | `cause_started_at` (real onset) | actual gap |
|---|---|---|---|
| `HighOverallControlPlaneMemory` | 2026-08-21 15:16:04 | 2026-08-19 20:40:29 | ~42h |
| `ControlPlaneNodeMemoryHigh` | 2026-08-21 15:16:04 | 2026-08-21 12:35:58 | ~2h40m |

`cause_started_at` — the alert's real Prometheus onset — was already being recorded on the agent side since pulse-agent v2.15.0 (`episodes.py`'s `changes_around()` already prefers it over `started_at` for exactly this reason, per that release's own CHANGELOG entry: *"a cause firing for 30 hours, an episode 12 minutes old"*). It reaches the `/episodes` API response already (confirmed via a direct call to the live agent) — the frontend just never read it for the "started"/"running" line.

## Fix

- `Episode.cause_started_at: number | null` added to the type (`episodeApi.ts`) — the field the API already sends.
- `EpisodePanel.tsx`: `started {formatElapsed(episode.cause_started_at ?? episode.started_at)} ago`
- `OpenEpisodeBanner.tsx`: `running {formatElapsed(first.cause_started_at ?? first.started_at)}`
- Same fallback semantics the agent's own `changes_around()` already uses, so a cause that reports no onset still falls back to the episode's own start.

## Test plan

- [x] New regression tests in both `EpisodePanel.test.tsx` and `OpenEpisodeBanner.test.tsx`: a cause with `cause_started_at` 2 days before `started_at` renders "started 2d ago" / "running 2d", never "7s ago"/"running 7s".
- [x] `pnpm run type-check` — clean
- [x] `pnpm run lint` — clean (0 errors on changed files; pre-existing unrelated warnings elsewhere untouched)
- [x] `pnpm run test` — 175 files / 2131 tests passed

Made with [Cursor](https://cursor.com)