### PR TITLE
fix: "All clear" was the loading state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### "All clear" was the loading state
+- Before the first scan lands every count is zero, and the posture bar read zero criticals as health — on the landing page, as the first thing an operator sees. It rendered "All clear — 0 critical, 0 warnings | No scan yet" in one sentence, holding the evidence against its own claim
+- There is now an `unknown` posture: **"Checking the cluster…"**, in neutral slate rather than green, with the reason still shown beside it. `unknown` is not a shade of green
+- A real finding outranks not having scanned. Findings can arrive before `lastScanTime` is set, and reporting "checking" over a known problem would be the same lie pointing the other way
+- Same failure the capability banner was built to prevent, one screen earlier: absence of data presented as absence of problems
+
 ### The session-expired modal could be raised but never lowered
 - `session_expired` was added from seven call sites and removed from none outside the test suite, while every other degraded reason already cleared itself — `observability_unavailable` in the incident hooks, `polling_fallback` and `agent_unreachable` in agent notifications. So a single transient 401 pinned the modal for the life of the page
 - Not a theoretical window: on a cluster whose API server is restarting and dropping TLS handshakes, a one-off 401 is routine. The operator is told their session expired while every request behind the modal succeeds. Reported from real use, twice

--- a/src/kubeview/views/PulseView.tsx
+++ b/src/kubeview/views/PulseView.tsx
@@ -1,7 +1,7 @@
 import React, { lazy, Suspense, useState, useEffect, useRef } from 'react';
 import {
   HeartPulse, Shield, Activity,
-  AlertTriangle,
+  AlertTriangle, HelpCircle,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Tooltip } from '../components/primitives/Tooltip';
@@ -33,7 +33,20 @@ import { formatRelativeTime } from '../engine/formatters';
 
 const ClusterResourceMap = lazy(() => import('../components/topology/TopologyMap'));
 
