### PR TITLE
feat(protocol): accept phases that did not meet their contract

### DIFF
--- a/src/kubeview/engine/monitorClient.ts
+++ b/src/kubeview/engine/monitorClient.ts
@@ -17,10 +17,17 @@ export interface ResourceRef {
 
 export interface InvestigationPhase {
   id: string;
-  status: 'pending' | 'running' | 'complete' | 'failed' | 'skipped';
+  /**
+   * `partial` means the phase ran but never produced the output fields its plan
+   * template declared, even after being asked again. It is not a less confident
+   * `complete` — the plan advanced without something it was supposed to have.
+   */
+  status: 'pending' | 'running' | 'complete' | 'partial' | 'failed' | 'skipped';
   skill_name: string;
   summary?: string;
   confidence?: number;
+  /** Fields the phase declared but did not produce. Present when status is `partial`. */
+  unmetContract?: string[];
   started_at?: number;
   completed_at?: number;
 }


### PR DESCRIPTION
Companion to [pulse-agent#76](https://github.com/PulseSRE/pulse-agent/pull/76).

The agent now downgrades a plan phase to `partial` when it does not produce the output fields its template declared in `produces`, and emits `unmetContract` listing what is missing.

`InvestigationPhase['status']` did not include `'partial'`, so a value that genuinely arrives on the wire had no type.

The doc comment states the distinction explicitly:

> `partial` means the phase ran but never produced the output fields its plan template declared, even after being asked again. It is **not** a less confident `complete` — the plan advanced without something it was supposed to have.

That matters because the obvious styling choice is a dimmer green, and this is closer to a warning: anything downstream that depended on those fields was working without them.

**Note:** phases are typed and stored but not yet rendered anywhere in the UI. This makes the data correct and self-describing for whoever builds that view; it does not itself put anything on screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)