### PR TITLE
Warn when a proposed fix treats a symptom of a known cause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Approve buttons for symptoms of a cause we had already named
+- The Inbox showed **"4 fixes waiting on you"**, each with an Approve button, targeting exactly the four pods the same screen labelled *"Explained by the cause above — not separate problems"* under an open `HighOverallControlPlaneMemory` episode. Same pods, same restart counts, one screen
+- Approving any of them restarts a pod whose cause is control-plane memory pressure; it crashloops again while the memory stays high. The agent's causal model knew that, and the panel with the buttons did not say
+- A proposal that the agent marks `explainedBy` now reads **"Symptom of *&lt;cause&gt;* — fixing this treats the symptom, not the cause"**, beside the button rather than buried in the reasoning text
+- The Approve button stays. A stopgap restart is sometimes the right call and it is the operator's to make — it is only wrong to ask them to make it blind
+
 ### The map took most of the first screen, and then moved it
 - `WorldMap` hardcoded a 520px container. Measured against the reference cluster on a 1440x900 desktop: **57.8% of the viewport**, for a drawing of seven nodes — and it pushed Heartbeat, Healthy and the utilisation metrics below the fold. The front door led with a picture and hid the numbers an operator opens it for
 - Now `clamp(280px, 42vh, 520px)`. On that same 1440x900 screen the map is 378px and all three readouts sit above the fold; on a 1280x720 laptop it is 302px; on anything shorter the 280px floor keeps it legible. The 520px ceiling means nothing changes on a large display

--- a/src/kubeview/engine/fixHistory.ts
+++ b/src/kubeview/engine/fixHistory.ts
@@ -19,6 +19,13 @@ export interface ActionRecord {
   afterState: string;
   error?: string;
   reasoning: string;
+  /**
+   * Cause title of the open episode that already explains this finding.
+   *
+   * Present when the agent's own causal model says this fix treats a symptom.
+   * Absent on older agents, and on proposals nothing explains.
+   */
+  explainedBy?: string;
   durationMs: number;
   rollbackAvailable: boolean;
   rollbackAction?: { tool: string; input: Record<string, unknown> };

--- a/src/kubeview/views/inbox/ProposedFixes.tsx
+++ b/src/kubeview/views/inbox/ProposedFixes.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Check, Loader2, Wrench } from 'lucide-react';
+import { Check, GitBranch, Loader2, Wrench } from 'lucide-react';
 import { Button } from '../../components/primitives/Button';
 import { approveFix, fetchFixHistory, type ActionRecord } from '../../engine/fixHistory';
 import { formatElapsed } from '../../engine/dateUtils';