-type PostureLevel = 'green' | 'yellow' | 'red';
+/**
+ * `unknown` is not a shade of green.
+ *
+ * Before the first scan lands, every count is zero — and zero criticals read as
+ * "all clear" when it actually means "nothing has looked yet". The posture bar
+ * asserted health on an empty result set, on the landing page, as the first
+ * thing an operator sees. It even computed "No scan yet" for the line beside
+ * the claim, so the component held the evidence against itself.
+ *
+ * A monitoring product saying "all clear" before it knows is the same failure
+ * as an empty investigation panel reading as "nothing worth investigating":
+ * absence of data presented as absence of problems.
+ */
+type PostureLevel = 'unknown' | 'green' | 'yellow' | 'red';
 
 function ClusterPostureBar({
   findings,
@@ -52,9 +65,12 @@ function ClusterPostureBar({
   const warningCount = incidentCounts.warning;
   const autoFixedCount = findings.filter((f) => (f as any).autoFixable).length;
 
+  // A real finding outranks not having scanned: if something already came back
+  // critical, say so rather than "checking". Only genuine silence is unknown.
   let level: PostureLevel = 'green';
   if (criticalCount > 0) level = 'red';
   else if (warningCount > 0 || findings.length > 0) level = 'yellow';
+  else if (!lastScanTime) level = 'unknown';
 
   const topFinding = findings.length > 0 ? findings[0] : null;
 
@@ -63,24 +79,27 @@ function ClusterPostureBar({
     : 'No scan yet';
 
   const borderColor: Record<PostureLevel, string> = {
+    unknown: 'border-l-slate-500',
     green: 'border-l-emerald-500',
     yellow: 'border-l-amber-500',
     red: 'border-l-red-500',
   };
 
   const bgColor: Record<PostureLevel, string> = {
+    unknown: 'bg-slate-500/5',
     green: 'bg-emerald-500/5',
     yellow: 'bg-amber-500/5',
     red: 'bg-red-500/5',
   };
 
   const iconColor: Record<PostureLevel, string> = {
+    unknown: 'text-slate-400',
     green: 'text-emerald-400',
     yellow: 'text-amber-400',
     red: 'text-red-400',
   };
 
-  const Icon = level === 'green' ? Shield : AlertTriangle;
+  const Icon = level === 'unknown' ? HelpCircle : level === 'green' ? Shield : AlertTriangle;
 
   return (
     <div
@@ -93,6 +112,12 @@ function ClusterPostureBar({
     >
       <Icon className={cn('w-4 h-4 shrink-0', iconColor[level])} />
       <span className="text-slate-200 truncate">
+        {level === 'unknown' && (
+          <>
+            Checking the cluster…
+            <span className="text-slate-500"> | {scanLabel} | Agent: {monitorConnected ? 'healthy' : 'disconnected'}</span>
+          </>
+        )}
         {level === 'green' && (
           <>
             All clear — 0 critical, 0 warnings

--- a/src/kubeview/views/__tests__/ClusterPostureBar.test.tsx
+++ b/src/kubeview/views/__tests__/ClusterPostureBar.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import PulseViewModule from '../PulseView';
+
+/**
+ * "All clear" was the loading state.
+ *
+ * Before the first scan lands every count is zero, and the posture bar read
+ * zero criticals as health — on the landing page, as the first thing an
+ * operator sees. It even rendered "No scan yet" in the same sentence, so the
+ * component was holding the evidence against its own claim.
+ *
+ * This is the same failure as an empty investigation panel reading as "nothing
+ * worth investigating": absence of data presented as absence of problems.
+ */
+
+// PulseView pulls in the topology map, k8s watches and several stores; the bar
+// is a private component, so drive it through the exported view with
+// everything below it stubbed out.
+vi.mock('../../hooks/useK8sListWatch', () => ({
+  useK8sListWatch: () => ({ data: [], isLoading: false }),
+}));
+vi.mock('../../hooks/useIncidentFeed', () => ({ useIncidentFeed: () => ({ incidents: [], counts: {} }) }));
+vi.mock('../../components/topology/TopologyMap', () => ({ default: () => null }));
+vi.mock('../pulse/ReportTab', () => ({ ReportTab: () => null }));
+vi.mock('../pulse/FleetReportTab', () => ({ FleetReportTab: () => null }));
+vi.mock('../pulse/OpenEpisodeBanner', () => ({ OpenEpisodeBanner: () => null }));
+
+const monitorState = {
+  connected: true,
+  activeSkill: null,
+  monitorEnabled: true,
+  setMonitorEnabled: vi.fn(),
+  triggerScan: vi.fn(),
+  findings: [] as Array<{ severity: string; title: string }>,
+  lastScanTime: null as number | null,
+};
+
+vi.mock('../../store/monitorStore', () => ({
+  useMonitorStore: (selector: (s: typeof monitorState) => unknown) => selector(monitorState),
+}));
+vi.mock('../../store/uiStore', () => ({
+  useUIStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ selectedNamespace: '*', addDegradedReason: vi.fn(), removeDegradedReason: vi.fn() }),
+}));
+vi.mock('../../store/fleetStore', () => ({
+  useFleetStore: (selector: (s: Record<string, unknown>) => unknown) => selector({ fleetMode: false }),
+}));
+vi.mock('../../store/trustStore', () => ({
+  useTrustStore: (selector: (s: Record<string, unknown>) => unknown) => selector({ trustLevel: 1 }),
+}));
+vi.mock('../../hooks/useNavigateTab', () => ({ useNavigateTab: () => vi.fn() }));
+
+function renderBar(over: Partial<typeof monitorState>) {
+  Object.assign(monitorState, { findings: [], lastScanTime: null, connected: true }, over);
+  return render(<PulseViewModule />);
+}
+
+describe('the posture bar does not claim health before it has looked', () => {
+  afterEach(cleanup);
+
+  it('says it is checking when no scan has landed', () => {
+    renderBar({ lastScanTime: null, findings: [] });
+    expect(screen.getByText(/Checking the cluster/)).toBeDefined();
+    expect(screen.queryByText(/All clear/)).toBeNull();
+  });
+
+  it('says all clear once a scan has come back empty', () => {
+    renderBar({ lastScanTime: Date.now(), findings: [] });
+    expect(screen.getByText(/All clear/)).toBeDefined();
+    expect(screen.queryByText(/Checking the cluster/)).toBeNull();
+  });
+
+  it('a real finding outranks not having scanned', () => {
+    // Findings can arrive before lastScanTime is set. Reporting "checking"
+    // over a known problem would be the same lie in the other direction.
+    renderBar({ lastScanTime: null, findings: [{ severity: 'warning', title: 'etcd is unhappy' }] });
+    expect(screen.queryByText(/Checking the cluster/)).toBeNull();
+    expect(screen.getByText(/etcd is unhappy/)).toBeDefined();
+  });
+
+  it('still shows the reason it cannot say more', () => {
+    renderBar({ lastScanTime: null, findings: [] });
+    expect(screen.getByText(/No scan yet/)).toBeDefined();
+  });
+});


### PR DESCRIPTION
Found by opening the product with real data for the first time.

## What it said

The landing page, before any scan has come back:

> 🛡 **All clear — 0 critical, 0 warnings** | No scan yet | Agent: healthy

Green shield, health asserted — and *"No scan yet"* in the same sentence. Every count is zero because nothing has looked yet, and the bar read zero criticals as proof of health. The component was holding the evidence against its own claim.

## What it says now

> ❔ **Checking the cluster…** | No scan yet | Agent: healthy

Neutral slate, `HelpCircle`, no verdict. **`unknown` is not a shade of green.**

## The ordering rule

A real finding outranks not having scanned. Findings can arrive before `lastScanTime` is set, and reporting "checking" over a known problem would be the same lie pointing the other way — so `unknown` is only reached when there is genuinely nothing to report.

## Why this one matters

It is the failure the capability banner exists to prevent — *"treat anything these cover as unknown rather than clear"* — occurring one screen earlier, on the first thing an operator sees. Absence of data presented as absence of problems.

## Verification

4 tests: checking before a scan, all-clear after an empty one, a finding outranking the unknown state, and the reason still being shown. Mutation-tested: removing the `unknown` branch fails one.

Full suite **2,149 passing across 178 files**, `tsc --noEmit` clean.

## Noted

My first commit here produced **two** `## [Unreleased]` sections, because a session-expired entry had already merged to main. pulse-agent has a `one-unreleased-section` discipline rule that mechanically blocks exactly this; pulse-ui has no such check. Worth adding — I have now hit this twice in two repos.