### PR TITLE
An unreachable Prometheus is not an all-clear on Administration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
 - A real zero is still reported as zero. Turning genuine quiet into "unknown" would be the same lie pointing the other way
 - An explicit guard stopping the alarm border lighting on an unknown came back out: a mutation test passed with it removed, because the failed query leaves the alert list empty and the count is already zero. The assertion stays, guarding a different mistake — making the border react to the error state itself
 
+### "No alerts firing", sourced from a failed request
+- Administration rendered a green **"No alerts firing"** badge on a cluster whose alert backend it could not reach. The query swallowed its own failure — `if (!res.ok) return []` — so an unreachable Prometheus produced an empty list and the Overview read it as good news
+- Third instance of the same failure in this UI: the posture bar said "All clear", the Alerts tiles said "Firing 0", Administration said "No alerts firing" in emerald. Absence of data presented as absence of problems, on the page an operator opens to ask whether the cluster is healthy
+- The query now throws so the failure exists to be read, and the badge only appears when the request actually succeeded. Otherwise: *"Alert status unavailable — could not reach Prometheus"*
+- A real quiet cluster still gets its all-clear. Turning genuine quiet into a permanent unknown would be the same lie pointing the other way
+- The presentation fix alone was not enough: restoring `return []` passed every prop-driven test in the file, because `alertsUnavailable` is a prop and the swallowing happens in `AdminView`. Two source-level assertions now cover the seam
+
 ### The trust page showed your preference as the agent's state
 - With the agent reporting `effective_trust_level: 2`, the Pulse Agent page rendered **level 1's** summary — because `TrustPolicy` reads `useTrustStore`, this browser's localStorage preference, while taking only `maxTrustLevel` from the server. The front-door badge was fixed to read the agent's real level; the page that *configures* trust was not
 - The summary now describes the level the agent is actually running at, and says so plainly when this browser has a different one selected. Hovering another level still previews that level — that is the point of hovering

--- a/src/kubeview/views/AdminView.tsx
+++ b/src/kubeview/views/AdminView.tsx
@@ -154,11 +154,14 @@ export default function AdminView() {
     apiPath: '/apis/config.openshift.io/v1/clusteroperators',
   });
 