@@ -87,6 +87,23 @@ export function ProposedFixes() {
                 {action.resources?.[0] ? `${action.resources[0].kind} ${action.resources[0].name}` : action.category}
                 {action.timestamp ? ` · proposed ${formatElapsed(Math.floor(action.timestamp / 1000))} ago` : ''}
               </div>
+              {/* The agent's causal model already knows this is a symptom.
+                  Measured on the reference cluster: all four fixes awaiting
+                  approval targeted the exact four pods the same screen called
+                  "Explained by the cause above — not separate problems".
+                  Restarting them treats a symptom of control-plane memory
+                  pressure and they crashloop again while the cause persists.
+                  Said out loud rather than suppressed — a stopgap restart is
+                  sometimes the right call, but never a blind one. */}
+              {action.explainedBy && (
+                <div className="mt-1 flex items-start gap-1.5 text-xs text-amber-400/90">
+                  <GitBranch className="w-3.5 h-3.5 shrink-0 mt-px" />
+                  <span>
+                    Symptom of <span className="font-medium">{action.explainedBy}</span> — fixing this
+                    treats the symptom, not the cause
+                  </span>
+                </div>
+              )}
               {errors[action.id] && <div className="text-xs text-red-400 mt-1">{errors[action.id]}</div>}
             </div>
             <Button size="sm" onClick={() => approve(action)} disabled={busy === action.id}>

--- a/src/kubeview/views/inbox/__tests__/ProposedFixes.test.tsx
+++ b/src/kubeview/views/inbox/__tests__/ProposedFixes.test.tsx
@@ -108,6 +108,45 @@ describe('ProposedFixes', () => {
     await waitFor(() => expect(vi.mocked(fetchFixHistory).mock.calls.length).toBeGreaterThan(1));
   });
 
+  it('warns when the fix treats a symptom of a known cause', async () => {
+    // On the reference cluster all four fixes awaiting approval targeted the
+    // exact four pods the same screen called "Explained by the cause above —
+    // not separate problems". The Approve button said nothing about it.
+    vi.mocked(fetchFixHistory).mockResolvedValue({
+      actions: [{ ...PROPOSAL, explainedBy: 'HighOverallControlPlaneMemory' }],
+      total: 1, page: 1, pageSize: 20,
+    });
+    render(<ProposedFixes />);
+    await waitFor(() => expect(screen.getByText(/HighOverallControlPlaneMemory/)).toBeDefined());
+    expect(screen.getByText(/treats the symptom, not the cause/)).toBeDefined();
+  });
+
+  it('still offers the fix — the operator decides, they are just not blind', async () => {
+    // Suppressing it would be worse: a stopgap restart is sometimes right.
+    vi.mocked(fetchFixHistory).mockResolvedValue({
+      actions: [{ ...PROPOSAL, explainedBy: 'HighOverallControlPlaneMemory' }],
+      total: 1, page: 1, pageSize: 20,
+    });
+    render(<ProposedFixes />);
+    await waitFor(() => expect(screen.getByText('Approve')).toBeDefined());
+  });
+
+  it('says nothing when no episode explains the finding', async () => {
+    render(<ProposedFixes />);
+    await waitFor(() => expect(screen.getByText('Approve')).toBeDefined());
+    expect(screen.queryByText(/treats the symptom/)).toBeNull();
+  });
+
+  it('an agent too old to send the field is not treated as a cause', async () => {
+    vi.mocked(fetchFixHistory).mockResolvedValue({
+      actions: [{ ...PROPOSAL, explainedBy: undefined }],
+      total: 1, page: 1, pageSize: 20,
+    });
+    render(<ProposedFixes />);
+    await waitFor(() => expect(screen.getByText('Approve')).toBeDefined());
+    expect(screen.queryByText(/treats the symptom/)).toBeNull();
+  });
+
   it('a list that will not load stays quiet instead of shouting over the inbox', async () => {
     vi.mocked(fetchFixHistory).mockRejectedValue(new Error('network'));
     const { container } = render(<ProposedFixes />);


### PR DESCRIPTION
Renders the label added by pulse-agent [#104](https://github.com/PulseSRE/pulse-agent/pull/104).

## What the Inbox showed

Two panels, one screen, at the same moment:

> **4 fixes waiting on you** — Approve · Approve · Approve · Approve
>
> **CAUSE — HighOverallControlPlaneMemory** — *"Explained by the cause above — not separate problems."*

Extracting both lists from the live DOM and intersecting them:

```
podsTheFixPanelAsksYouToApprove: [ocm-controller…, cluster-proxy-addon-manager…,
                                  multicluster-observability-operator…, controller-manager…]
podsTheEpisodeCallsSymptoms:     [controller-manager…, cluster-proxy-addon-manager…,
                                  ocm-controller…, multicluster-observability-operator…]
verdict: EVERY proposed fix targets a pod the same screen calls a symptom
```

The screen simultaneously told the operator "these are not separate problems" and "approve fixing each of them individually". Approving restarts pods whose cause is control-plane memory pressure — they crashloop again while the memory stays high.

## The change

A proposal the agent marks `explainedBy` now carries, beside the Approve button:

> ⑂ Symptom of **HighOverallControlPlaneMemory** — fixing this treats the symptom, not the cause

The button stays. A stopgap restart is sometimes the right call and it is the operator's to make; it is only wrong to ask them to make it blind.

## Tests

Four added: the warning appears with a cause, the Approve button survives it, nothing is said when no episode explains the finding, and an older agent that omits the field is not treated as if it named a cause.

Mutation: removing the warning block fails 1 test.

`2183 passed`, tsc clean.