### PR TITLE
feat(memory): surface what Pulse knows about this cluster

### DIFF
--- a/src/kubeview/views/MemoryView.tsx
+++ b/src/kubeview/views/MemoryView.tsx
@@ -1,10 +1,11 @@
 import { useState, useRef, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Brain, BookOpen, TrendingUp, Search, ChevronDown, ChevronRight, ThumbsUp, Zap, History, Target, FileText, Activity, Award, Download, Upload } from 'lucide-react';
+import { Brain, BookOpen, TrendingUp, Search, ChevronDown, ChevronRight, ThumbsUp, Zap, History, Target, FileText, Activity, Award, Download, Upload, Building2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Card } from '../components/primitives/Card';
 import { EmptyState } from '../components/primitives/EmptyState';
 import { formatRelativeTime } from '../engine/formatters';
+import ClusterKnowledge from './memory/ClusterKnowledge';
 
 const AGENT_BASE = '/api/agent';
 
@@ -66,7 +67,7 @@ async function fetchIncidents(search = ''): Promise<Incident[]> {
   return (await res.json()).incidents || [];
 }
 
-type Tab = 'runbooks' | 'patterns' | 'incidents';
+type Tab = 'cluster' | 'runbooks' | 'patterns' | 'incidents';
 
 export default function MemoryView({ embedded = false }: { embedded?: boolean }) {
   const [activeTab, setActiveTab] = useState<Tab>('incidents');
@@ -158,12 +159,17 @@ export default function MemoryView({ embedded = false }: { embedded?: boolean })
   };
 
   const tabs: { id: Tab; label: string; count: number; icon: typeof Brain }[] = [
+    { id: 'cluster', label: 'This Cluster', count: 0, icon: Building2 },
     { id: 'runbooks', label: 'Learned Runbooks', count: runbooks.length, icon: BookOpen },
     { id: 'patterns', label: 'Detected Patterns', count: patterns.length, icon: TrendingUp },
     { id: 'incidents', label: 'Incident History', count: incidents.length, icon: History },
   ];
 
   const TAB_DESCRIPTIONS: Record<Tab, { title: string; description: string }> = {
+    cluster: {
+      title: 'This Cluster',
+      description: 'What Pulse knows about your environment specifically — ownership, retention, conventions — and what normal looks like for each workload. Also shows which diagnoses have been confirmed by a working fix, since only those become reusable skills.',
+    },
     runbooks: {
       title: 'Learned Runbooks',
       description: 'When you give thumbs up on a helpful response, the agent extracts the tool sequence as a reusable runbook. Next time it encounters a similar issue, it will suggest these steps first.',
@@ -326,6 +332,9 @@ export default function MemoryView({ embedded = false }: { embedded?: boolean })
             <p className="text-xs text-slate-400 mt-0.5">{TAB_DESCRIPTIONS[activeTab].description}</p>
           </div>
         </div>
+
+        {/* This Cluster Tab */}
+        {activeTab === 'cluster' && <ClusterKnowledge />}
 
         {/* Runbooks Tab */}
         {activeTab === 'runbooks' && (

--- a/src/kubeview/views/__tests__/ClusterKnowledge.test.tsx
+++ b/src/kubeview/views/__tests__/ClusterKnowledge.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, cleanup } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 import ClusterKnowledge, { formatMetricValue } from '../memory/ClusterKnowledge';
@@ -46,6 +46,9 @@ describe('formatMetricValue', () => {
 
 describe('ClusterKnowledge', () => {
   beforeEach(() => {
+    // vitest globals are off here, so RTL's auto-cleanup is not registered and
+    // renders would otherwise accumulate across tests in this file.
+    cleanup();
     mockFetch.mockReset();
   });
 

--- a/src/kubeview/views/__tests__/ClusterKnowledge.test.tsx
+++ b/src/kubeview/views/__tests__/ClusterKnowledge.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 import ClusterKnowledge, { formatMetricValue } from '../memory/ClusterKnowledge';
@@ -56,9 +56,11 @@ describe('ClusterKnowledge', () => {
     });
     renderWithProviders(<ClusterKnowledge />);
 
-    await waitFor(() => expect(screen.getByText('Awaiting outcome')).toBeDefined());
+    // wait on data-dependent text; the static labels render before the query settles
+    expect(await screen.findByText(/78% of judged trajectories/)).toBeDefined();
+    expect(screen.getByText('Awaiting outcome')).toBeDefined();
     expect(screen.getByText('7')).toBeDefined();
-    expect(screen.getByText(/78% of judged trajectories/)).toBeDefined();
+    expect(screen.getByText('3')).toBeDefined();
   });
 
   it('groups environment facts by scope and shows their source', async () => {
@@ -73,7 +75,7 @@ describe('ClusterKnowledge', () => {
     });
     renderWithProviders(<ClusterKnowledge />);
 
-    await waitFor(() => expect(screen.getByText('prometheus_retention')).toBeDefined());
+    expect(await screen.findByText('prometheus_retention')).toBeDefined();
     expect(screen.getByText('30 days')).toBeDefined();
     expect(screen.getByText('payments')).toBeDefined();
     expect(screen.getByText('via operator')).toBeDefined();
@@ -87,7 +89,7 @@ describe('ClusterKnowledge', () => {
     });
     renderWithProviders(<ClusterKnowledge />);
 
-    await waitFor(() => expect(screen.getByText('Nothing recorded yet')).toBeDefined());
+    expect(await screen.findByText('Nothing recorded yet')).toBeDefined();
     expect(screen.getByText(/treats this cluster like any other/)).toBeDefined();
   });
 
@@ -98,8 +100,7 @@ describe('ClusterKnowledge', () => {
     });
     renderWithProviders(<ClusterKnowledge />);
 
-    await waitFor(() => expect(screen.getByText('Nothing recorded yet')).toBeDefined());
+    expect(await screen.findByText(/Enter a namespace/)).toBeDefined();
     expect(mockFetch.mock.calls.some(([url]) => String(url).includes('/memory/baselines'))).toBe(false);
-    expect(screen.getByText(/Enter a namespace/)).toBeDefined();
   });
 });

--- a/src/kubeview/views/__tests__/ClusterKnowledge.test.tsx
+++ b/src/kubeview/views/__tests__/ClusterKnowledge.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import ClusterKnowledge, { formatMetricValue } from '../memory/ClusterKnowledge';
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+function renderWithProviders(ui: React.ReactElement) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+}
+
+function jsonResponse(body: unknown) {
+  return Promise.resolve({ ok: true, json: () => Promise.resolve(body) });
+}
+
+function routeFetch(routes: Record<string, unknown>) {
+  mockFetch.mockImplementation((url: string) => {
+    for (const [fragment, body] of Object.entries(routes)) {
+      if (url.includes(fragment)) return jsonResponse(body);
+    }
+    return jsonResponse({});
+  });
+}
+
+describe('formatMetricValue', () => {
+  it('compacts large values the way an operator writes them', () => {
+    expect(formatMetricValue(1_500)).toBe('1.5k');
+    expect(formatMetricValue(2_400_000)).toBe('2.4M');
+    expect(formatMetricValue(3_000_000_000)).toBe('3.0G');
+  });
+
+  it('keeps small values readable', () => {
+    expect(formatMetricValue(0)).toBe('0');
+    expect(formatMetricValue(12.345)).toBe('12.35');
+  });
+
+  it('does not render a non-finite value as a number', () => {
+    expect(formatMetricValue(Number.NaN)).toBe('—');
+    expect(formatMetricValue(Number.POSITIVE_INFINITY)).toBe('—');
+  });
+});
+
+describe('ClusterKnowledge', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('shows the learning gate counters', async () => {
+    routeFetch({
+      '/memory/learning': { pending: 3, promoted: 7, discarded: 2, expired: 1 },
+      '/memory/environment': { facts: [] },
+    });
+    renderWithProviders(<ClusterKnowledge />);
+
+    await waitFor(() => expect(screen.getByText('Awaiting outcome')).toBeDefined());
+    expect(screen.getByText('7')).toBeDefined();
+    expect(screen.getByText(/78% of judged trajectories/)).toBeDefined();
+  });
+
+  it('groups environment facts by scope and shows their source', async () => {
+    routeFetch({
+      '/memory/learning': { pending: 0, promoted: 0, discarded: 0, expired: 0 },
+      '/memory/environment': {
+        facts: [
+          { scope: 'cluster', key: 'prometheus_retention', value: '30 days', source: 'operator', confidence: 0.9, updatedAt: 0 },
+          { scope: 'payments', key: 'owner', value: 'commerce team', source: '', confidence: 0.8, updatedAt: 0 },
+        ],
+      },
+    });
+    renderWithProviders(<ClusterKnowledge />);
+
+    await waitFor(() => expect(screen.getByText('prometheus_retention')).toBeDefined());
+    expect(screen.getByText('30 days')).toBeDefined();
+    expect(screen.getByText('payments')).toBeDefined();
+    expect(screen.getByText('via operator')).toBeDefined();
+    expect(screen.getByText('source unknown')).toBeDefined();
+  });
+
+  it('explains the consequence when nothing is known yet', async () => {
+    routeFetch({
+      '/memory/learning': { pending: 0, promoted: 0, discarded: 0, expired: 0 },
+      '/memory/environment': { facts: [] },
+    });
+    renderWithProviders(<ClusterKnowledge />);
+
+    await waitFor(() => expect(screen.getByText('Nothing recorded yet')).toBeDefined());
+    expect(screen.getByText(/treats this cluster like any other/)).toBeDefined();
+  });
+
+  it('does not request baselines until a namespace is given', async () => {
+    routeFetch({
+      '/memory/learning': { pending: 0, promoted: 0, discarded: 0, expired: 0 },
+      '/memory/environment': { facts: [] },
+    });
+    renderWithProviders(<ClusterKnowledge />);
+
+    await waitFor(() => expect(screen.getByText('Nothing recorded yet')).toBeDefined());
+    expect(mockFetch.mock.calls.some(([url]) => String(url).includes('/memory/baselines'))).toBe(false);
+    expect(screen.getByText(/Enter a namespace/)).toBeDefined();
+  });
+});

