### PR TITLE
Bound the map, and make the skeleton reserve what it takes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### The map took most of the first screen, and then moved it
+- `WorldMap` hardcoded a 520px container. Measured against the reference cluster on a 1440x900 desktop: **57.8% of the viewport**, for a drawing of seven nodes — and it pushed Heartbeat, Healthy and the utilisation metrics below the fold. The front door led with a picture and hid the numbers an operator opens it for
+- Now `clamp(280px, 42vh, 520px)`. On that same 1440x900 screen the map is 378px and all three readouts sit above the fold; on a 1280x720 laptop it is 302px; on anything shorter the 280px floor keeps it legible. The 520px ceiling means nothing changes on a large display
+- Separately, PulseView's Suspense skeleton reserved `h-[420px]` for a map that renders at 520, so the whole page below it **jumped 100px** the moment the lazy chunk landed. Both now read one exported constant, and a test fails if the skeleton drifts back to a literal
+
 ### The trust badge on the front door reported a browser preference
 - `Agent · Trust 1` came from `useTrustStore` — zustand `persist` on localStorage, keyed per hostname. It is sent to the agent when the monitor socket connects and **never read back**. So the badge showed what this tab had asked for, not what the agent was doing
 - Two operators on one cluster could read two different trust levels off the same agent. Since the server-side floor is now `settings.monitor.max_trust_level`, both of them could be wrong about what it would do with nobody watching — on a badge whose entire job is to answer that question

--- a/src/kubeview/components/topology/WorldMap.tsx
+++ b/src/kubeview/components/topology/WorldMap.tsx
@@ -11,6 +11,22 @@ import { NodeGrid } from './overlays/NodeGrid';
 import { PodGrid } from './overlays/PodGrid';
 import { Search, Filter, Cpu, MemoryStick, Server, Box, AlertTriangle, Activity, Maximize2, Minimize2 } from 'lucide-react';
 
