### PR TITLE
The trust badge reports the agent, not the browser tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### The trust badge on the front door reported a browser preference
+- `Agent · Trust 1` came from `useTrustStore` — zustand `persist` on localStorage, keyed per hostname. It is sent to the agent when the monitor socket connects and **never read back**. So the badge showed what this tab had asked for, not what the agent was doing
+- Two operators on one cluster could read two different trust levels off the same agent. Since the server-side floor is now `settings.monitor.max_trust_level`, both of them could be wrong about what it would do with nobody watching — on a badge whose entire job is to answer that question
+- It now reads `effective_trust_level` from `/monitor/capabilities`, on the same query key Mission Control already uses, so the two screens cannot disagree. Falls back to the local value while the query is in flight, or against an agent too old to send the field
+- `??` rather than `||`: trust 0 is Observe, the most restrictive setting there is, and it is falsy. An agent that dropped to 0 is exactly the case an operator most needs told
+- Where the tab's request and the agent's reality diverge, the tooltip names the gap instead of leaving the operator to assume the badge is broken
+
 ### "All clear" was the loading state
 - Before the first scan lands every count is zero, and the posture bar read zero criticals as health — on the landing page, as the first thing an operator sees. It rendered "All clear — 0 critical, 0 warnings | No scan yet" in one sentence, holding the evidence against its own claim
 - There is now an `unknown` posture: **"Checking the cluster…"**, in neutral slate rather than green, with the reason still shown beside it. `unknown` is not a shade of green

--- a/src/kubeview/engine/analyticsApi.ts
+++ b/src/kubeview/engine/analyticsApi.ts
@@ -145,7 +145,17 @@ export const fetchReadinessSummary = () =>
   get<ReadinessSummary>(`${AGENT_BASE}/analytics/readiness`);
 
 export interface AgentCapabilities {
+  /** The ceiling a client may select. Mission Control greys out levels above it. */
   max_trust_level: number;
+  /**
+   * The level the agent's scan loop is actually running at — which a
+   * subscriber may raise above the configured floor. This is the number to
+   * show an operator who wants to know what the agent will do unattended;
+   * `max_trust_level` only says what they are allowed to ask for.
+   *
+   * Optional because an older agent will not send it.
+   */
+  effective_trust_level?: number;
   supported_auto_fix_categories?: string[];
 }
 

--- a/src/kubeview/views/PulseView.tsx
+++ b/src/kubeview/views/PulseView.tsx
@@ -6,6 +6,26 @@ import {
 import { cn } from '@/lib/utils';
 import { Tooltip } from '../components/primitives/Tooltip';
 
+/**
+ * What to say when this tab's requested trust level is not the one the agent
+ * is running at.
+ *
+ * The badge shows the agent's level, which is the number that decides what
+ * happens unattended. But an operator who set this tab to 1 and reads "Trust 3"
+ * deserves to know why rather than assuming the badge is broken.
+ *
+ * Returns null when there is nothing to explain — the levels agree, or the
+ * agent is too old to report its own.
+ */
+export function trustDivergenceNote(
+  requested: number,
+  effective: number | undefined,
+): string | null {
+  if (effective === undefined) return null;
+  if (effective === requested) return null;
+  return `This tab asked for ${requested}. The agent is running at ${effective}, set on the server.`;
+}
+
 const TRUST_LEVELS = [
   [0, 'Observe', 'agent watches only'],
   [1, 'Confirm', 'you approve each action'],
@@ -23,6 +43,8 @@ import { useFleetStore } from '../store/fleetStore';
 import { useShallow } from 'zustand/react/shallow';
 import { useMonitorStore } from '../store/monitorStore';
 import { useTrustStore } from '../store/trustStore';
+import { useQuery } from '@tanstack/react-query';
+import { fetchCapabilities } from '../engine/analyticsApi';
 import { useNavigateTab } from '../hooks/useNavigateTab';
 import { useK8sListWatch } from '../hooks/useK8sListWatch';
 import { useIncidentFeed } from '../hooks/useIncidentFeed';
@@ -177,7 +199,25 @@ export default function PulseView() {
       findings: s.findings,
       lastScanTime: s.lastScanTime,
     })));