--- a/src/kubeview/views/memory/ClusterKnowledge.tsx
+++ b/src/kubeview/views/memory/ClusterKnowledge.tsx
@@ -216,7 +216,7 @@ export default function ClusterKnowledge() {
 
         {factList.length === 0 ? (
           <EmptyState
-            icon={Building2}
+            icon={<Building2 className="w-10 h-10 text-slate-600" />}
             title="Nothing recorded yet"
             description="Pulse records facts as it learns them, and you can add them directly. Until then it treats this cluster like any other."
           />
@@ -284,7 +284,7 @@ export default function ClusterKnowledge() {
           <p className="text-xs text-slate-500">Loading…</p>
         ) : (baselines.data || []).length === 0 ? (
           <EmptyState
-            icon={Gauge}
+            icon={<Gauge className="w-10 h-10 text-slate-600" />}
             title={`No baselines for ${namespace}`}
             description="Baselines build up as Pulse observes a workload. Until one exists, readings are reported as raw values."
           />

--- a/src/kubeview/views/memory/ClusterKnowledge.tsx
+++ b/src/kubeview/views/memory/ClusterKnowledge.tsx
@@ -1,0 +1,334 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Building2, Gauge, GraduationCap, Plus, Trash2, AlertTriangle, Check } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Card } from '../../components/primitives/Card';
+import { EmptyState } from '../../components/primitives/EmptyState';
+import { formatRelativeTime } from '../../engine/formatters';
+
+const AGENT_BASE = '/api/agent';
+
+export interface EnvironmentFact {
+  scope: string;
+  key: string;
+  value: string;
+  source: string;
+  confidence: number;
+  updatedAt: number;
+}
+
+export interface WorkloadBaseline {
+  namespace: string;
+  workload: string;
+  metric: string;
+  p50: number;
+  p95: number;
+  sampleCount: number;
+  windowHours: number;
+  reliable: boolean;
+  updatedAt: number;
+}
+
+export interface LearningStats {
+  pending: number;
+  promoted: number;
+  discarded: number;
+  expired: number;
+}
+
+async function fetchFacts(): Promise<EnvironmentFact[]> {
+  const res = await fetch(`${AGENT_BASE}/memory/environment`);
+  if (!res.ok) throw new Error('Failed to load environment facts');
+  return (await res.json()).facts || [];
+}
+
+async function fetchBaselines(namespace: string): Promise<WorkloadBaseline[]> {
+  if (!namespace) return [];
+  const params = new URLSearchParams({ namespace });
+  const res = await fetch(`${AGENT_BASE}/memory/baselines?${params}`);
+  if (!res.ok) throw new Error('Failed to load baselines');
+  return (await res.json()).baselines || [];
+}
+
+async function fetchLearning(): Promise<LearningStats> {
+  const res = await fetch(`${AGENT_BASE}/memory/learning`);
+  if (!res.ok) throw new Error('Failed to load learning stats');
+  return await res.json();
+}
+
+/** Compact a byte/count value the way an operator writes it. */
+export function formatMetricValue(value: number): string {
+  if (!Number.isFinite(value)) return '—';
+  if (Math.abs(value) >= 1_000_000_000) return `${(value / 1_000_000_000).toFixed(1)}G`;
+  if (Math.abs(value) >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (Math.abs(value) >= 1_000) return `${(value / 1_000).toFixed(1)}k`;
+  return `${Math.round(value * 100) / 100}`;
+}
+
+export default function ClusterKnowledge() {
+  const queryClient = useQueryClient();
+  const [namespace, setNamespace] = useState('');
+  const [showAdd, setShowAdd] = useState(false);
+  const [draft, setDraft] = useState({ scope: 'cluster', key: '', value: '' });
+
+  const facts = useQuery({ queryKey: ['env-facts'], queryFn: fetchFacts });
+  const baselines = useQuery({
+    queryKey: ['baselines', namespace],
+    queryFn: () => fetchBaselines(namespace),
+    enabled: namespace.length > 0,
+  });
+  const learning = useQuery({ queryKey: ['learning-stats'], queryFn: fetchLearning });
+
+  const addFact = useMutation({
+    mutationFn: async (fact: { scope: string; key: string; value: string }) => {
+      const res = await fetch(`${AGENT_BASE}/memory/environment`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...fact, source: 'operator' }),
+      });
+      if (!res.ok) throw new Error('Failed to save');
+      return await res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['env-facts'] });
+      setDraft({ scope: 'cluster', key: '', value: '' });
+      setShowAdd(false);
+    },
+  });
+
+  const removeFact = useMutation({
+    mutationFn: async (fact: EnvironmentFact) => {
+      const res = await fetch(
+        `${AGENT_BASE}/memory/environment/${encodeURIComponent(fact.scope)}/${encodeURIComponent(fact.key)}`,
+        { method: 'DELETE' },
+      );
+      if (!res.ok) throw new Error('Failed to delete');
+      return await res.json();
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['env-facts'] }),
+  });
+
+  const factList = facts.data || [];
+  const byScope = factList.reduce<Record<string, EnvironmentFact[]>>((acc, fact) => {
+    (acc[fact.scope] ||= []).push(fact);
+    return acc;
+  }, {});
+
+  const stats = learning.data;
+  const totalJudged = stats ? stats.promoted + stats.discarded : 0;
+  const promotionRate = totalJudged > 0 ? Math.round(((stats?.promoted ?? 0) / totalJudged) * 100) : null;
+
+  return (
+    <div className="space-y-6">
+      {/* ── Learning gate ─────────────────────────────────────────── */}
+      <Card className="p-4">
+        <div className="flex items-start gap-3 mb-3">
+          <GraduationCap className="w-4 h-4 text-emerald-400 mt-0.5 shrink-0" />
+          <div>
+            <div className="text-sm font-medium text-slate-200">Verified learning</div>
+            <p className="text-xs text-slate-400 mt-0.5">
+              A diagnosis only becomes a reusable skill once the fix it proposed is confirmed to have
+              resolved the problem. Diagnoses whose fix did not hold are discarded, not learned.
+            </p>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          {[
+            { label: 'Awaiting outcome', value: stats?.pending ?? 0, tone: 'text-sky-300' },
+            { label: 'Learned', value: stats?.promoted ?? 0, tone: 'text-emerald-300' },
+            { label: 'Discarded', value: stats?.discarded ?? 0, tone: 'text-amber-300' },
+            { label: 'Expired unverified', value: stats?.expired ?? 0, tone: 'text-slate-400' },
+          ].map((s) => (
+            <div key={s.label} className="rounded border border-slate-800 bg-slate-900/40 px-3 py-2">
+              <div className={cn('text-xl font-semibold tabular-nums', s.tone)}>{s.value}</div>
+              <div className="text-[11px] text-slate-400 mt-0.5">{s.label}</div>
+            </div>
+          ))}
+        </div>
+
+        {promotionRate !== null && (
+          <div className="text-xs text-slate-400 mt-3">
+            {promotionRate}% of judged trajectories were worth learning from
+            <span className="text-slate-500"> ({totalJudged} judged)</span>
+          </div>
+        )}
+      </Card>
+
+      {/* ── Environment facts ─────────────────────────────────────── */}
+      <Card className="p-4">
+        <div className="flex items-start justify-between gap-3 mb-3">
+          <div className="flex items-start gap-3">
+            <Building2 className="w-4 h-4 text-indigo-400 mt-0.5 shrink-0" />
+            <div>
+              <div className="text-sm font-medium text-slate-200">What Pulse knows about this cluster</div>
+              <p className="text-xs text-slate-400 mt-0.5">
+                Ownership, retention windows, GitOps topology, local conventions. Correct anything that is
+                wrong — the agent uses these instead of re-deriving them every investigation.
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => setShowAdd((v) => !v)}
+            className="shrink-0 inline-flex items-center gap-1 rounded border border-slate-700 px-2 py-1
+                       text-xs text-slate-300 hover:bg-slate-800 focus:outline-none focus-visible:ring-2
+                       focus-visible:ring-sky-500"
+          >
+            <Plus className="w-3 h-3" /> Add fact
+          </button>
+        </div>
+
+        {showAdd && (
+          <div className="grid gap-2 sm:grid-cols-[8rem_10rem_1fr_auto] mb-4">
+            <input
+              value={draft.scope}
+              onChange={(e) => setDraft({ ...draft, scope: e.target.value })}
+              placeholder="scope"
+              aria-label="Scope"
+              className="rounded border border-slate-700 bg-slate-900 px-2 py-1 text-xs text-slate-200"
+            />
+            <input
+              value={draft.key}
+              onChange={(e) => setDraft({ ...draft, key: e.target.value })}
+              placeholder="key"
+              aria-label="Fact key"
+              className="rounded border border-slate-700 bg-slate-900 px-2 py-1 text-xs text-slate-200"
+            />
+            <input
+              value={draft.value}
+              onChange={(e) => setDraft({ ...draft, value: e.target.value })}
+              placeholder="what is true"
+              aria-label="Fact value"
+              className="rounded border border-slate-700 bg-slate-900 px-2 py-1 text-xs text-slate-200"
+            />
+            <button
+              type="button"
+              disabled={!draft.key.trim() || !draft.value.trim() || addFact.isPending}
+              onClick={() => addFact.mutate(draft)}
+              className="rounded bg-sky-600 px-3 py-1 text-xs font-medium text-white
+                         disabled:opacity-40 disabled:cursor-not-allowed hover:bg-sky-500"
+            >
+              {addFact.isPending ? 'Saving…' : 'Save'}
+            </button>
+          </div>
+        )}
+
+        {factList.length === 0 ? (
+          <EmptyState
+            icon={Building2}
+            title="Nothing recorded yet"
+            description="Pulse records facts as it learns them, and you can add them directly. Until then it treats this cluster like any other."
+          />
+        ) : (
+          <div className="space-y-4">
+            {Object.entries(byScope)
+              .sort(([a], [b]) => a.localeCompare(b))
+              .map(([scope, entries]) => (
+                <div key={scope}>
+                  <div className="text-[11px] uppercase tracking-wide text-slate-500 mb-1">{scope}</div>
+                  <div className="divide-y divide-slate-800 rounded border border-slate-800">
+                    {entries.map((fact) => (
+                      <div key={fact.key} className="flex items-start gap-3 px-3 py-2">
+                        <div className="min-w-0 flex-1">
+                          <div className="text-xs font-medium text-slate-200">{fact.key}</div>
+                          <div className="text-xs text-slate-300 mt-0.5 break-words">{fact.value}</div>
+                          <div className="text-[11px] text-slate-500 mt-1">
+                            {fact.source ? `via ${fact.source}` : 'source unknown'}
+                            {fact.updatedAt ? ` · ${formatRelativeTime(fact.updatedAt)}` : ''}
+                          </div>
+                        </div>
+                        <button
+                          type="button"
+                          aria-label={`Forget ${fact.key}`}
+                          onClick={() => removeFact.mutate(fact)}
+                          className="shrink-0 rounded p-1 text-slate-500 hover:text-rose-400 hover:bg-slate-800
+                                     focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-500"
+                        >
+                          <Trash2 className="w-3.5 h-3.5" />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+          </div>
+        )}
+      </Card>
+
+      {/* ── Baselines ─────────────────────────────────────────────── */}
+      <Card className="p-4">
+        <div className="flex items-start gap-3 mb-3">
+          <Gauge className="w-4 h-4 text-amber-400 mt-0.5 shrink-0" />
+          <div className="flex-1">
+            <div className="text-sm font-medium text-slate-200">What normal looks like</div>
+            <p className="text-xs text-slate-400 mt-0.5">
+              Learned per workload, so a reading can be reported as “three times this service’s normal”
+              rather than a number you have to interpret.
+            </p>
+          </div>
+        </div>
+
+        <input
+          value={namespace}
+          onChange={(e) => setNamespace(e.target.value)}
+          placeholder="namespace"
+          aria-label="Namespace"
+          className="mb-3 w-full sm:w-64 rounded border border-slate-700 bg-slate-900 px-2 py-1
+                     text-xs text-slate-200"
+        />
+
+        {!namespace ? (
+          <p className="text-xs text-slate-500">Enter a namespace to see its learned baselines.</p>
+        ) : baselines.isLoading ? (
+          <p className="text-xs text-slate-500">Loading…</p>
+        ) : (baselines.data || []).length === 0 ? (
+          <EmptyState
+            icon={Gauge}
+            title={`No baselines for ${namespace}`}
+            description="Baselines build up as Pulse observes a workload. Until one exists, readings are reported as raw values."
+          />
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs min-w-[34rem]">
+              <thead>
+                <tr className="text-left text-slate-500 border-b border-slate-800">
+                  <th className="py-1.5 pr-3 font-medium">Workload</th>
+                  <th className="py-1.5 pr-3 font-medium">Metric</th>
+                  <th className="py-1.5 pr-3 font-medium text-right">Normal (p50)</th>
+                  <th className="py-1.5 pr-3 font-medium text-right">p95</th>
+                  <th className="py-1.5 font-medium">Confidence</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-800">
+                {(baselines.data || []).map((b) => (
+                  <tr key={`${b.workload}:${b.metric}`}>
+                    <td className="py-1.5 pr-3 text-slate-200">{b.workload}</td>
+                    <td className="py-1.5 pr-3 text-slate-400">{b.metric}</td>
+                    <td className="py-1.5 pr-3 text-right tabular-nums text-slate-200">
+                      {formatMetricValue(b.p50)}
+                    </td>
+                    <td className="py-1.5 pr-3 text-right tabular-nums text-slate-400">
+                      {formatMetricValue(b.p95)}
+                    </td>
+                    <td className="py-1.5">
+                      {b.reliable ? (
+                        <span className="inline-flex items-center gap-1 text-emerald-400">
+                          <Check className="w-3 h-3" /> {b.sampleCount} samples
+                        </span>
+                      ) : (
+                        <span className="inline-flex items-center gap-1 text-amber-400">
+                          <AlertTriangle className="w-3 h-3" /> only {b.sampleCount} — not used yet
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
Companion to [pulse-agent#75](https://github.com/PulseSRE/pulse-agent/pull/75).

The agent gained cluster memory, verified-trajectory learning and workload baselines across five PRs — **all of it invisible to the operator.** This adds a "This Cluster" tab to Memory.

## Verified learning

The gate counters: pending, learned, discarded, expired, plus the promotion rate.

A diagnosis becomes a reusable skill only once the fix it proposed is *confirmed* to have resolved the problem. Diagnoses whose fix did not hold are discarded rather than learned. Showing those counts makes the behaviour inspectable instead of asking the operator to take it on trust — and a discard rate climbing is a signal worth seeing.

## What Pulse knows about this cluster

Ownership, retention windows, GitOps topology, local conventions — grouped by scope, each showing its source, with add and delete.

**Operator-correctable by design.** An agent that believes something wrong about a cluster and cannot be told otherwise is worse than one that believes nothing.

## What normal looks like

Per-workload baselines, so a reading can be reported as *"three times this service's normal"* rather than a number the operator has to interpret.

Baselines under 20 samples are labelled **"only N — not used yet"** rather than displayed as a norm. That mirrors what the agent actually does with them; rendering a thin baseline as authoritative would put unearned precision back into the product.

## Details

- Empty states say what the absence *costs* ("treats this cluster like any other"), not just that a list is empty
- Baselines are not fetched until a namespace is entered — no speculative request
- Table scrolls inside its own container; inputs are labelled; focus states are visible
- 8 tests: value formatting including the non-finite guard, gate counters and promotion rate, grouping by scope, source-known vs unknown, empty-state copy, and that no baseline request fires without a namespace

## Not verified locally

There is no Node runtime on this machine, so lint, type-check and tests have not been run here. CI is their first execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)