### PR TITLE
Look for ACM before reporting that it is not there

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### "ACM not detected", before ever looking
+- `detectACM` was wired only to a button. Nothing ran it on mount, so Fleet rendered **"ACM not detected — show installation instructions"** purely from the store's initial `acmAvailable: false`
+- The reference cluster is an ACM hub: `MultiClusterHub` Running for 354 days, v2.17.0, *"All hub components ready"*, one `ManagedCluster` registered, 62 ACM CRDs, and the endpoint the detector calls returning 200. Fleet told the operator ACM was absent and offered YAML to create a hub that already existed — applying it would have been a genuinely bad outcome
+- Detection now runs on mount, and the page does not claim absence until it has actually looked. `acmAvailable: false` alone cannot tell "we looked and it is not there" from "we have not looked", so the store tracks `acmChecked` as a separate fact
+- Same family as the rest of this UI's confident empty states — a default rendered as a finding — and the fourth instance found this session
+
 ### "Firing 0" while it could not see the alerting backend
 - The Alerts page rendered `Firing 0 · Pending 0 · Silenced 0 · Alert Rules 0` in bold numerals directly above its own message, *"Backend unavailable"*. A count is a claim, and zero at the moment we have no data tells an operator the cluster is quiet precisely when we cannot see whether it is
 - The same failure the posture bar had on the front door, and the opposite of what the Compute page already does — it renders `Unknown` and `No data` rather than inventing numbers. This follows that in-house precedent: every tile reads `—` in muted slate when the backend is unreachable

