### PR TITLE
fix: a list says where each item is, not the whole ladder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 - `formatRelativeTime` subtracted an agent timestamp from the browser's clock without a floor. Two machines, two clocks: a beat of skew rendered **"Last scan: -1s ago"** on the landing page. Anything under five seconds now reads "just now", which absorbs the skew and reads better besides
 - The first fix added a `Math.max(0, …)` as well. A mutation test passed with it removed, proving it was dead code — the "just now" branch already covered the case — so it came back out
 
+### A list says where each item is, not the whole ladder
+- Every inbox row rendered all five lifecycle stages inline — `New › Triaged › Claimed › In Progress › Resolved`. Read down a real inbox that is the same five words on every row, taking more width than the finding's own title. Measured on the reference cluster at 32 open items, the phrase dominating the screen was identical on all of them
+- The row now shows five dots filled to the current stage, and names only that stage. Position stays legible, the full ladder is on hover, and the stepper in the detail drawer — where one item's whole progression is the point — is unchanged
+
 ### The session-expired modal could be raised but never lowered
 - `session_expired` was added from seven call sites and removed from none outside the test suite, while every other degraded reason already cleared itself — `observability_unavailable` in the incident hooks, `polling_fallback` and `agent_unreachable` in agent notifications. So a single transient 401 pinned the modal for the life of the page
 - Not a theoretical window: on a cluster whose API server is restarting and dropping TLS handshakes, a one-off 401 is routine. The operator is told their session expired while every request behind the modal succeeds. Reported from real use, twice

--- a/src/kubeview/views/inbox/InboxLifecycle.tsx
+++ b/src/kubeview/views/inbox/InboxLifecycle.tsx
@@ -21,6 +21,21 @@ const STATUS_MAP: Record<string, string> = {
   agent_cleared: 'resolved',
 };
 