-  const { data: firingAlerts = [] } = useQuery<Array<{ labels: Record<string, string>; annotations: Record<string, string>; state: string }>>({
+  const { data: firingAlerts = [], error: firingAlertsError } = useQuery<Array<{ labels: Record<string, string>; annotations: Record<string, string>; state: string }>>({
     queryKey: ['admin', 'firing-alerts'],
     queryFn: async () => {
       const res = await fetch('/api/prometheus/api/v1/alerts');
-      if (!res.ok) return [];
+      // Throw, don't swallow. Returning [] here turned "Prometheus is not
+      // reachable" into "no alerts are firing", and the Overview rendered a
+      // green all-clear on the strength of a failed request.
+      if (!res.ok) throw new Error(`Prometheus returned ${res.status} ${res.statusText}`);
       const json = await res.json();
       return (json.data?.alerts || []).filter((a: { state: string }) => a.state === 'firing');
     },
@@ -494,6 +497,7 @@ export default function AdminView() {
             overviewLoading={overviewLoading}
             overviewError={overviewError}
             firingAlerts={firingAlerts}
+            alertsUnavailable={!!firingAlertsError}
             alertCounts={alertCounts}
             operators={operators}
             opDegraded={opDegraded}

--- a/src/kubeview/views/admin/OverviewTab.tsx
+++ b/src/kubeview/views/admin/OverviewTab.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import {
   Settings, Server, Shield, ArrowRight, Activity,
   CheckCircle, XCircle, RefreshCw,
-  ArrowUpCircle, AlertTriangle, AlertCircle,
-} from 'lucide-react';
+  ArrowUpCircle, AlertTriangle, AlertCircle, HelpCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { K8sResource } from '../../engine/renderers';
 import type { ClusterOperator, Node, Condition } from '../../engine/types';
@@ -34,6 +33,8 @@ export interface OverviewTabProps {
   overviewLoading: boolean;
   overviewError: boolean;
   firingAlerts: Array<{ labels: Record<string, string>; annotations: Record<string, string>; state: string }>;
+  /** True when the alert query failed — "none firing" is then unknown, not zero. */
+  alertsUnavailable?: boolean;
   alertCounts: { critical: number; warning: number; info: number };
   operators: ClusterOperator[];
   opDegraded: number;
@@ -82,7 +83,7 @@ function getOperatorStatus(op: K8sResource | OperatorResource | null): string {
 
 export function OverviewTab({
   overviewLoading, overviewError,
-  firingAlerts, alertCounts,
+  firingAlerts, alertsUnavailable, alertCounts,
   operators, opDegraded, opProgressing, degradedOperators,
   nodes, nodeRoles,
   cvVersion, cvChannel, platform, apiUrl,
@@ -157,11 +158,22 @@ export function OverviewTab({
         </div>
       )}
 
-      {/* No alerts -- green signal */}
-      {firingAlerts.length === 0 && !overviewLoading && (
+      {/* No alerts -- green signal, but only when we actually looked.
+          A failed Prometheus request used to land here and render an
+          all-clear: absence of data presented as absence of problems, the
+          same failure the posture bar and the Alerts tiles had. */}
+      {firingAlerts.length === 0 && !overviewLoading && !alertsUnavailable && (
         <div className="bg-emerald-950/20 border border-emerald-800/50 rounded-lg px-4 py-2.5 flex items-center gap-3">
           <CheckCircle className="w-4 h-4 text-emerald-400" />
           <span className="text-sm text-emerald-300">No alerts firing</span>
+        </div>
+      )}
+      {alertsUnavailable && !overviewLoading && (
+        <div className="bg-slate-800/40 border border-slate-700/60 rounded-lg px-4 py-2.5 flex items-center gap-3">
+          <HelpCircle className="w-4 h-4 text-slate-400" />
+          <span className="text-sm text-slate-300">
+            Alert status unavailable — could not reach Prometheus
+          </span>
         </div>
       )}
 

--- a/src/kubeview/views/admin/__tests__/OverviewTab.test.tsx
+++ b/src/kubeview/views/admin/__tests__/OverviewTab.test.tsx
@@ -207,3 +207,73 @@ describe('OverviewTab', () => {
     expect(screen.getByText('Back-off restarting failed container')).toBeDefined();
   });
 });
+
+/**
+ * "No alerts firing", sourced from a failed request.
+ *
+ * The query swallowed its own failure — `if (!res.ok) return []` — so an
+ * unreachable Prometheus produced an empty list, and the Overview rendered a
+ * green all-clear on the strength of a request that never succeeded.
+ *
+ * Third instance of the same failure in this UI: the posture bar called it
+ * "All clear", the Alerts tiles called it "Firing 0", and Administration
+ * called it "No alerts firing" in emerald. Absence of data presented as
+ * absence of problems, on the page an operator opens to ask whether the
+ * cluster is healthy.
+ */
+describe('an unreachable Prometheus is not an all-clear', () => {
+  afterEach(cleanup);
+
+  it('does not claim no alerts are firing when the query failed', () => {
+    render(<OverviewTab {...makeProps({ firingAlerts: [], alertsUnavailable: true })} />);
+    expect(screen.queryByText('No alerts firing')).toBeNull();
+  });
+
+  it('says the status is unavailable, and why', () => {
+    render(<OverviewTab {...makeProps({ firingAlerts: [], alertsUnavailable: true })} />);
+    expect(screen.getByText(/Alert status unavailable/)).toBeDefined();
+    expect(screen.getByText(/could not reach Prometheus/)).toBeDefined();
+  });
+
+  it('still gives the all-clear when it genuinely looked and found none', () => {
+    // The fix must not turn a real quiet cluster into a permanent unknown.
+    render(<OverviewTab {...makeProps({ firingAlerts: [], alertsUnavailable: false })} />);
+    expect(screen.getByText('No alerts firing')).toBeDefined();
+    expect(screen.queryByText(/Alert status unavailable/)).toBeNull();
+  });
+
+  it('says nothing either way while the page is still loading', () => {
+    render(<OverviewTab {...makeProps({ firingAlerts: [], alertsUnavailable: true, overviewLoading: true })} />);
+    expect(screen.queryByText(/Alert status unavailable/)).toBeNull();
+    expect(screen.queryByText('No alerts firing')).toBeNull();
+  });
+});
+
+describe('the alert query surfaces its failure instead of swallowing it', () => {
+  /**
+   * The presentation fix above is worth nothing if the query keeps turning a
+   * failed request into an empty list. `alertsUnavailable` can only ever be
+   * true if the queryFn throws, and that lives in AdminView — outside the
+   * props this file otherwise drives, so it is asserted at the source.
+   *
+   * Mutation-tested: restoring `if (!res.ok) return []` passed every
+   * prop-driven test in this file. This is the assertion that catches it.
+   */
+  it('throws on a non-ok response rather than returning an empty list', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '../../AdminView.tsx'), 'utf8');
+    const start = src.indexOf("queryKey: ['admin', 'firing-alerts']");
+    expect(start, "the firing-alerts query should still exist").toBeGreaterThan(-1);
+    const block = src.slice(start, start + 700);
+    expect(block).toMatch(/if \(!res\.ok\) throw new Error/);
+    expect(block).not.toMatch(/if \(!res\.ok\) return \[\]/);
+  });
+
+  it('passes the failure down to the Overview', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const src = readFileSync(resolve(__dirname, '../../AdminView.tsx'), 'utf8');
+    expect(src).toMatch(/alertsUnavailable=\{!!firingAlertsError\}/);
+  });
+});


### PR DESCRIPTION
Third instance of the same failure in this UI, and the most confident-looking one.

Administration rendered, on a cluster with 43 items in the Inbox and two open control-plane memory episodes:

> ✅ **No alerts firing**

Sourced from this:

```ts
const { data: firingAlerts = [] } = useQuery({
  queryFn: async () => {
    const res = await fetch('/api/prometheus/api/v1/alerts');
    if (!res.ok) return [];          // ← the failure is swallowed here
    ...
```

An unreachable Prometheus produces an empty list, and the Overview reads an empty list as good news. There was not even an `error` to consult, because the query discarded it.

## The family

| page | what it said | on what basis |
|---|---|---|
| Pulse front door | "All clear — 0 critical, 0 warnings" | no scan had run yet |
| Alerts | "Firing 0 · Pending 0 · Rules 0" | backend unreachable |
| **Administration** | **"No alerts firing"** (emerald) | **request failed** |

Same root shape each time: absence of data presented as absence of problems. This is the page an operator opens specifically to ask whether the cluster is healthy.

Worth noting the codebase does have a right answer — Compute renders `Unknown` and `No data` rather than inventing numbers. There is no shared primitive for "we do not know", so each page re-derives the distinction and some get it wrong.

## The change

The query throws, so the failure exists to be read. The green badge renders only when the request actually succeeded; otherwise the page says *"Alert status unavailable — could not reach Prometheus"* in neutral slate.

A genuinely quiet cluster still gets its all-clear — turning real quiet into a permanent unknown would be the same lie pointing the other way, and a test pins that.

## The presentation fix alone was not enough

Restoring `if (!res.ok) return []` **passed every prop-driven test in the file**, because `alertsUnavailable` arrives as a prop while the swallowing happens in `AdminView`. Two source-level assertions now cover that seam.

| mutation | before | after |
|---|---|---|
| green badge ignores the flag | 1 failed | 1 failed |
| unknown notice removed | 1 failed | 1 failed |
| query swallows the failure again | **passed** | 1 failed |
| flag no longer passed down | — | 1 failed |

`2201 passed`, tsc clean.