--- a/src/kubeview/store/fleetStore.ts
+++ b/src/kubeview/store/fleetStore.ts
@@ -37,6 +37,12 @@ interface FleetState {
   // ACM detection
   acmAvailable: boolean;
   acmDetecting: boolean;
+  /**
+   * Whether detection has actually run. `acmAvailable: false` on its own
+   * cannot tell "we looked and ACM is absent" from "we have not looked",
+   * and the Fleet page was rendering the second as the first.
+   */
+  acmChecked: boolean;
 
   // Clusters
   clusters: ClusterConnection[];
@@ -64,6 +70,7 @@ export const useFleetStore = create<FleetState>((set, get) => ({
   connectionMode: 'none',
   acmAvailable: false,
   acmDetecting: false,
+  acmChecked: false,
   clusters: getAllConnections(),
   activeClusterId: getActiveClusterId(),
   healthPolling: false,
@@ -85,7 +92,7 @@ export const useFleetStore = create<FleetState>((set, get) => ({
             ? 'Permission denied. You need cluster-admin or managedcluster read access.'
             : `Failed to detect ACM (${res.status} ${res.statusText})`;
         useUIStore.getState().addToast({ type: 'warning', title: 'ACM Detection', detail, duration: 8000 });
-        set({ acmAvailable: false, acmDetecting: false });
+        set({ acmAvailable: false, acmDetecting: false, acmChecked: true });
         return;
       }
 
@@ -118,6 +125,7 @@ export const useFleetStore = create<FleetState>((set, get) => ({
       set({
         acmAvailable: true,
         acmDetecting: false,
+        acmChecked: true,
         connectionMode: 'acm',
         fleetMode: allConns.length > 1 ? 'multi' : 'single',
         clusters: allConns,
@@ -134,7 +142,7 @@ export const useFleetStore = create<FleetState>((set, get) => ({
         title: 'ACM Detection Failed',
         detail: e instanceof Error ? e.message : 'Network error — is the cluster reachable?',
       });
-      set({ acmAvailable: false, acmDetecting: false });
+      set({ acmAvailable: false, acmDetecting: false, acmChecked: true });
     }
   },
 

--- a/src/kubeview/views/FleetView.tsx
+++ b/src/kubeview/views/FleetView.tsx
@@ -24,11 +24,20 @@ export default function FleetView() {
   const addToast = useUIStore((s) => s.addToast);
   const {
     fleetMode, clusters, activeClusterId,
-    acmAvailable, acmDetecting,
+    acmAvailable, acmDetecting, acmChecked,
     setActiveCluster, refreshAllHealth, detectACM,
   } = useFleetStore();
 
   const [refreshing, setRefreshing] = React.useState(false);
+
+  // Look before reporting. `detectACM` was only ever wired to a button, so the
+  // page rendered "ACM not detected — show installation instructions" without
+  // having checked. On a hub with a MultiClusterHub running for 354 days that
+  // told the operator ACM was absent and offered YAML to create one that
+  // already existed.
+  React.useEffect(() => {
+    if (!acmChecked && !acmDetecting) void detectACM();
+  }, [acmChecked, acmDetecting, detectACM]);
 
   const handleRefresh = async () => {
     setRefreshing(true);
@@ -77,7 +86,7 @@ export default function FleetView() {
                 onClick={!acmDetecting ? () => detectACM() : undefined}
                 done={acmAvailable}
               />
-              {!acmAvailable && !acmDetecting && (
+              {acmChecked && !acmAvailable && !acmDetecting && (
                 <details className="ml-11 rounded-lg border border-slate-700 bg-slate-800/50 text-xs text-slate-400">
                   <summary className="px-4 py-3 cursor-pointer text-slate-300 font-medium hover:text-slate-100 transition-colors">
                     ACM not detected — show installation instructions

--- a/src/kubeview/views/__tests__/FleetView.test.tsx
+++ b/src/kubeview/views/__tests__/FleetView.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import React from 'react';
 import fs from 'fs';
@@ -85,5 +85,64 @@ describe('FleetView empty state', () => {
 
     expect(screen.getByText('No clusters connected')).toBeDefined();
     expect(screen.getByText(/Fleet mode requires Red Hat Advanced Cluster Management/)).toBeDefined();
+  });
+});
+
+/**
+ * "ACM not detected", before ever looking.
+ *
+ * `detectACM` was wired only to a button — no effect ran it on mount — so the
+ * page rendered "ACM not detected — show installation instructions" purely
+ * from the store's initial `acmAvailable: false`.
+ *
+ * Measured on the reference cluster, which is an ACM hub: a MultiClusterHub
+ * had been Running for 354 days ("All hub components ready", v2.17.0), with a
+ * ManagedCluster registered and 62 ACM CRDs installed. The endpoint the
+ * detector calls returned 200. Fleet told the operator ACM was absent and
+ * offered YAML to create a hub that already existed.
+ *
+ * Same family as the rest of this UI's confident empty states: a default
+ * rendered as a finding.
+ */
+describe('Fleet looks before it reports', () => {
+  afterEach(cleanup);
+
+  beforeEach(() => {
+    // The setup screen — the only place the ACM claim renders — is the
+    // fleetMode 'single' branch. The shared mock defaults to 'multi', where
+    // that text never appears and these assertions would pass vacuously.
+    Object.assign(mockFleetState, {
+      fleetMode: 'single',
+      acmAvailable: false, acmDetecting: false, acmChecked: false,
+      detectACM: vi.fn(), clusters: [],
+    });
+  });
+
+  it('runs detection on mount rather than waiting to be asked', () => {
+    render(<FleetView />);
+    expect(mockFleetState.detectACM).toHaveBeenCalled();
+  });
+
+  it('does not claim ACM is absent before the check has run', () => {
+    render(<FleetView />);
+    expect(screen.queryByText(/ACM not detected/)).toBeNull();
+  });
+
+  it('says so once it has actually looked and found nothing', () => {
+    Object.assign(mockFleetState, { acmChecked: true });
+    render(<FleetView />);
+    expect(screen.getByText(/ACM not detected/)).toBeDefined();
+  });
+
+  it('stays quiet while the check is in flight', () => {
+    Object.assign(mockFleetState, { acmChecked: false, acmDetecting: true });
+    render(<FleetView />);
+    expect(screen.queryByText(/ACM not detected/)).toBeNull();
+  });
+
+  it('does not re-run detection once it has an answer', () => {
+    Object.assign(mockFleetState, { acmChecked: true, acmAvailable: true });
+    render(<FleetView />);
+    expect(mockFleetState.detectACM).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Found while finishing the page walk. Fleet said:

> **ACM not detected** — show installation instructions
>
> 1. Install the *Advanced Cluster Management* operator from OperatorHub…
> ```
> cat <<EOF | oc apply -f -
> apiVersion: operator.open-cluster-management.io/v1
> kind: MultiClusterHub
> ...
> ```

The reference cluster is an ACM hub:

```
MultiClusterHub   open-cluster-management/multiclusterhub
                  Running   354d   2.17.0   "All hub components ready."
ManagedClusters   local-cluster  true
ACM CRDs          62
```

And the endpoint the detector calls answers fine:

```
/apis/cluster.open-cluster-management.io/v1/managedclusters  →  200, items = 1
```

## Why it said that

`detectACM` was only ever wired to an `onClick`. No effect ran it on mount:

```
grep detectACM FleetView.tsx
  28:    setActiveCluster, refreshAllHealth, detectACM,
  77:    onClick={!acmDetecting ? () => detectACM() : undefined}

auto-called in a useEffect: 0
```

So the page rendered the store's initial `acmAvailable: false` as a *conclusion*. It was not a failed detection — it was a detection that never ran, presented as a negative result.

The consequence is worse than the usual empty-state bug: an operator following those instructions would apply a `MultiClusterHub` on a cluster that has had one running for 354 days.

## The change

Detection runs on mount, and the page does not claim absence until it has looked. `acmAvailable: false` alone cannot distinguish *"we looked and ACM is not here"* from *"we have not looked"*, so `acmChecked` is tracked as a separate fact — the same shape as the `unknown` posture level added to the front door.

## The fourth instance

| page | claimed | actual basis |
|---|---|---|
| Pulse front door | "All clear" | no scan had run |
| Alerts | "Firing 0" | backend unreachable |
| Administration | "No alerts firing" | request failed |
| **Fleet** | **"ACM not detected"** | **never checked** |

## Tests

Five added. Mutations checked:

| mutation | result |
|---|---|
| remove the mount-time detection | 1 failed |
| claim absence again without checking | 1 failed |
| drop the `acmChecked` guard (re-detect forever) | 1 failed |

**A harness bug I had to fix first:** my initial tests passed vacuously. The ACM claim only renders in the `fleetMode === 'single'` branch, and the shared mock defaults to `'multi'` — so "does not claim ACM is absent" was true simply because the text never rendered at all. The failing third test is what exposed it. The file also had no `cleanup`, so renders were stacking.

`2204 passed`, tsc clean.