+/**
+ * Where this item is, not the whole ladder.
+ *
+ * This used to render all five stages inline — `New › Triaged › Claimed › In
+ * Progress › Resolved` — on every row. Read down a real inbox and that is the
+ * same five words twenty times over, taking more width than the finding's own
+ * title. Measured on the reference cluster: 32 open items, and the phrase that
+ * dominated the screen was identical on every one of them.
+ *
+ * A list answers "where is each of these"; one item's full progression is the
+ * detail view's job, which is what InboxLifecycleStepper already does in the
+ * drawer. So the badge keeps the position — five dots, filled to here — and
+ * spends its words on the one stage that differs between rows. The full ladder
+ * stays available on hover for anyone who wants it.
+ */
 export function InboxLifecycleBadge({
   itemType,
   status,
@@ -32,40 +47,49 @@ export function InboxLifecycleBadge({
   const isCleared = status === 'agent_cleared';
   const mappedStatus = STATUS_MAP[status] || status;
   const currentIdx = isCleared ? steps.length : steps.findIndex((s) => s.key === mappedStatus);
+  const isProcessing = status === 'agent_reviewing';
+  const current = steps[currentIdx];
+
+  const ladder = steps.map((s, i) => (i === currentIdx ? `${s.label} ←` : s.label)).join(' › ');
+
+  if (isCleared) {
+    return (
+      <span
+        className="inline-flex items-center rounded-md bg-slate-800/80 border border-slate-700/50 px-1.5 py-0.5 text-[10px] leading-none text-emerald-400 font-medium"
+        title={`Cleared by the agent — ${ladder}`}
+      >
+        Cleared ✓
+      </span>
+    );
+  }
 
   return (
-    <div className="inline-flex items-center gap-px rounded-md bg-slate-800/80 border border-slate-700/50 px-1 py-0.5">
-      {isCleared && (
-        <span className="px-1.5 py-0.5 text-[10px] leading-none rounded-xs text-emerald-400 font-medium">
-          Cleared ✓
-        </span>
-      )}
-      {!isCleared && steps.map((step, idx) => {
-        const isCurrent = step.key === mappedStatus;
-        const isPast = idx < currentIdx;
-        const isLast = idx === steps.length - 1;
-        const isProcessing = status === 'agent_reviewing';
-
-        return (
-          <div key={step.key} className="flex items-center">
-            <span
-              className={cn(
-                'px-1.5 py-0.5 text-[10px] leading-none rounded-xs',
-                isCurrent && isProcessing && 'bg-violet-600 text-white font-medium animate-pulse',
-                isCurrent && !isProcessing && 'bg-violet-600 text-white font-medium',
-                isPast && 'text-emerald-400',
-                !isCurrent && !isPast && 'text-slate-600',
-              )}
-            >
-              {step.label}
-            </span>
-            {!isLast && (
-              <span className={cn('text-[8px]', isPast ? 'text-emerald-600' : 'text-slate-700')}>›</span>
+    <span
+      className="inline-flex items-center gap-1.5 rounded-md bg-slate-800/80 border border-slate-700/50 px-1.5 py-0.5"
+      title={ladder}
+    >
+      <span className="flex items-center gap-0.5" aria-hidden="true">
+        {steps.map((step, idx) => (
+          <span
+            key={step.key}
+            className={cn(
+              'w-1 h-1 rounded-full',
+              idx < currentIdx && 'bg-emerald-500',
+              idx === currentIdx && (isProcessing ? 'bg-violet-400 animate-pulse' : 'bg-violet-400'),
+              idx > currentIdx && 'bg-slate-600',
             )}
-          </div>
-        );
-      })}
-    </div>
+          />
+        ))}
+      </span>
+      <span
+        className={cn(
+          'text-[10px] leading-none font-medium',
+          isProcessing ? 'text-violet-300 animate-pulse' : 'text-slate-300',
+        )}
+      >
+        {current?.label ?? mappedStatus}
+      </span>
+    </span>
   );
 }
 

--- a/src/kubeview/views/inbox/__tests__/InboxLifecycle.test.tsx
+++ b/src/kubeview/views/inbox/__tests__/InboxLifecycle.test.tsx
@@ -3,28 +3,49 @@ import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { InboxLifecycleBadge, InboxLifecycleStepper } from '../InboxLifecycle';
 
-describe('InboxLifecycleBadge', () => {
-  it('renders universal lifecycle stages', () => {
+describe('InboxLifecycleBadge — where this item is, not the whole ladder', () => {
+  // The badge used to print all five stages on every row. Down a real inbox
+  // that is the same five words twenty times, wider than the finding's own
+  // title — measured on the reference cluster at 32 open items. A list answers
+  // "where is each of these"; one item's full progression belongs to the
+  // detail view, which is what the stepper does in the drawer.
+
+  it('names only the stage the item is actually at', () => {
     render(<InboxLifecycleBadge itemType="finding" status="triaged" />);
-    expect(screen.getAllByText('New').length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByText('Triaged').length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByText('Claimed').length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByText('In Progress').length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByText('Resolved').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Triaged')).toBeDefined();
+    for (const other of ['New', 'Claimed', 'In Progress', 'Resolved']) {
+      expect(screen.queryByText(other)).toBeNull();
+    }
   });
 
-  it('renders same stages for all item types', () => {
+  it('still shows position, so the stage is not just a word', () => {
+    // Five dots, filled up to here: "Triaged" alone does not say whether that
+    // is early or nearly done.
+    const { container } = render(<InboxLifecycleBadge itemType="finding" status="triaged" />);
+    expect(container.querySelectorAll('.rounded-full').length).toBe(5);
+    expect(container.querySelectorAll('.bg-emerald-500').length).toBe(1); // New, behind us
+    expect(container.querySelectorAll('.bg-slate-600').length).toBe(3); // three still ahead
+  });
+
+  it('keeps the full ladder available on hover', () => {
+    const { container } = render(<InboxLifecycleBadge itemType="finding" status="claimed" />);
+    const title = container.querySelector('[title]')?.getAttribute('title') ?? '';
+    expect(title).toContain('New');
+    expect(title).toContain('Claimed ←');
+    expect(title).toContain('Resolved');
+  });
+
+  it('reads the same for every item type', () => {
     for (const type of ['finding', 'task', 'alert', 'assessment'] as const) {
       const { unmount } = render(<InboxLifecycleBadge itemType={type} status="new" />);
-      expect(screen.getAllByText('Triaged').length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText('New')).toBeDefined();
       unmount();
     }
   });
 
   it('highlights current status with pulse for agent_reviewing', () => {
     const { container } = render(<InboxLifecycleBadge itemType="finding" status="agent_reviewing" />);
-    const pulsingEl = container.querySelector('.animate-pulse');
-    expect(pulsingEl).not.toBeNull();
+    expect(container.querySelector('.animate-pulse')).not.toBeNull();
   });
 
   it('shows Cleared for agent_cleared', () => {


### PR DESCRIPTION
Found by reading the real Inbox against the live cluster.

## Every row carried the whole ladder

```
TargetDown
Monitor · 2h ago · New › Triaged › Claimed › In Progress › Resolved

TargetDown
Monitor · 1d ago · New › Triaged › Claimed › In Progress › Resolved
```

Thirty-two open items, and the widest thing on each row was five words identical to the row above it — wider than the finding's own title.

## What it says now

```
TargetDown
Monitor · 2h ago · ●●○○○ Triaged
```

Five dots filled to the current stage, then the one stage that differs between rows. Position stays legible without spelling out the stages nobody is at.

The full ladder is on `title` for anyone who wants it, and `InboxLifecycleStepper` in the detail drawer — where a single item's whole progression *is* the point — is untouched. The split was already there; only the list-row half was wrong.

## Verified on real data, not just tests

Reloaded against the live cluster and re-read the rendered list: rows went from the full ladder to `Monitor · 2h ago · Triaged`.

## Honest limitation

With this deployed, **every row currently reads "Triaged"** — all 31 of them. The agent triages everything and nothing moves items along afterwards, so the column carries almost no information today. Five identical words becoming one identical word is still a real gain, but the thing that will actually differentiate these rows is the namespace, which has never rendered — see PulseSRE/pulse-agent#86.

## Verification

6 tests, rewritten rather than deleted: the previous ones asserted the old design. They now pin that only the current stage is named, that the dots convey position (one behind, three ahead), and that the ladder survives on hover.

Full suite **2,147 passing across 177 files**, `tsc --noEmit` clean.