### PR TITLE
An unreachable alerting backend is not zero alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### "Firing 0" while it could not see the alerting backend
+- The Alerts page rendered `Firing 0 · Pending 0 · Silenced 0 · Alert Rules 0` in bold numerals directly above its own message, *"Backend unavailable"*. A count is a claim, and zero at the moment we have no data tells an operator the cluster is quiet precisely when we cannot see whether it is
+- The same failure the posture bar had on the front door, and the opposite of what the Compute page already does — it renders `Unknown` and `No data` rather than inventing numbers. This follows that in-house precedent: every tile reads `—` in muted slate when the backend is unreachable
+- A real zero is still reported as zero. Turning genuine quiet into "unknown" would be the same lie pointing the other way
+- An explicit guard stopping the alarm border lighting on an unknown came back out: a mutation test passed with it removed, because the failed query leaves the alert list empty and the count is already zero. The assertion stays, guarding a different mistake — making the border react to the error state itself
+
 ### The trust page showed your preference as the agent's state
 - With the agent reporting `effective_trust_level: 2`, the Pulse Agent page rendered **level 1's** summary — because `TrustPolicy` reads `useTrustStore`, this browser's localStorage preference, while taking only `maxTrustLevel` from the server. The front-door badge was fixed to read the agent's real level; the page that *configures* trust was not
 - The summary now describes the level the agent is actually running at, and says so plainly when this browser has a different one selected. Hovering another level still previews that level — that is the point of hovering

--- a/src/kubeview/views/AlertsView.tsx
+++ b/src/kubeview/views/AlertsView.tsx
@@ -410,28 +410,37 @@ export default function AlertsView() {
           )}
         </div>
 
+        {/* A count is a claim. When the backend is unreachable we have no
+            counts, and rendering "0 Firing" in the same bold numeral as a real
+            zero tells an operator the cluster is quiet at precisely the moment
+            we cannot see it. Compute already gets this right — it renders
+            "Unknown" and "No data" rather than dashes of zero — so this
+            follows the in-house precedent rather than inventing one.
+
+            Same failure the posture bar had on the front door: absence of data
+            presented as absence of problems. */}
         {/* Stats */}
         <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
           <button onClick={() => { setActiveTab('firing'); setSeverityFilter('all'); }} className={cn('bg-slate-900 rounded-lg border p-3 text-left hover:border-slate-600 transition-colors', firingAlerts.length > 0 ? 'border-red-800' : 'border-slate-800')}>
             <div className="text-xs text-slate-400 mb-1">Firing</div>
-            <div className="text-xl font-bold text-slate-100">{firingAlerts.length}</div>
+            <div className={cn('text-xl font-bold', backendUnavailable ? 'text-slate-500' : 'text-slate-100')}>{backendUnavailable ? '—' : firingAlerts.length}</div>
           </button>
           <button onClick={() => { setActiveTab('firing'); setSeverityFilter('all'); }} className={cn('bg-slate-900 rounded-lg border p-3 text-left hover:border-slate-600 transition-colors', pendingAlerts.length > 0 ? 'border-yellow-800' : 'border-slate-800')}>
             <div className="text-xs text-slate-400 mb-1">Pending</div>
-            <div className="text-xl font-bold text-slate-100">{pendingAlerts.length}</div>
+            <div className={cn('text-xl font-bold', backendUnavailable ? 'text-slate-500' : 'text-slate-100')}>{backendUnavailable ? '—' : pendingAlerts.length}</div>
             <div className="text-xs text-slate-600 mt-0.5">About to fire</div>
           </button>
           <button onClick={() => setActiveTab('silences')} className="bg-slate-900 rounded-lg border border-slate-800 p-3 text-left hover:border-slate-600 transition-colors">
             <div className="text-xs text-slate-400 mb-1">Silenced</div>
-            <div className="text-xl font-bold text-slate-100">{allAlerts.filter(a => a.isSilenced).length}</div>
+            <div className={cn('text-xl font-bold', backendUnavailable ? 'text-slate-500' : 'text-slate-100')}>{backendUnavailable ? '—' : allAlerts.filter(a => a.isSilenced).length}</div>
           </button>
           <button onClick={() => setActiveTab('rules')} className="bg-slate-900 rounded-lg border border-slate-800 p-3 text-left hover:border-slate-600 transition-colors">
             <div className="text-xs text-slate-400 mb-1">Alert Rules</div>
-            <div className="text-xl font-bold text-slate-100">{allRules.length}</div>
+            <div className={cn('text-xl font-bold', backendUnavailable ? 'text-slate-500' : 'text-slate-100')}>{backendUnavailable ? '—' : allRules.length}</div>
           </button>
           <button onClick={() => setActiveTab('silences')} className="bg-slate-900 rounded-lg border border-slate-800 p-3 text-left hover:border-slate-600 transition-colors">
             <div className="text-xs text-slate-400 mb-1">Active Silences</div>
-            <div className="text-xl font-bold text-slate-100">{activeSilences.length}</div>
+            <div className={cn('text-xl font-bold', backendUnavailable ? 'text-slate-500' : 'text-slate-100')}>{backendUnavailable ? '—' : activeSilences.length}</div>
           </button>
         </div>
 

