### PR TITLE
fix: clamp a long fix-failure message to one line in the Inbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.16.2] - 2026-08-21
+
+### A long fix-failure message could blow out the "Fixes applied" row
+- The failed-fix line in the Inbox's Fixes-applied banner rendered `Failed: ${error}` with no truncation. pulse-agent already cleans up Kubernetes API failures before they reach the UI, but nothing stopped an unexpectedly long message from wrapping past the row -- as a safety net, it is now clamped to a single line with the full text available on hover
+
 ## [2.16.1] - 2026-08-21
 
 ### "Started" now means when the condition began, not when Pulse noticed it again

--- a/src/kubeview/views/inbox/ProposedFixes.tsx
+++ b/src/kubeview/views/inbox/ProposedFixes.tsx
@@ -98,8 +98,13 @@ export function ProposedFixes() {
 
       {finished.map(([id, message]) => (
         <div key={id} className="flex items-center gap-2 px-3 py-2 text-xs text-slate-400">
-          <Check className="w-3.5 h-3.5 text-emerald-400" />
-          {message}
+          <Check className="w-3.5 h-3.5 text-emerald-400 shrink-0" />
+          {/* Backend messages are cleaned up before they get here, but a
+              single-line clamp is a cheap safety net against anything long
+              blowing out this row's layout. */}
+          <span className="min-w-0 truncate" title={message}>
+            {message}
+          </span>
         </div>
       ))}
     </div>

--- a/src/kubeview/views/inbox/__tests__/ProposedFixes.test.tsx
+++ b/src/kubeview/views/inbox/__tests__/ProposedFixes.test.tsx
@@ -76,6 +76,20 @@ describe('ProposedFixes', () => {
     await waitFor(() => expect(screen.getByText(/Failed: api server said no/)).toBeDefined());
   });
 
+  it('a long failure message is clamped to one line as a layout safety net', async () => {
+    // The backend cleans up ApiException text before this ever arrives, but a
+    // clamp here means a surprise wall of text can never blow out this row —
+    // the full message is still available on hover via title.
+    const longMessage =
+      'pods "klusterlet-646d4fdd8b-4kz56" is forbidden: User "system:serviceaccount:openshiftpulse:pulse-openshift-sre-agent" cannot delete resource "pods" in API group "" in the namespace "open-cluster-management-agent"';
+    vi.mocked(approveFix).mockResolvedValue({ ...PROPOSAL, status: 'failed', error: longMessage });
+    render(<ProposedFixes />);
+    await waitFor(() => expect(screen.getByText('Approve')).toBeDefined());
+    fireEvent.click(screen.getByText('Approve'));
+    const messageEl = await waitFor(() => screen.getByTitle(`Failed: ${longMessage}`));
+    expect(messageEl.className).toContain('truncate');
+  });
+
   it('surfaces a refusal, because the agent refuses on purpose', async () => {
     vi.mocked(approveFix).mockRejectedValue(
       new Error('The condition this was proposed for is no longer being reported — nothing to fix'),


### PR DESCRIPTION
## What

Secondary/defensive fix for the "Fixes applied" banner rendering an
unbounded-length `Failed: ${error}` string. The primary fix is on the
backend (pulse-agent#64: stop generating garbage text in the first place —
`str(ApiException)` was dumping the whole exception repr, headers included,
into this exact field). This PR is the UI-side safety net so a long message
— of any origin — can never blow out this row's layout again.

## Change

`ProposedFixes.tsx`'s finished-fix row now wraps the message in a
`truncate` + `min-w-0` span (matching the existing pattern in
`ToolDetailDrawer.tsx`), with the full text available via `title` on hover.

## Tests

- New test: a long failure message renders clamped (`truncate` class
  present) with the full text in `title`.
- `pnpm run type-check`, `pnpm eslint`, `pnpm vitest run` on the touched
  files: all green.

## Test plan
- [x] `pnpm run type-check`
- [x] `pnpm eslint src/kubeview/views/inbox/ProposedFixes.tsx src/kubeview/views/inbox/__tests__/ProposedFixes.test.tsx`
- [x] `pnpm vitest run src/kubeview/views/inbox/__tests__/ProposedFixes.test.tsx` (9/9 passed)
- [ ] CI green

Made with [Cursor](https://cursor.com)