### PR TITLE
Rank episodes by what they explain, and stop alarming on empty ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### A cause that explains nothing led the queue
+- Two control-plane memory episodes opened in the same second on the reference cluster: `HighOverallControlPlaneMemory` with **8 symptoms** and `ControlPlaneNodeMemoryHigh` with **none**. Neither can explain the other — equal causal layers — so symptom ownership went entirely to whichever claimed them first, and the loser still rendered as a full-width red cause card *above* the one doing the explaining
+- Episodes are now ordered by how much they explain, and one explaining nothing drops the red alarm styling for neutral slate. An episode is a claim that one thing explains others; until it explains something it has made no claim, and dressing it identically spends the operator's attention on the wrong card
+- It also reads **"explains nothing yet"** rather than "0 symptoms" — a bare zero reads like a count that failed to load
+- The first version of this keyed off the asynchronously-loaded symptom list, so *every* card flashed grey "explains nothing yet" before flipping to red on each load. It now reads `symptom_count` from the list payload until the detail fetch answers. Caught by its own test failing only in the full suite run, then pinned deterministically with a detail fetch that never resolves
+
 ### Approve buttons for symptoms of a cause we had already named
 - The Inbox showed **"4 fixes waiting on you"**, each with an Approve button, targeting exactly the four pods the same screen labelled *"Explained by the cause above — not separate problems"* under an open `HighOverallControlPlaneMemory` episode. Same pods, same restart counts, one screen
 - Approving any of them restarts a pod whose cause is control-plane memory pressure; it crashloops again while the memory stays high. The agent's causal model knew that, and the panel with the buttons did not say

