### PR TITLE
Describe the agent's trust level on the page that configures it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### The trust page showed your preference as the agent's state
+- With the agent reporting `effective_trust_level: 2`, the Pulse Agent page rendered **level 1's** summary — because `TrustPolicy` reads `useTrustStore`, this browser's localStorage preference, while taking only `maxTrustLevel` from the server. The front-door badge was fixed to read the agent's real level; the page that *configures* trust was not
+- The summary now describes the level the agent is actually running at, and says so plainly when this browser has a different one selected. Hovering another level still previews that level — that is the point of hovering
+- The level-1 sentence was also still wrong in its own right: *"suggests fixes with dry-run previews. It never acts without your approval."* Level 1 never enters `auto_fix`, so it suggests nothing and there is nothing to approve. The same falsehood as the old "Confirm" label, surviving in a second copy of the ladder that the relabel missed — now *"reports findings. You act on them; it never remediates on its own."*
+
 ### A cause that explains nothing led the queue
 - Two control-plane memory episodes opened in the same second on the reference cluster: `HighOverallControlPlaneMemory` with **8 symptoms** and `ControlPlaneNodeMemoryHigh` with **none**. Neither can explain the other — equal causal layers — so symptom ownership went entirely to whichever claimed them first, and the loser still rendered as a full-width red cause card *above* the one doing the explaining
 - Episodes are now ordered by how much they explain, and one explaining nothing drops the red alarm styling for neutral slate. An episode is a claim that one thing explains others; until it explains something it has made no claim, and dressing it identically spends the operator's attention on the wrong card

