### PR TITLE
fix: relative times said "ago" twice, and sometimes counted backwards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 - A real finding outranks not having scanned. Findings can arrive before `lastScanTime` is set, and reporting "checking" over a known problem would be the same lie pointing the other way
 - Same failure the capability banner was built to prevent, one screen earlier: absence of data presented as absence of problems
 
+### Relative times said "ago" twice, and sometimes counted backwards
+- The status bar rendered `synced {formatRelativeTime(t)} ago` while the function already ends in "ago" — **"synced 26s ago ago"**, in the status bar of every page
+- `formatRelativeTime` subtracted an agent timestamp from the browser's clock without a floor. Two machines, two clocks: a beat of skew rendered **"Last scan: -1s ago"** on the landing page. Anything under five seconds now reads "just now", which absorbs the skew and reads better besides
+- The first fix added a `Math.max(0, …)` as well. A mutation test passed with it removed, proving it was dead code — the "just now" branch already covered the case — so it came back out
+
 ### The session-expired modal could be raised but never lowered
 - `session_expired` was added from seven call sites and removed from none outside the test suite, while every other degraded reason already cleared itself — `observability_unavailable` in the incident hooks, `polling_fallback` and `agent_unreachable` in agent notifications. So a single transient 401 pinned the modal for the life of the page
 - Not a theoretical window: on a cluster whose API server is restarting and dropping TLS handshakes, a one-off 401 is routine. The operator is told their session expired while every request behind the modal succeeds. Reported from real use, twice

--- a/src/kubeview/components/StatusBar.tsx
+++ b/src/kubeview/components/StatusBar.tsx
@@ -79,7 +79,9 @@ export function StatusBar() {
           className={isStale ? 'text-amber-400' : undefined}
           title={isStale ? 'Data may be stale — session may be expired or connectivity lost' : undefined}
         >
-          synced {relativeTime} ago
+          {/* formatRelativeTime already ends in "ago" — appending another
+              produced "synced 26s ago ago" in the status bar of every page. */}
+          synced {relativeTime}
           {isStale && !degradedReasons.has('session_expired') && (
             <span className="ml-1 text-amber-400">· may be stale</span>
           )}

--- a/src/kubeview/engine/__tests__/relativeTime.test.ts
+++ b/src/kubeview/engine/__tests__/relativeTime.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { formatRelativeTime } from '../formatters';
+
+/**
+ * Two things this got wrong, both visible on the landing page.
+ *
+ * The status bar rendered `synced {formatRelativeTime(t)} ago` while the
+ * function already ends in "ago" — "synced 26s ago ago", on every page.
+ *
+ * And the subtraction was unclamped. The timestamp comes from the agent and
+ * the comparison from the browser: two machines, two clocks. A beat of skew
+ * rendered "Last scan: -1s ago".
+ */
+
+const NOW = 1_787_000_000_000;
+
+function at(msAgo: number) {
+  vi.setSystemTime(NOW);
+  return formatRelativeTime(NOW - msAgo);
+}
+
+describe('formatRelativeTime', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('never reports the past as the future', () => {
+    vi.useFakeTimers();
+    // Agent clock a second ahead of the browser's.
+    expect(at(-1000)).toBe('just now');
+    expect(at(-60_000)).toBe('just now');
+  });
+
+  it('says just now rather than counting single seconds', () => {
+    vi.useFakeTimers();
+    expect(at(0)).toBe('just now');
+    expect(at(4_000)).toBe('just now');
+  });
+
+  it('counts seconds, minutes, hours and days', () => {
+    vi.useFakeTimers();
+    expect(at(30_000)).toBe('30s ago');
+    expect(at(5 * 60_000)).toBe('5m ago');
+    expect(at(3 * 3_600_000)).toBe('3h ago');
+    expect(at(2 * 86_400_000)).toBe('2d ago');
+  });
+
+  it('already carries its own "ago", so callers must not add one', () => {
+    // The bug was `synced ${formatRelativeTime(t)} ago`. Anything appending to
+    // this needs to know the word is already there.
+    vi.useFakeTimers();
+    expect(at(30_000).endsWith('ago')).toBe(true);
+  });
+});

--- a/src/kubeview/engine/formatters.ts
+++ b/src/kubeview/engine/formatters.ts
@@ -2,6 +2,12 @@
 
 export function formatRelativeTime(timestamp: number): string {
   const seconds = Math.floor((Date.now() - timestamp) / 1000);
+  // This also absorbs a negative. The timestamp comes from the agent and the
+  // comparison from the browser — two machines, two clocks — and a beat of
+  // skew rendered "Last scan: -1s ago" on the landing page. A separate
+  // Math.max(0, …) would be dead code: this branch already covers it, which a
+  // mutation test proved by passing with the clamp removed.
+  if (seconds < 5) return 'just now';
   if (seconds < 60) return `${seconds}s ago`;
   if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
   if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;


### PR DESCRIPTION
Two bugs in the same function, both found by reading the running UI against the live cluster.

## "synced 26s ago ago"

`StatusBar` renders:

```tsx
synced {relativeTime} ago
```

while `formatRelativeTime` already returns `"26s ago"`. That is in the status bar of **every page**.

## "Last scan: -1s ago"

The function subtracts an agent timestamp from the browser's clock with no floor. Two machines, two clocks — a beat of skew and the landing page counts backwards. Anything under five seconds now reads **"just now"**, which absorbs the skew and reads better than `0s ago` regardless.

## A redundant fix, caught by its own mutation test

My first version also added `Math.max(0, …)`. The mutation test **passed with it removed** — the `just now` branch already covered the negative case, so the clamp was dead code. It came back out, and the comment now records why a future reader should not re-add it.

Shipping a redundant guard as a fix is how a codebase accumulates lines nobody can explain.

## Verification

4 tests: never reports the past as the future, "just now" under five seconds, the full seconds/minutes/hours/days ladder, and an explicit assertion that the string already carries its own "ago" so callers do not add one. Mutation-tested — removing the guard fails 2.

Full suite **2,149 passing across 178 files**, `tsc --noEmit` clean.