### PR TITLE
Make the trust ladder describe the agent that ships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
 - Now `clamp(280px, 42vh, 520px)`. On that same 1440x900 screen the map is 378px and all three readouts sit above the fold; on a 1280x720 laptop it is 302px; on anything shorter the 280px floor keeps it legible. The 520px ceiling means nothing changes on a large display
 - Separately, PulseView's Suspense skeleton reserved `h-[420px]` for a map that renders at 520, so the whole page below it **jumped 100px** the moment the lazy chunk landed. Both now read one exported constant, and a test fails if the skeleton drifts back to a literal
 
+### The trust ladder described a different agent than the one that ships
+- Level 1 read **"Confirm — every action requires your explicit approval"**. The agent never enters `auto_fix` below level 2, so level 1 proposes nothing and there is nothing to approve. An operator who wanted supervised remediation read that, chose 1, and got an agent that did nothing at all — the `total_actions: 0` symptom, named right there on the control
+- Level 2 read "Batch — low-risk auto-approved" and is in fact the level that asks: it proposes every fix and waits for you. The two were the wrong way round
+- Levels 3 and 4 promised LOW/MEDIUM/HIGH risk tiers. Nothing implements them — `risk_level` exists only in investigation output and the fix path never reads it. What separates 3 from 4 is category filtering
+- The ladder now reads: **0 Observe** (watches only, writes blocked), **1 Manual** (you act, the agent does not), **2 Propose** (proposes fixes, you approve), **3 Bounded** (fixes allowed categories itself), **4 Autonomous** (fixes anything it can). Behaviour is unchanged — the names were wrong, not the ladder
+- `PulseView` kept its own copy of the level names, which is how the badge tooltip and Mission Control came to describe different agents. Both now render from one exported map, and a test fails if a screen starts restating the ladder again
+
 ### The trust badge on the front door reported a browser preference
 - `Agent · Trust 1` came from `useTrustStore` — zustand `persist` on localStorage, keyed per hostname. It is sent to the agent when the monitor socket connects and **never read back**. So the badge showed what this tab had asked for, not what the agent was doing
 - Two operators on one cluster could read two different trust levels off the same agent. Since the server-side floor is now `settings.monitor.max_trust_level`, both of them could be wrong about what it would do with nobody watching — on a badge whose entire job is to answer that question