--- a/src/kubeview/views/mission-control/TrustPolicy.tsx
+++ b/src/kubeview/views/mission-control/TrustPolicy.tsx
@@ -37,6 +37,19 @@ const LEVEL_CATEGORIES: Record<number, string[]> = {
 
 interface TrustPolicyProps {
   maxTrustLevel: number;
+  /**
+   * The level the agent's scan loop is actually running at.
+   *
+   * Distinct from the selected level, which is this browser's stored
+   * preference: `useTrustStore` is zustand `persist` on localStorage, sent to
+   * the agent on connect and never read back. The front-door badge was fixed
+   * to read the server value; this page — the one that *configures* trust —
+   * was still describing the browser's.
+   *
+   * Optional, because an agent too old to report it leaves the page no worse
+   * off than before.
+   */
+  effectiveTrustLevel?: number;
   scannerCount: number;
   fixSummary: FixHistorySummary | null;
   supportedAutoFixCategories?: string[];
@@ -54,7 +67,7 @@ function resolveCategories(serverCategories?: string[]): AutofixCategory[] {
   );
 }
 
-export function TrustPolicy({ maxTrustLevel, scannerCount, fixSummary, supportedAutoFixCategories }: TrustPolicyProps) {
+export function TrustPolicy({ maxTrustLevel, effectiveTrustLevel, scannerCount, fixSummary, supportedAutoFixCategories }: TrustPolicyProps) {
   const { trustLevel, setTrustLevel, autoFixCategories, setAutoFixCategories, communicationStyle, setCommunicationStyle } =
     useTrustStore(useShallow((s) => ({
       trustLevel: s.trustLevel, setTrustLevel: s.setTrustLevel,
@@ -86,7 +99,13 @@ export function TrustPolicy({ maxTrustLevel, scannerCount, fixSummary, supported
   };
 
   const previewLevel = hoveredLevel ?? trustLevel;
-  const policySummary = buildPolicySummary(previewLevel, scannerCount, autoFixCategories, communicationStyle);
+  // Describe what the agent is actually doing, not what this browser asked
+  // for — except while hovering another level, where the point is to preview it.
+  const describedLevel =
+    hoveredLevel ?? ((effectiveTrustLevel ?? trustLevel) as TrustLevel);
+  const policySummary = buildPolicySummary(describedLevel, scannerCount, autoFixCategories, communicationStyle);
+  const runningElsewhere =
+    effectiveTrustLevel !== undefined && effectiveTrustLevel !== trustLevel ? effectiveTrustLevel : null;
   const impactPreview = hoveredLevel !== null && hoveredLevel !== trustLevel
     ? buildImpactPreview(trustLevel, hoveredLevel, fixSummary)
     : null;
@@ -145,6 +164,13 @@ export function TrustPolicy({ maxTrustLevel, scannerCount, fixSummary, supported
 
         {/* Policy Summary */}
         <p className="text-sm text-slate-300 leading-relaxed">{policySummary}</p>
+        {runningElsewhere !== null && (
+          <p className="mt-2 text-xs text-amber-400/90">
+            This browser has {TRUST_LABELS[trustLevel]} ({trustLevel}) selected, but the agent is
+            running at {TRUST_LABELS[runningElsewhere as TrustLevel]} ({runningElsewhere}), set on
+            the server. The description above is the agent's.
+          </p>
+        )}
 
         {/* Impact Preview (on hover) */}
         {impactPreview && (
@@ -247,7 +273,11 @@ function buildPolicySummary(level: TrustLevel, scanners: number, categories: str
     case 0:
       return `Your agent monitors ${scanners} scanners and reports findings. It takes no actions. Communication: ${style}.`;
     case 1:
-      return `Your agent monitors ${scanners} scanners and suggests fixes with dry-run previews. It never acts without your approval. Communication: ${style}.`;
+      // Level 1 does not suggest fixes. `auto_fix` is only entered at trust
+      // >= 2, so nothing is ever proposed and there is nothing to approve.
+      // This sentence was the same falsehood as the old "Confirm" label, in a
+      // second copy of the ladder that the relabel missed.
+      return `Your agent monitors ${scanners} scanners and reports findings. You act on them; it never remediates on its own. Communication: ${style}.`;
     case 2:
       return `Your agent monitors ${scanners} scanners and proposes fixes for your review before acting. Communication: ${style}.`;
     case 3:

--- a/src/kubeview/views/mission-control/__tests__/TrustPolicy.test.tsx
+++ b/src/kubeview/views/mission-control/__tests__/TrustPolicy.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { TrustPolicy } from '../TrustPolicy';
+import { useTrustStore } from '../../../store/trustStore';
+
+/**
+ * The page that configures trust described the browser, not the agent.
+ *
+ * `useTrustStore` is zustand `persist` on localStorage — sent to the agent on
+ * connect and never read back. The front-door badge was fixed to read the
+ * server's `effective_trust_level`; this page was not, so with the agent
+ * running at 2 it rendered level 1's summary: "suggests fixes with dry-run
+ * previews. It never acts without your approval."
+ *
+ * That sentence was doubly wrong. Level 1 never enters `auto_fix` at all, so
+ * it suggests nothing — the same falsehood as the old "Confirm" label,
+ * surviving in a second copy of the ladder that the relabel missed.
+ */
+describe('the trust page describes the agent, not the browser', () => {
+  beforeEach(() => {
+    useTrustStore.setState({ trustLevel: 1, autoFixCategories: [], communicationStyle: 'detailed' });
+  });
+  afterEach(cleanup);
+
+  const renderAt = (effective?: number) =>
+    render(
+      <TrustPolicy
+        maxTrustLevel={4}
+        effectiveTrustLevel={effective}
+        scannerCount={27}
+        fixSummary={null}
+      />,
+    );
+
+  it('describes the level the agent is running at, not the one stored here', () => {
+    renderAt(2);
+    expect(screen.getByText(/proposes fixes for your review/)).toBeDefined();
+  });
+
+  it('names the gap when the two disagree', () => {
+    renderAt(2);
+    expect(screen.getByText(/agent is running at/)).toBeDefined();
+    expect(screen.getByText(/Propose \(2\)/)).toBeDefined();
+  });
+
+  it('stays quiet when they agree', () => {
+    useTrustStore.setState({ trustLevel: 2 });
+    renderAt(2);
+    expect(screen.queryByText(/agent is running at/)).toBeNull();
+  });
+
+  it('falls back to the stored level against an agent that does not report one', () => {
+    renderAt(undefined);
+    expect(screen.queryByText(/agent is running at/)).toBeNull();
+  });
+
+  it('does not claim level 1 suggests fixes, because it never proposes anything', () => {
+    useTrustStore.setState({ trustLevel: 1 });
+    renderAt(1);
+    expect(screen.queryByText(/suggests fixes with dry-run previews/)).toBeNull();
+    expect(screen.queryByText(/never acts without your approval/)).toBeNull();
+    expect(screen.getByText(/never remediates on its own/)).toBeDefined();
+  });
+
+  it('level 0 still reports and takes no action', () => {
+    renderAt(0);
+    expect(screen.getByText(/takes no actions/)).toBeDefined();
+  });
+});

--- a/src/kubeview/views/pulse-agent/OverviewTab.tsx
+++ b/src/kubeview/views/pulse-agent/OverviewTab.tsx
@@ -50,6 +50,7 @@ export function OverviewTab() {
       {/* 3. Trust Controls */}
       <TrustPolicy
         maxTrustLevel={capQ.data?.max_trust_level ?? 0}
+        effectiveTrustLevel={capQ.data?.effective_trust_level}
         scannerCount={scannerCount}
         fixSummary={fixQ.data ?? null}
         supportedAutoFixCategories={capQ.data?.supported_auto_fix_categories}


### PR DESCRIPTION
Found while reviewing the Pulse Agent page. Two bugs, one of them a miss in my own earlier fix.

## 1. The page showed the browser, not the agent

The agent reports:

```json
{ "max_trust_level": 2, "effective_trust_level": 2 }
```

The page rendered **level 1's** summary: *"suggests fixes with dry-run previews. It never acts without your approval."*

`TrustPolicy` reads `useTrustStore` — zustand `persist` on localStorage, sent to the agent on connect and never read back — while taking only `maxTrustLevel` from the server. [pulse-ui #87](https://github.com/PulseSRE/pulse-ui/pull/87) fixed exactly this on the front-door badge and stopped there. The page an operator opens *to change trust* kept describing their browser.

It now describes the level the agent is actually running at, and names the gap when this browser has a different one selected. Hovering another level still previews that level — that is what hovering is for.

## 2. The level-1 sentence was wrong on its own terms

> Your agent monitors 27 scanners and suggests fixes with dry-run previews. **It never acts without your approval.**

Level 1 never enters `auto_fix`. It suggests nothing, so there is nothing to approve. This is the same falsehood as the old "Confirm" label — [pulse-ui #90](https://github.com/PulseSRE/pulse-ui/pull/90) corrected `TRUST_LABELS` and `TRUST_DESCRIPTIONS` and missed `buildPolicySummary`, a **second copy of the ladder's semantics in the same file**.

That is the exact failure #90's own changelog warned about: *"PulseView kept its own copy of the level names, which is how the badge tooltip and Mission Control came to describe different agents."* I collapsed two copies and left a third.

Now: *"reports findings. You act on them; it never remediates on its own."*

## Tests

Six, in a file that did not exist. Mutations checked:

| mutation | result |
|---|---|
| describe the local level again | 2 failed |
| drop the divergence notice | 1 failed |
| restore the old level-1 sentence | 1 failed |

`2195 passed`, tsc clean.