+/**
+ * How much of the first screen the map may take.
+ *
+ * It was a flat 520px. Measured on a 1440x900 desktop against the reference
+ * cluster: 520px is 57.8% of the viewport, and it pushed Heartbeat, Healthy
+ * and the utilisation metrics below the fold — so the front door led with a
+ * picture of seven nodes and hid the numbers an operator opens it for.
+ *
+ * Clamped instead of shrunk: 42vh keeps the same proportion on a large display
+ * where there is room to spare, the 280px floor keeps it legible on a laptop,
+ * and the 520px ceiling means nothing about the roomy case changes.
+ *
+ * The SVG scales to its container via viewBox, so the drawing is unaffected.
+ */
+export const MAP_HEIGHT = 'clamp(280px, 42vh, 520px)';
+
 export interface MapStats {
   totalNodes: number;
   readyNodes: number;
@@ -256,7 +272,7 @@ export function WorldMap({ clusters, zones, nodes, pods, events = [], zoneUtiliz
   const statColor = (val: number, warn: number, crit: number) => val >= crit ? 'text-red-400' : val >= warn ? 'text-amber-400' : 'text-emerald-400';
 
   return (
-    <div ref={containerRef} className={`relative rounded-lg border border-slate-800 overflow-hidden bg-[#080e1a] transition-all duration-300 ${fullscreen ? 'fixed inset-0 z-50 rounded-none border-0' : ''}`} style={fullscreen ? undefined : { height: 520 }}>
+    <div ref={containerRef} className={`relative rounded-lg border border-slate-800 overflow-hidden bg-[#080e1a] transition-all duration-300 ${fullscreen ? 'fixed inset-0 z-50 rounded-none border-0' : ''}`} style={fullscreen ? undefined : { height: MAP_HEIGHT }}>
       <style>{css}</style>
 
       {/* ═══ STATS HEADER ═══ */}

--- a/src/kubeview/components/topology/__tests__/mapHeight.test.ts
+++ b/src/kubeview/components/topology/__tests__/mapHeight.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { MAP_HEIGHT } from '../WorldMap';
+
+/**
+ * The map took most of the first screen, and then moved it.
+ *
+ * Two separate faults in the same few lines. WorldMap hardcoded a 520px
+ * container — measured against the reference cluster on a 1440x900 desktop,
+ * 57.8% of the viewport, which pushed Heartbeat, Healthy and the utilisation
+ * metrics off the bottom. The front door led with a picture of seven nodes and
+ * hid the numbers an operator opens it for.
+ *
+ * And PulseView's Suspense skeleton reserved `h-[420px]` for that 520px map,
+ * so everything below jumped 100px the moment the lazy chunk landed.
+ */
+describe('the map is bounded, and the skeleton reserves what it will take', () => {
+  const parse = (v: string) => {
+    const m = v.match(/^clamp\((\d+)px,\s*(\d+)vh,\s*(\d+)px\)$/);
+    if (!m) throw new Error(`MAP_HEIGHT is not a clamp: ${v}`);
+    return { floor: +m[1], vh: +m[2], ceiling: +m[3] };
+  };
+
+  it('never takes more than half the viewport', () => {
+    // The whole point: at any viewport height, the fraction is under 50%, so
+    // the health readouts below it cannot be pushed off the fold again.
+    expect(parse(MAP_HEIGHT).vh).toBeLessThan(50);
+  });
+
+  it('stays legible on a short screen', () => {
+    // 42vh on a 600px laptop is 252px, which is not a usable map. The floor is
+    // what stops the clamp from solving one problem by creating another.
+    expect(parse(MAP_HEIGHT).floor).toBeGreaterThanOrEqual(280);
+  });
+
+  it('does not grow past what it used to be on a large display', () => {
+    // Nothing about the roomy case should change — this was a fix for small
+    // and medium screens, not licence to take more space on big ones.
+    expect(parse(MAP_HEIGHT).ceiling).toBeLessThanOrEqual(520);
+  });
+
+  it('pins the value, so a change has to be deliberate', () => {
+    expect(MAP_HEIGHT).toBe('clamp(280px, 42vh, 520px)');
+  });
+
+  it('the loading skeleton reserves exactly the map height', () => {
+    // A literal here is how the 100px jump got in. The skeleton and the map
+    // must read from one constant or they drift apart again silently.
+    const src = readFileSync(resolve(__dirname, '../../../views/PulseView.tsx'), 'utf8');
+    const fallback = src.match(/<Suspense fallback=\{[\s\S]*?\}>/);
+    expect(fallback, 'PulseView should still lazy-load the map behind a Suspense fallback').toBeTruthy();
+    expect(fallback![0]).toContain('MAP_HEIGHT');
+    expect(fallback![0]).not.toMatch(/h-\[\d+px\]|height:\s*\d+/);
+  });
+});

--- a/src/kubeview/views/PulseView.tsx
+++ b/src/kubeview/views/PulseView.tsx
@@ -54,6 +54,7 @@ import { FleetReportTab } from './pulse/FleetReportTab';
 import { formatRelativeTime } from '../engine/formatters';
 
 const ClusterResourceMap = lazy(() => import('../components/topology/TopologyMap'));
+import { MAP_HEIGHT } from '../components/topology/WorldMap';
 
 /**
  * `unknown` is not a shade of green.
@@ -332,8 +333,11 @@ export default function PulseView() {
           </div>
         </div>
 
+        {/* The skeleton reserves exactly what the map will occupy. It used to
+            say 420px against a map that renders at 520, so the whole page
+            below it jumped 100px the moment the lazy chunk landed. */}
         <Suspense fallback={
-          <div className="h-[420px] bg-slate-900 rounded-lg border border-slate-800 animate-pulse" />
+          <div style={{ height: MAP_HEIGHT }} className="bg-slate-900 rounded-lg border border-slate-800 animate-pulse" />
         }>
           <ClusterResourceMap
             nodes={nodes}


### PR DESCRIPTION
Two faults in the same few lines, both measured live against the reference cluster rather than eyeballed.

## 1. The map took most of the first screen

`WorldMap.tsx` hardcoded its container:

```tsx
style={fullscreen ? undefined : { height: 520 }}
```

Measured at 1440×900:

| | before | after |
|---|---|---|
| map height | 520px | **378px** |
| share of viewport | **57.8%** | 42% |
| `Heartbeat` | y=768 | y=626 |
| `Healthy` | y=888 | y=746 |
| `Bottleneck` | y=1032 — **off-screen** | y=890 |

58% of the first screen went to a drawing of seven nodes, and the numbers an operator opens the front door for were below the fold.

Now `clamp(280px, 42vh, 520px)`:

- **42vh** — proportional, so it cannot eat the fold at any height
- **280px floor** — 42vh on a 720p-class laptop is 252px, which is not a usable map. Verified: at 1280×600 the floor holds at 280 where the raw value would be 252
- **520px ceiling** — nothing changes on a large display; this was a fix for small and medium screens, not licence to take more room on big ones

At 1280×720: map 302px, `Heartbeat` at y=550, above the fold.

## 2. The skeleton reserved the wrong height

```tsx
<Suspense fallback={<div className="h-[420px] ..." />}>
```

420px reserved for a map that renders at 520 — so the entire page below it **jumped 100px** when the lazy chunk resolved. Both now read one exported `MAP_HEIGHT`, and a test fails if the fallback drifts back to a literal, since a literal is exactly how the two got out of step.

## Tests

Five, including a source-level guard on the skeleton. Mutations checked:

| mutation | result |
|---|---|
| back to a flat `520px` | 4 failed |
| a clamp that still eats the fold (`55vh`) | 2 failed |
| floor lowered to 120px | 2 failed |
| skeleton back to `h-[420px]` | 1 failed |

`2172 passed`, tsc clean.