-  const trustLevel = useTrustStore((s) => s.trustLevel);
+  const requestedTrust = useTrustStore((s) => s.trustLevel);
+  // Same query key as Mission Control, so the two screens cannot disagree.
+  const capQ = useQuery({ queryKey: ['agent', 'capabilities'], queryFn: fetchCapabilities, staleTime: 60_000 });
+  /**
+   * What the agent is actually running at, not what this tab asked for.
+   *
+   * `useTrustStore` is zustand `persist` on localStorage, keyed per hostname.
+   * It is sent to the agent when the monitor socket connects and never read
+   * back — so the badge was reporting a browser preference as if it were the
+   * agent's state. Two operators on one cluster could read two different
+   * numbers off the same agent, and with the server-side floor now set by
+   * `settings.monitor.max_trust_level`, both could be wrong about what it
+   * would do unattended.
+   *
+   * Falls back to the local value only while the query is in flight, or
+   * against an agent too old to send the field.
+   */
+  const trustLevel = capQ.data?.effective_trust_level ?? requestedTrust;
+  const divergenceNote = trustDivergenceNote(requestedTrust, capQ.data?.effective_trust_level);
   const { counts: incidentCounts } = useIncidentFeed({ limit: 0 });
 
   const [scanning, setScanning] = useState(false);
@@ -256,6 +296,11 @@ export default function PulseView() {
                       </div>
                     ))}
                   </div>
+                  {divergenceNote && (
+                    <div className="mt-2 pt-2 border-t border-slate-700 text-[11px] text-amber-400/90">
+                      {divergenceNote}
+                    </div>
+                  )}
                 </div>
               }
               side="bottom"

--- a/src/kubeview/views/__tests__/ClusterPostureBar.test.tsx
+++ b/src/kubeview/views/__tests__/ClusterPostureBar.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import PulseViewModule from '../PulseView';
 
 /**
@@ -54,7 +55,14 @@ vi.mock('../../hooks/useNavigateTab', () => ({ useNavigateTab: () => vi.fn() }))
 
 function renderBar(over: Partial<typeof monitorState>) {
   Object.assign(monitorState, { findings: [], lastScanTime: null, connected: true }, over);
-  return render(<PulseViewModule />);
+  // PulseView reads the agent's own trust level through react-query, so it
+  // needs a client even when the test is only looking at the posture bar.
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <PulseViewModule />
+    </QueryClientProvider>,
+  );
 }
 
 describe('the posture bar does not claim health before it has looked', () => {

--- a/src/kubeview/views/__tests__/PulseView.test.tsx
+++ b/src/kubeview/views/__tests__/PulseView.test.tsx
@@ -71,7 +71,16 @@ vi.mock('../../engine/diagnosis', () => ({
   diagnoseResource: () => [],
 }));
 
-import PulseView from '../PulseView';
+// Partial mock: PulseView pulls only fetchCapabilities from this module, but
+// components rendered inside it use the rest, so keep the real exports.
+const capabilitiesMock = vi.fn();
+vi.mock('../../engine/analyticsApi', async () => {
+  const actual = await vi.importActual<any>('../../engine/analyticsApi');
+  return { ...actual, fetchCapabilities: (...a: any[]) => capabilitiesMock(...a) };
+});
+
+import PulseView, { trustDivergenceNote } from '../PulseView';
+import { useTrustStore } from '../../store/trustStore';
 
 function setMockData(data: Record<string, { data: any[]; isLoading: boolean }>) {
   for (const key of Object.keys(_mockListWatchData)) {
@@ -199,5 +208,88 @@ describe('PulseView', () => {
 
     renderPulse();
     expect(screen.getByText('Control Plane')).toBeDefined();
+  });
+});
+
+
+/**
+ * The trust badge on the front door reported a browser preference.
+ *
+ * `useTrustStore` is zustand `persist` on localStorage, keyed per hostname. It
+ * is sent to the agent when the monitor socket connects and never read back,
+ * so the badge showed what this tab had asked for rather than what the agent
+ * was doing. Two operators on one cluster could read two different trust
+ * levels off the same agent — and since the server-side floor is now set by
+ * `settings.monitor.max_trust_level`, both could be wrong about what it would
+ * do with nobody watching.
+ */
+describe('the trust badge reports the agent, not the tab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setMockData({});
+    useTrustStore.setState({ trustLevel: 1 });
+  });
+
+  afterEach(cleanup);
+
+  it('shows the level the agent is running at, not the one this tab asked for', async () => {
+    capabilitiesMock.mockResolvedValue({ max_trust_level: 3, effective_trust_level: 3 });
+    renderPulse();
+    expect(await screen.findByText(/Trust 3/)).toBeDefined();
+    expect(screen.queryByText(/Trust 1/)).toBeNull();
+  });
+
+  // The explanation itself lives in the tooltip, which Radix renders through a
+  // portal only once open. Its decision is a pure function, so it is tested
+  // directly rather than by driving hover in jsdom.
+  describe('trustDivergenceNote', () => {
+    it('explains the gap when the tab and the agent disagree', () => {
+      expect(trustDivergenceNote(1, 3)).toBe(
+        'This tab asked for 1. The agent is running at 3, set on the server.',
+      );
+    });
+
+    it('says nothing when they agree', () => {
+      expect(trustDivergenceNote(2, 2)).toBeNull();
+    });
+
+    it('says nothing when the agent does not report a level', () => {
+      expect(trustDivergenceNote(1, undefined)).toBeNull();
+    });
+
+    it('explains a gap that runs the other way, too', () => {
+      // A subscriber can raise the level, so the tab may be above the agent
+      // as well as below it. Both directions are worth explaining.
+      expect(trustDivergenceNote(3, 1)).toContain('running at 1');
+    });
+
+    it('treats 0 as a level, not as absent', () => {
+      // Observe is the most restrictive setting and it is falsy — an operator
+      // whose agent dropped to 0 most needs to be told.
+      expect(trustDivergenceNote(2, 0)).toContain('running at 0');
+    });
+  });
+
+  it('falls back to the local value against an agent that does not send the field', async () => {
+    // An older agent has no effective_trust_level. Showing nothing, or zero,
+    // would both be worse than showing the only number available.
+    capabilitiesMock.mockResolvedValue({ max_trust_level: 2 });
+    renderPulse();
+    expect(await screen.findByText(/Trust 1/)).toBeDefined();
+    expect(screen.queryByText(/This tab asked for/)).toBeNull();
+  });
+
+  it('falls back when the capabilities call fails outright', async () => {
+    capabilitiesMock.mockRejectedValue(new Error('agent unreachable'));
+    renderPulse();
+    expect(await screen.findByText(/Trust 1/)).toBeDefined();
+  });
+
+  it('reads trust 0 as trust 0, not as missing', async () => {
+    // `?? requestedTrust` rather than `|| requestedTrust`: level 0 is Observe,
+    // a real and the most restrictive setting, and it is falsy.
+    capabilitiesMock.mockResolvedValue({ max_trust_level: 0, effective_trust_level: 0 });
+    renderPulse();
+    expect(await screen.findByText(/Trust 0/)).toBeDefined();
   });
 });


