### PR TITLE
fix: the My Items pill printed an identity hash at you

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
 - Every inbox row rendered all five lifecycle stages inline — `New › Triaged › Claimed › In Progress › Resolved`. Read down a real inbox that is the same five words on every row, taking more width than the finding's own title. Measured on the reference cluster at 32 open items, the phrase dominating the screen was identical on all of them
 - The row now shows five dots filled to the current stage, and names only that stage. Position stays legible, the full ladder is on hover, and the stepper in the detail drawer — where one item's whole progression is the point — is unchanged
 
+### The My Items pill printed an identity hash at you
+- When the agent cannot resolve a real username it falls back to `user-<16 hex>` — stable, unforgeable, and exactly the right thing to key data on. It is not a thing to show a person. Observed live: the filter pill read **"My Items (user-5451b787f74974ba)"**, telling the reader nothing they did not know and spending half the pill's width to say it
+- A real name is still shown. An opaque fallback, or no user at all, now reads simply "My Items"
+
 ### The session-expired modal could be raised but never lowered
 - `session_expired` was added from seven call sites and removed from none outside the test suite, while every other degraded reason already cleared itself — `observability_unavailable` in the incident hooks, `polling_fallback` and `agent_unreachable` in agent notifications. So a single transient 401 pinned the modal for the life of the page
 - Not a theoretical window: on a cluster whose API server is restarting and dropping TLS handshakes, a one-off 401 is routine. The operator is told their session expired while every request behind the modal succeeds. Reported from real use, twice

--- a/src/kubeview/views/inbox/InboxHeader.tsx
+++ b/src/kubeview/views/inbox/InboxHeader.tsx
@@ -21,6 +21,20 @@ const SEVERITY_BADGES: Array<{ key: string; label: string; color: string }> = [
   { key: 'info', label: 'Info', color: 'bg-blue-500/15 text-blue-400' },
 ];
 
+/**
+ * The agent falls back to `user-<16 hex>` when it cannot resolve a real name —
+ * a stable, unforgeable identity, and exactly the right thing to key data on.
+ * It is not a thing to show a person. Observed live: the filter pill read
+ * "My Items (user-5451b787f74974ba)", which tells the reader nothing they did
+ * not already know and costs half the pill's width to say it.
+ */
+const OPAQUE_IDENTITY = /^user-[0-9a-f]{16}$/;
+
+function myItemsLabel(currentUser: string | null | undefined): string {
+  if (!currentUser || OPAQUE_IDENTITY.test(currentUser)) return 'My Items';
+  return `My Items (${currentUser})`;
+}
+
 export function InboxHeader({
   onNewTask,
 }: {
@@ -102,7 +116,7 @@ export function InboxHeader({
                   : 'bg-slate-800 text-slate-400 hover:bg-slate-700 hover:text-slate-300',
               )}
             >
-              {preset.id === 'my_items' && currentUser ? `My Items (${currentUser})` : preset.label}
+              {preset.id === 'my_items' ? myItemsLabel(currentUser) : preset.label}
               {count > 0 && (
                 <span className={cn(
                   'px-1.5 py-0.5 rounded-full text-[10px] font-semibold leading-none',

--- a/src/kubeview/views/inbox/__tests__/InboxHeader.test.tsx
+++ b/src/kubeview/views/inbox/__tests__/InboxHeader.test.tsx
@@ -1,7 +1,11 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, act } from '@testing-library/react';
 import { InboxHeader } from '../InboxHeader';
+
+// Mutable so a test can vary one field (e.g. currentUser) without restating
+// the whole store.
+let stateOverride: Record<string, unknown> = {};
 
 vi.mock('../../../store/inboxStore', () => ({
   useInboxStore: vi.fn((selector) => {
@@ -9,6 +13,8 @@ vi.mock('../../../store/inboxStore', () => ({
       stats: { new: 3, total: 10, agent_cleared: 5, critical: 2, warning: 4 },
       activePreset: null,
       setPreset: vi.fn(),
+      refresh: vi.fn(),
+      ...stateOverride,
     };
     return selector(state);
   }),
@@ -45,5 +51,30 @@ describe('InboxHeader', () => {
     render(<InboxHeader onNewTask={onNewTask} />);
     expect(screen.getAllByText(/Critical/).length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText(/Warning/).length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('the My Items pill does not print an identity hash at you', () => {
+  afterEach(cleanup);
+
+  it('names a real user', () => {
+    stateOverride = { currentUser: 'kube:admin' };
+    render(<InboxHeader onNewTask={vi.fn()} />);
+    expect(screen.getByText(/My Items \(kube:admin\)/)).toBeDefined();
+  });
+
+  it('says just My Items when the identity is the agent opaque fallback', () => {
+    // Observed live: "My Items (user-5451b787f74974ba)". The hash is the right
+    // thing to key data on and the wrong thing to show a person.
+    stateOverride = { currentUser: 'user-5451b787f74974ba' };
+    render(<InboxHeader onNewTask={vi.fn()} />);
+    expect(screen.getByText('My Items')).toBeDefined();
+    expect(screen.queryByText(/user-5451b/)).toBeNull();
+  });
+
+  it('says just My Items when there is no user at all', () => {
+    stateOverride = { currentUser: null };
+    render(<InboxHeader onNewTask={vi.fn()} />);
+    expect(screen.getByText('My Items')).toBeDefined();
   });
 });


### PR DESCRIPTION
Observed live on the reference cluster:

> **My Items (user-5451b787f74974ba)**

## The identity is right; showing it is not

When the agent cannot resolve a real username — no `X-Forwarded-User`, TokenReview unavailable — it falls back to `user-<16 hex of the token hash>`. That is a *good* identity: stable across requests, distinct per token, unforgeable, and exactly the right thing to key "my items" on.

It is not a thing to put in front of a person. It tells the reader nothing they did not already know and costs half the pill's width to say it.

A real name is still shown — `My Items (kube:admin)`. An opaque fallback, or no user at all, now reads simply **My Items**.

## Verification

3 tests: a real name is named, the opaque fallback is suppressed, and no user at all still renders. Mutation-tested — dropping the fallback detection fails one.

The existing test file mocked the store with a fixed object, so varying a single field meant restating the whole thing. The mock now takes an override, which is what let these tests be about one field.

Full suite **2,148 passing across 177 files**, `tsc --noEmit` clean.