--- a/src/kubeview/views/inbox/EpisodePanel.tsx
+++ b/src/kubeview/views/inbox/EpisodePanel.tsx
@@ -35,6 +35,7 @@ function recurrenceLine(r: EpisodeRecurrence): string | null {
 function EpisodeCard({ episode, onChanged }: { episode: Episode; onChanged: () => void }) {
   const [expanded, setExpanded] = useState(true);
   const [symptoms, setSymptoms] = useState<EpisodeSymptom[]>([]);
+  const [symptomsLoaded, setSymptomsLoaded] = useState(false);
   const [changes, setChanges] = useState<EpisodeChange[]>([]);
   const [recurrence, setRecurrence] = useState<EpisodeRecurrence | null>(null);
   const [investigation, setInvestigation] = useState<EpisodeInvestigation | null>(null);
@@ -46,6 +47,7 @@ function EpisodeCard({ episode, onChanged }: { episode: Episode; onChanged: () =
       .then((d) => {
         if (cancelled) return;
         setSymptoms(d.symptoms.filter((s) => s.detached_at == null));
+        setSymptomsLoaded(true);
         setChanges(d.changes ?? []);
         setRecurrence(d.recurrence ?? null);
         setInvestigation(d.investigation ?? null);
@@ -97,21 +99,56 @@ function EpisodeCard({ episode, onChanged }: { episode: Episode; onChanged: () =
     .filter(Boolean)
     .join(' ');
 
+  // An episode is a claim that one thing explains others. Until it explains
+  // something it has made no claim, and dressing it in the same red alarm as a
+  // cause with eight symptoms underneath spends the operator's attention on
+  // the wrong card.
+  //
+  // Read from the list payload until the detail fetch answers. Basing this on
+  // the async `symptoms` alone meant every card rendered "explains nothing
+  // yet" in grey for a beat and then flipped to red — a flash of the wrong
+  // state on every episode, every load. `symptom_count` arrives with the list.
+  const explainsNothing = symptomsLoaded ? symptoms.length === 0 : episode.symptom_count === 0;
+
   return (
-    <div className="rounded-lg border border-red-500/25 bg-red-500/[0.06]">
+    <div
+      className={cn(
+        'rounded-lg border',
+        explainsNothing
+          ? 'border-slate-700/60 bg-slate-800/30'
+          : 'border-red-500/25 bg-red-500/[0.06]',
+      )}
+    >
       <div className="flex items-start gap-2 px-3 py-2.5">
-        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-red-400" />
+        <AlertTriangle
+          className={cn('mt-0.5 h-4 w-4 shrink-0', explainsNothing ? 'text-slate-500' : 'text-red-400')}
+        />
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-            <span className="text-[10px] font-semibold uppercase tracking-wider text-red-400">Cause</span>
+            <span
+              className={cn(
+                'text-[10px] font-semibold uppercase tracking-wider',
+                explainsNothing ? 'text-slate-500' : 'text-red-400',
+              )}
+            >
+              Cause
+            </span>
             <span className="truncate text-sm font-medium text-slate-100">{episode.cause_title}</span>
           </div>
           <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-slate-400">
             <span>{episode.cause_category}</span>
             <span>started {formatElapsed(episode.cause_started_at ?? episode.started_at)} ago</span>
             <span>
-              {symptoms.length} {symptoms.length === 1 ? 'symptom' : 'symptoms'}
-              {episode.namespaces.length > 0 && ` across ${episode.namespaces.length} namespaces`}
+              {explainsNothing ? (
+                // "0 symptoms" reads like a count that failed to load. Saying
+                // it in words makes clear this is a state, not a gap.
+                'explains nothing yet'
+              ) : (
+                <>
+                  {symptoms.length} {symptoms.length === 1 ? 'symptom' : 'symptoms'}
+                  {episode.namespaces.length > 0 && ` across ${episode.namespaces.length} namespaces`}
+                </>
+              )}
             </span>
             {recurrenceLabel && (
               <span className="inline-flex items-center gap-1 font-medium text-amber-400">
@@ -240,7 +277,13 @@ export function EpisodePanel() {
 
   const load = useCallback(() => {
     fetchOpenEpisodes()
-      .then(setEpisodes)
+      // Most explanatory first. Two control-plane memory episodes opened in
+      // the same second on the reference cluster: one explained eight
+      // symptoms, its twin explained none, and the empty one rendered first.
+      // Neither can explain the other — equal causal layers — so symptom
+      // ownership went entirely to whichever claimed them, and the loser
+      // still took a full-width card at the top of the queue.
+      .then((list) => setEpisodes([...list].sort((a, b) => b.symptom_count - a.symptom_count)))
       .catch(() => setEpisodes([]));
   }, []);
 

--- a/src/kubeview/views/inbox/__tests__/EpisodePanel.test.tsx
+++ b/src/kubeview/views/inbox/__tests__/EpisodePanel.test.tsx
@@ -313,3 +313,98 @@ describe('EpisodePanel investigation and dismissal', () => {
     expect(screen.queryByTestId('inline-agent')).toBeNull();
   });
 });
+
+/**
+ * A cause that explains nothing.
+ *
+ * Two control-plane memory episodes opened in the same second on the reference
+ * cluster: `HighOverallControlPlaneMemory` with eight symptoms, and
+ * `ControlPlaneNodeMemoryHigh` with none. Neither can explain the other — they
+ * sit at the same causal layer — so symptom ownership went entirely to
+ * whichever claimed them first, and the loser still rendered as a full-width
+ * red cause card, ahead of the one doing the explaining.
+ *
+ * An episode is a claim that one thing explains others. Until it explains
+ * something it has made no claim.
+ */
+describe('an episode that explains nothing does not lead the queue', () => {
+  const EMPTY = {
+    ...EPISODE,
+    id: 'ep-empty',
+    cause_title: 'ControlPlaneNodeMemoryHigh',
+    symptom_count: 0,
+    namespaces: [],
+    correlation_key: 'alerts::Alert/ControlPlaneNodeMemoryHigh',
+  };
+  const FULL = { ...EPISODE, id: 'ep-full', cause_title: 'HighOverallControlPlaneMemory', symptom_count: 8 };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    detachSymptom.mockResolvedValue(undefined);
+    fetchEpisode.mockImplementation((id: string) =>
+      Promise.resolve(
+        id === 'ep-empty'
+          ? { episode: EMPTY, symptoms: [] }
+          : { episode: FULL, symptoms: SYMPTOMS },
+      ),
+    );
+  });
+
+  afterEach(cleanup);
+
+  it('puts the cause that explains the most first', async () => {
+    // Returned worst-first by the API, as it was on the cluster.
+    fetchOpenEpisodes.mockResolvedValue([EMPTY, FULL]);
+    render(<EpisodePanel />);
+    await waitFor(() => expect(screen.getByText('HighOverallControlPlaneMemory')).toBeDefined());
+    const rendered = document.body.textContent ?? '';
+    expect(rendered.indexOf('HighOverallControlPlaneMemory')).toBeLessThan(
+      rendered.indexOf('ControlPlaneNodeMemoryHigh'),
+    );
+  });
+
+  it('says so in words rather than showing a bare zero', async () => {
+    // "0 symptoms" reads like a count that failed to load.
+    fetchOpenEpisodes.mockResolvedValue([EMPTY]);
+    render(<EpisodePanel />);
+    expect(await screen.findByText(/explains nothing yet/)).toBeDefined();
+    expect(screen.queryByText(/0 symptoms/)).toBeNull();
+  });
+
+  it('does not dress it as an alarm', async () => {
+    fetchOpenEpisodes.mockResolvedValue([EMPTY]);
+    const { container } = render(<EpisodePanel />);
+    await screen.findByText(/explains nothing yet/);
+    const card = container.querySelector('div[class*="rounded-lg"][class*="border"]');
+    expect(card?.className).not.toMatch(/border-red/);
+  });
+
+  it('does not flash "explains nothing" while its symptoms are still loading', async () => {
+    // The list payload carries symptom_count synchronously; the symptom detail
+    // arrives later. Reading only the async list meant every card rendered
+    // grey "explains nothing yet" for a beat and then flipped to red.
+    // A detail fetch that never resolves pins the pre-load state.
+    fetchOpenEpisodes.mockResolvedValue([FULL]);
+    fetchEpisode.mockImplementation(() => new Promise(() => {}));
+    const { container } = render(<EpisodePanel />);
+    await screen.findByText('HighOverallControlPlaneMemory');
+    expect(screen.queryByText(/explains nothing yet/)).toBeNull();
+    const card = container.querySelector('div[class*="rounded-lg"][class*="border"]');
+    expect(card?.className).toMatch(/border-red/);
+  });
+
+  it('trusts the list payload for an empty episode before detail loads too', async () => {
+    fetchOpenEpisodes.mockResolvedValue([EMPTY]);
+    fetchEpisode.mockImplementation(() => new Promise(() => {}));
+    render(<EpisodePanel />);
+    expect(await screen.findByText(/explains nothing yet/)).toBeDefined();
+  });
+
+  it('an episode that does explain something keeps the alarm', async () => {
+    fetchOpenEpisodes.mockResolvedValue([FULL]);
+    const { container } = render(<EpisodePanel />);
+    await screen.findByText('HighOverallControlPlaneMemory');
+    const card = container.querySelector('div[class*="rounded-lg"][class*="border"]');
+    expect(card?.className).toMatch(/border-red/);
+  });
+});


### PR DESCRIPTION
Third open finding from the [triage audit](https://claude.ai/code/artifact/035643b8-69c4-4e49-8fd3-4a36cb4c08ba).

## What the Inbox showed

```
open episodes: 2
  symptoms=0   ControlPlaneNodeMemoryHigh      started=1787416412
  symptoms=8   HighOverallControlPlaneMemory   started=1787416412
```

Two control-plane memory episodes, opened in the **same second**, and the one explaining *nothing* rendered first — a full-width red cause card, above the one explaining eight symptoms.

I first assumed the empty one was mis-classified into the wrong causal layer. It is not:

```
HighOverallControlPlaneMemory    infrastructure
ControlPlaneNodeMemoryHigh       infrastructure
```

Both are infrastructure, which is exactly the problem: neither can explain the other, because `can_explain` requires a *strictly* lower layer. Symptom ownership is exclusive, so all eight attached to whichever claimed them first and its twin got none.

## The change (UI only)

Episodes are ordered by how much they explain, and one explaining nothing drops the alarm styling for neutral slate, reading **"explains nothing yet"** instead of "0 symptoms" — a bare zero reads like a count that failed to load.

An episode is a claim that one thing explains others. Until it explains something it has made no claim, and dressing it identically to a cause with eight symptoms underneath spends the operator's attention on the wrong card.

**Not fixed here:** that two episodes exist for one physical condition. Merging same-layer causes is a change to the correlation model, and the safe threshold is not obvious — symptoms can attach up to two hours after onset, so anything that closes an empty episode early would close real ones. That is worth doing deliberately, not guessed at in a UI PR.

## A defect I introduced and caught

The first version read `symptoms.length`, which loads asynchronously. So **every** episode card rendered grey "explains nothing yet" for a beat and then flipped to red — a flash of the wrong state on every load.

It surfaced as my own new test passing alone and failing in the full suite, which is the kind of thing that is tempting to re-run until it goes green. It now reads `symptom_count` from the list payload — which arrives synchronously — until the detail fetch answers, and two tests pin that with a detail fetch that never resolves, so the pre-load state is deterministic rather than a race.

## Tests

Six added. Mutations checked:

| mutation | result |
|---|---|
| drop the sort | 1 failed |
| sort ascending | 1 failed |
| empty episode keeps the red alarm | 2 failed |
| regress to the async-only read (the flash) | 1 failed |

`2189 passed`, tsc clean.