### PR DESCRIPTION
## The bug

The front-door badge reads `Agent · Trust 1`. That number came from:

```ts
const trustLevel = useTrustStore((s) => s.trustLevel);
```

`useTrustStore` is zustand `persist` on localStorage, keyed `openshiftpulse-trust-{hostname}`. It is sent **to** the agent when the monitor socket connects ([monitorClient.ts:228](src/kubeview/engine/monitorClient.ts:228)) and never read back. So the badge reported a per-browser preference as though it were the agent's state.

Two operators on the same cluster could read two different trust levels off the same agent. And since `effective_trust_level` server-side now reads `settings.monitor.max_trust_level` rather than whichever tabs are open, **both of them could be wrong** about what the agent would do unattended — on a badge whose only job is to answer that question.

Same shape as "All clear" being the loading state: a confident-looking indicator sourced from something that doesn't know the answer.

## The change

Reads `effective_trust_level` from `/monitor/capabilities`, on the **same query key** Mission Control already uses (`['agent', 'capabilities']`), so the two screens cannot disagree and it costs no extra request.

```ts
const trustLevel = capQ.data?.effective_trust_level ?? requestedTrust;
```

`??` and not `||`. Trust 0 is Observe — the most restrictive level there is, and falsy. An agent that dropped to 0 is precisely the case an operator most needs to be told about.

Falls back to the local value while the query is in flight, and against an agent too old to send the field, so this works against any agent version. Requires pulse-agent [#98](https://github.com/PulseSRE/pulse-agent/pull/98) to show the true value.

Where the tab's request and the agent's reality diverge, the tooltip names the gap rather than leaving the operator to conclude the badge is broken.

## Tests

The badge value is tested through the rendered DOM. The tooltip's message is a pure function (`trustDivergenceNote`) tested directly — Radix portals tooltip content only once open, and driving hover in jsdom tests the portal rather than the logic.

Mutations checked — each fails at least one test:

| mutation | result |
|---|---|
| badge reverts to the local store | 2 failed |
| `??` → `\|\|` (trust 0 read as missing) | 1 failed |
| note fires when the levels agree | 1 failed |
| `undefined` guard dropped | 1 failed |

## One thing I broke and fixed

`ClusterPostureBar.test.tsx` renders `PulseView` without a `QueryClientProvider`, so the new `useQuery` threw in four tests. I completed that harness rather than guarding the hook — the component genuinely needs a client, and guarding would have hidden that from every future test.