--- a/src/kubeview/store/__tests__/trustLadder.test.ts
+++ b/src/kubeview/store/__tests__/trustLadder.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { TRUST_LABELS, TRUST_DESCRIPTIONS, TRUST_HINTS, type TrustLevel } from '../trustStore';
+
+/**
+ * The trust ladder described a different agent than the one that ships.
+ *
+ * Verified by running the agent's `auto_fix` at every level:
+ *
+ *   0  auto_fix not entered; write tool buttons blocked (max_trust_level < 1)
+ *   1  auto_fix not entered — nothing is ever proposed
+ *   2  auto_fix entered, every action saved as "proposed", nothing executed
+ *   3  auto_fix entered, executes without a confirmation gate, category-filtered
+ *   4  auto_fix entered, executes without a confirmation gate, unfiltered
+ *
+ * The labels said 1 was "Confirm — every action requires your explicit
+ * approval" for a level that proposes nothing, and 2 was "Batch — low-risk
+ * auto-approved" for the level that actually asks. An operator who wanted
+ * supervised remediation picked 1 and got an agent that did nothing — the
+ * `total_actions: 0` symptom, sitting in plain sight in the control's own name.
+ */
+describe('the trust ladder describes the agent that ships', () => {
+  const levels: TrustLevel[] = [0, 1, 2, 3, 4];
+
+  it('does not promise confirmation on a level that never proposes', () => {
+    // Level 1 does not enter auto_fix, so nothing exists to approve. Any
+    // label or description implying otherwise is the original bug.
+    expect(TRUST_LABELS[1]).not.toMatch(/confirm/i);
+    expect(TRUST_DESCRIPTIONS[1]).not.toMatch(/approv|confirm/i);
+    expect(TRUST_HINTS[1]).not.toMatch(/approv|confirm/i);
+  });
+
+  it('names level 2 as the one that actually asks', () => {
+    expect(TRUST_DESCRIPTIONS[2]).toMatch(/approv/i);
+    expect(TRUST_LABELS[2]).toBe('Propose');
+  });
+
+  it('does not claim risk tiers that the fix path does not implement', () => {
+    // `risk_level` exists only in LLM investigation output; auto_fix never
+    // reads it. Promising "low-risk auto-approved" invents a guarantee.
+    for (const l of levels) {
+      expect(TRUST_DESCRIPTIONS[l], `level ${l}`).not.toMatch(/low[- ]risk|medium|high[- ]risk/i);
+    }
+  });
+
+  it('describes what actually separates 3 from 4', () => {
+    // 3 filters by category; 4 does not. That is the only difference.
+    expect(TRUST_DESCRIPTIONS[3]).toMatch(/categor/i);
+    expect(TRUST_DESCRIPTIONS[4]).not.toMatch(/categor/i);
+  });
+
+  it('keeps every level distinct', () => {
+    // Two levels reading the same is how an operator picks the wrong one.
+    expect(new Set(Object.values(TRUST_LABELS)).size).toBe(5);
+    expect(new Set(Object.values(TRUST_DESCRIPTIONS)).size).toBe(5);
+    expect(new Set(Object.values(TRUST_HINTS)).size).toBe(5);
+  });
+
+  it('gets more autonomous as the number rises, in the words too', () => {
+    // 0 and 1 must not describe the agent acting on its own; 3 and 4 must.
+    expect(TRUST_DESCRIPTIONS[0]).toMatch(/never acts|no actions/i);
+    expect(TRUST_DESCRIPTIONS[1]).toMatch(/never remediates|does not/i);
+    expect(TRUST_DESCRIPTIONS[3]).toMatch(/without asking/i);
+    expect(TRUST_DESCRIPTIONS[4]).toMatch(/without asking/i);
+  });
+
+  it('is stated once, not restated per screen', () => {
+    // PulseView kept its own array of level names. That is how the badge
+    // tooltip and Mission Control came to describe different agents.
+    const src = readFileSync(resolve(__dirname, '../../views/PulseView.tsx'), 'utf8');
+    expect(src).toContain('TRUST_LABELS');
+    expect(src).not.toMatch(/\[\s*0,\s*'Observe'/);
+  });
+});

--- a/src/kubeview/store/__tests__/trustStore.test.ts
+++ b/src/kubeview/store/__tests__/trustStore.test.ts
@@ -122,7 +122,11 @@ describe('trustStore', () => {
 
   it('has level 4 label and description', () => {
     expect(TRUST_LABELS[4]).toBe('Autonomous');
-    expect(TRUST_DESCRIPTIONS[4]).toBe('Agent auto-fixes known issues from runbooks. All actions are logged and reversible.');
+    // Was pinned to "auto-fixes known issues from runbooks". There are no
+    // runbooks in the fix path — level 4 applies every auto-fixable finding it
+    // can, unfiltered. The old text made the most autonomous level sound like
+    // the most constrained one.
+    expect(TRUST_DESCRIPTIONS[4]).toBe('The agent applies any fix it can, without asking. All actions are logged.');
   });
 
   it('manages autoFixCategories state', () => {

--- a/src/kubeview/store/trustStore.ts
+++ b/src/kubeview/store/trustStore.ts
@@ -1,12 +1,31 @@
 /**
  * Trust Store — tracks agent confirmation history and progressive trust levels.
  *
- * Trust levels:
- *   0 OBSERVE     — Agent explains, no action buttons
- *   1 CONFIRM     — All actions require confirmation (default)
- *   2 BATCH       — LOW risk auto-approved
- *   3 BOUNDED     — LOW + MEDIUM auto-approved, only HIGH requires confirmation
- *   4 AUTONOMOUS  — Agent auto-fixes known issues from runbooks (all actions logged & reversible)
+ * The ladder below is written from what the agent actually does, verified by
+ * running `auto_fix` at each level. The previous version described a different
+ * product:
+ *
+ *   1 was "CONFIRM — all actions require confirmation". In fact `auto_fix` is
+ *   only entered at `trust_level >= 2`, so level 1 never proposes anything.
+ *   There is nothing to confirm. An operator who wanted supervised remediation
+ *   read that label, chose 1, and got an agent that did nothing at all — which
+ *   is exactly the `total_actions: 0` symptom measured on the reference
+ *   cluster.
+ *
+ *   2 was "BATCH — LOW risk auto-approved". In fact level 2 proposes *every*
+ *   fix and waits for a human. It is the level that actually confirms.
+ *
+ *   3 and 4 promised LOW/MEDIUM/HIGH risk tiers. No such tiering exists in the
+ *   fix path — `risk_level` appears only in LLM investigation output, and
+ *   `auto_fix` never consults it. What 3 really does is filter by category.
+ *
+ * The ladder is monotonic and the levels are genuinely distinct; only the
+ * names were wrong. Behaviour is deliberately unchanged here: making level 1
+ * act as its old label promised would start remediation on every cluster
+ * currently configured at 1, on upgrade, without anyone asking for it.
+ *
+ * This file is the single source for the ladder. Render from these maps rather
+ * than restating the levels, which is how the two copies drifted apart.
  */
 
 import { create } from 'zustand';
@@ -16,18 +35,27 @@ export type TrustLevel = 0 | 1 | 2 | 3 | 4;
 
 export const TRUST_LABELS: Record<TrustLevel, string> = {
   0: 'Observe',
-  1: 'Confirm',
-  2: 'Batch',
+  1: 'Manual',
+  2: 'Propose',
   3: 'Bounded',
   4: 'Autonomous',
 };
 
+/** Short form for the badge tooltip. Same ladder, fewer words. */
+export const TRUST_HINTS: Record<TrustLevel, string> = {
+  0: 'watches only, writes blocked',
+  1: 'you act, the agent does not',
+  2: 'proposes fixes, you approve',
+  3: 'fixes allowed categories itself',
+  4: 'fixes anything it can itself',
+};
+
 export const TRUST_DESCRIPTIONS: Record<TrustLevel, string> = {
-  0: 'Agent explains what it would do. No actions executed.',
-  1: 'Every action requires your explicit approval.',
-  2: 'Low-risk actions auto-approved. Medium and high require confirmation.',
-  3: 'Low and medium auto-approved. Only high-risk actions require confirmation.',
-  4: 'Agent auto-fixes known issues from runbooks. All actions are logged and reversible.',
+  0: 'Agent explains what it would do and never acts. Action buttons that write are blocked too.',
+  1: 'You act, the agent does not. Action buttons work; the agent never remediates on its own.',
+  2: 'The agent proposes every fix and waits for your approval before anything runs.',
+  3: 'The agent applies fixes without asking, limited to the categories you allow.',
+  4: 'The agent applies any fix it can, without asking. All actions are logged.',
 };
 
 export type CommunicationStyle = 'brief' | 'detailed' | 'technical';

--- a/src/kubeview/views/PulseView.tsx
+++ b/src/kubeview/views/PulseView.tsx
@@ -26,13 +26,12 @@ export function trustDivergenceNote(
   return `This tab asked for ${requested}. The agent is running at ${effective}, set on the server.`;
 }
 
-const TRUST_LEVELS = [
-  [0, 'Observe', 'agent watches only'],
-  [1, 'Confirm', 'you approve each action'],
-  [2, 'Batch', 'agent proposes fixes for review'],
-  [3, 'Bounded', 'auto-fixes within guardrails'],
-  [4, 'Autonomous', 'agent acts independently'],
-] as const;
+// Derived, not restated. This file used to keep its own copy of the ladder,
+// which is how the tooltip and Mission Control ended up describing different
+// agents — and how "Confirm" survived on a level that never proposes anything.
+const TRUST_LEVELS = ([0, 1, 2, 3, 4] as const).map(
+  (level) => [level, TRUST_LABELS[level], TRUST_HINTS[level]] as const,
+);
 import type { K8sResource } from '../engine/renderers';
 import type { Node, Pod, Event } from '../engine/types';
 import type { ClusterOperator } from '../engine/types/openshift';
@@ -42,7 +41,7 @@ import { useUIStore } from '../store/uiStore';
 import { useFleetStore } from '../store/fleetStore';
 import { useShallow } from 'zustand/react/shallow';
 import { useMonitorStore } from '../store/monitorStore';
-import { useTrustStore } from '../store/trustStore';
+import { useTrustStore, TRUST_LABELS, TRUST_HINTS } from '../store/trustStore';
 import { useQuery } from '@tanstack/react-query';
 import { fetchCapabilities } from '../engine/analyticsApi';
 import { useNavigateTab } from '../hooks/useNavigateTab';

--- a/src/kubeview/views/__tests__/ClusterPostureBar.test.tsx
+++ b/src/kubeview/views/__tests__/ClusterPostureBar.test.tsx
@@ -48,9 +48,15 @@ vi.mock('../../store/uiStore', () => ({
 vi.mock('../../store/fleetStore', () => ({
   useFleetStore: (selector: (s: Record<string, unknown>) => unknown) => selector({ fleetMode: false }),
 }));
-vi.mock('../../store/trustStore', () => ({
-  useTrustStore: (selector: (s: Record<string, unknown>) => unknown) => selector({ trustLevel: 1 }),
-}));
+vi.mock('../../store/trustStore', async () => {
+  // Keep the real ladder maps: PulseView renders the badge tooltip from them,
+  // and a partial mock here would let the labels drift without a test noticing.
+  const actual = await vi.importActual<typeof import('../../store/trustStore')>('../../store/trustStore');
+  return {
+    ...actual,
+    useTrustStore: (selector: (s: Record<string, unknown>) => unknown) => selector({ trustLevel: 1 }),
+  };
+});
 vi.mock('../../hooks/useNavigateTab', () => ({ useNavigateTab: () => vi.fn() }));
 
 function renderBar(over: Partial<typeof monitorState>) {


### PR DESCRIPTION
Paired with pulse-agent [#101](https://github.com/PulseSRE/pulse-agent/pull/101), which pins the behaviour these labels now describe.

## The ladder was wrong where it mattered most

| level | was | is |
|---|---|---|
| 0 | Observe — "explains, no actions" | Observe — watches only, writes blocked |
| 1 | **Confirm — "every action requires your explicit approval"** | **Manual — you act, the agent does not** |
| 2 | **Batch — "low-risk auto-approved"** | **Propose — proposes fixes, you approve** |
| 3 | Bounded — "low+medium auto-approved" | Bounded — fixes allowed categories itself |
| 4 | Autonomous — "known issues from runbooks" | Autonomous — fixes anything it can |

The agent never enters `auto_fix` below trust 2. So level 1 — the one labelled "every action requires your explicit approval" — proposes nothing, and there is nothing to approve. An operator who wanted supervised remediation read the ladder, picked 1, and got an agent that did nothing: the `total_actions: 0` symptom, named right there on the control they chose.

Level 2, which genuinely proposes every fix and waits, was labelled "low-risk auto-approved". The two were the wrong way round.

Levels 3 and 4 promised LOW/MEDIUM/HIGH risk tiers. Nothing implements them — `risk_level` appears only in LLM investigation output and the fix path never reads it. What actually separates 3 from 4 is category filtering.

## Behaviour is unchanged, deliberately

Making level 1 act as its old label promised would start remediation on every cluster currently configured at 1, on upgrade, without anyone asking for it. The ladder is monotonic and the levels are genuinely distinct. Only the names were wrong.

## One source, not three

`PulseView` kept its own array of level names alongside `trustStore`'s maps — which is exactly how the badge tooltip and Mission Control came to describe different agents, and how "Confirm" survived on a level that proposes nothing. Both now render from one exported map, and a test fails if a screen starts restating the ladder again.

## Tests

Seven, asserting the labels against verified behaviour rather than against themselves: no confirmation promised on a level that never proposes, no risk tiers claimed, 3 and 4 distinguished by category, every level distinct, and the ladder stated once.

Mutations checked — each fails at least one test:

| mutation | result |
|---|---|
| "Confirm" back on level 1 | 1 failed |
| old risk-tier description back on level 2 | 1 failed |
| two levels given the same label | 1 failed |
| PulseView restates its own ladder | 1 failed |

## Two tests I had to change rather than work around

`trustStore.test.ts` pinned level 4's old description verbatim — it encoded the text being corrected, so I updated it with a note on why.

`ClusterPostureBar.test.tsx` mocked `trustStore` partially and broke once `PulseView` began importing the label maps. I completed the mock with `importActual` rather than stubbing the maps, so the labels can't drift behind a mock.

`2174 passed`, tsc clean.