--- a/src/kubeview/views/__tests__/AlertsView.test.tsx
+++ b/src/kubeview/views/__tests__/AlertsView.test.tsx
@@ -355,3 +355,68 @@ describe('AlertsView', () => {
     expect(screen.getByText('Silences temporarily mute alerts. Create one to suppress a noisy alert during maintenance.')).toBeDefined();
   });
 });
+
+/**
+ * "Firing 0" while it cannot see the alerting backend.
+ *
+ * The page rendered `Firing 0 · Pending 0 · Silenced 0 · Alert Rules 0` in bold
+ * numerals directly above its own message: "Unable to reach alerting backend."
+ * A count is a claim. Rendering zero at the moment we have no data tells an
+ * operator the cluster is quiet precisely when we cannot see whether it is.
+ *
+ * The same failure the posture bar had on the front door, and the opposite of
+ * what the Compute page already does — it renders "Unknown" and "No data"
+ * rather than inventing numbers.
+ */
+describe('an unreachable alerting backend is not zero alerts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockImplementation(() => Promise.reject(new Error('THANOS_URL not configured')));
+  });
+
+  afterEach(cleanup);
+
+  it('does not report zero firing alerts when it cannot see any', async () => {
+    renderAlerts();
+    await waitFor(() => expect(screen.getByText(/Backend unavailable/i)).toBeDefined(), { timeout: 5000 });
+    const firingTile = screen.getByText('Firing').parentElement;
+    expect(firingTile?.textContent).not.toMatch(/\b0\b/);
+    expect(firingTile?.textContent).toContain('—');
+  });
+
+  it('shows every count as unknown, not just the first', async () => {
+    renderAlerts();
+    await waitFor(() => expect(screen.getByText(/Backend unavailable/i)).toBeDefined(), { timeout: 5000 });
+    for (const label of ['Firing', 'Pending', 'Silenced', 'Alert Rules', 'Active Silences']) {
+      expect(screen.getByText(label).parentElement?.textContent, label).toContain('—');
+    }
+  });
+
+  it('does not light the alarm border on a count it does not have', async () => {
+    // A red border says "something is firing". Unknown is not firing.
+    //
+    // This holds today because the failed query leaves the list empty, so the
+    // count is 0 and the border cannot light — an explicit guard for it was
+    // removed after a mutation test proved it unreachable. The assertion stays
+    // because it guards a different mistake: making the border react to the
+    // error state itself, which would paint "unknown" as "firing".
+    renderAlerts();
+    await waitFor(() => expect(screen.getByText(/Backend unavailable/i)).toBeDefined(), { timeout: 5000 });
+    const tile = screen.getByText('Firing').closest('button');
+    expect(tile?.className).not.toMatch(/border-red/);
+  });
+
+  it('still reports a real zero as zero when the backend answers', async () => {
+    // The fix must not turn a genuine "nothing is firing" into an unknown —
+    // that would be the same lie pointing the other way.
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/rules')) {
+        return Promise.resolve({ ok: true, headers: jsonHeaders, json: () => Promise.resolve({ data: { groups: [] } }) });
+      }
+      return Promise.resolve({ ok: true, headers: jsonHeaders, json: () => Promise.resolve([]) });
+    });
+    renderAlerts();
+    await waitFor(() => expect(screen.getByText('Firing')).toBeDefined());
+    expect(screen.getByText('Firing').parentElement?.textContent).toMatch(/0/);
+  });
+});


### PR DESCRIPTION
Found while reviewing the remaining pages. The Alerts page rendered this:

```
Backend unavailable

Firing      Pending     Silenced    Alert Rules   Active Silences
  0            0           0            0              0
```

Bold numerals, directly above the page's own admission that it cannot reach Prometheus or Alertmanager. Verified from the live DOM:

```
backendAdmittedlyDown: true
verdict: zero counts rendered as fact while the page says it cannot reach the backend
```

A count is a claim. Rendering zero when we have no data tells an operator the cluster is quiet at precisely the moment we cannot see whether it is — the same failure the posture bar had on the front door, one page over.

## Following the in-house precedent

The Compute page already gets this right. Walking it against the live cluster:

```
VERSION           —
ETCD LEADER       Unknown
CPU Utilization   —  No data
```

So this is not a new pattern, it is applying the existing one. Every Alerts tile now reads a muted `—` when the backend is unreachable.

**A real zero is still zero.** Turning genuine quiet into "unknown" would be the same lie pointing the other way, and one test pins exactly that.

## Dead code removed

My first version also guarded the red/amber alarm borders against lighting on an unknown. A mutation test passed with that guard removed — on a failed query the alert list defaults to empty, so the count is already zero and the border cannot light. Unreachable, so it came back out.

The assertion stays, because it guards a *different* mistake: making the border react to the error state itself, which would paint "unknown" as "firing".

## Tests

Four added. Mutations checked:

| mutation | result |
|---|---|
| firing tile shows 0 again when unreachable | 2 failed |
| only the firing tile fixed, the rest still zero | 1 failed |
| every count becomes unknown, even a real zero | 1 failed |
| alarm-border guard removed | **passed → guard was dead, removed** |

`2199 passed`, tsc clean.