### PR TITLE
Surface 'unverifiable' fix verification

### DIFF
--- a/src/kubeview/engine/analyticsApi.ts
+++ b/src/kubeview/engine/analyticsApi.ts
@@ -26,6 +26,8 @@ export interface FixHistorySummary {
     resolved: number;
     still_failing: number;
     improved: number;
+    /** Health check ran but could not get a clear reading — not the same as pending. */
+    unverifiable?: number;
     pending: number;
     resolution_rate: number;
   };

--- a/src/kubeview/engine/monitorClient.ts
+++ b/src/kubeview/engine/monitorClient.ts
@@ -63,7 +63,7 @@ export interface ActionReport {
   durationMs?: number;
   confidence?: number;
   rollbackAvailable?: boolean;
-  verificationStatus?: 'verified' | 'still_failing' | 'improved';
+  verificationStatus?: 'verified' | 'still_failing' | 'improved' | 'unverifiable';
   verificationEvidence?: string;
   verificationTimestamp?: number;
   fixStrategy?: string;
@@ -110,7 +110,7 @@ export interface VerificationReport {
   id: string;
   actionId: string;
   findingId: string;
-  status: 'verified' | 'still_failing';
+  status: 'verified' | 'still_failing' | 'improved' | 'unverifiable';
   evidence: string;
   timestamp: number;
 }

--- a/src/kubeview/views/incidents/IncidentLifecycleDrawer.tsx
+++ b/src/kubeview/views/incidents/IncidentLifecycleDrawer.tsx
@@ -71,6 +71,7 @@ export function IncidentLifecycleDrawer({ findingId, onClose }: IncidentLifecycl
     : lifecycle.action?.verificationStatus === 'unverifiable' ? 'skipped'
     : lifecycle.action?.verificationStatus === 'still_failing' ? 'failed'
     : 'pending';
+  const verificationBadge = lifecycle.verification?.status || lifecycle.action?.verificationStatus;
   const postmortemStatus: StageStatus = lifecycle.postmortem ? 'complete' : 'pending';
   const learningStatus: StageStatus = lifecycle.learning
     ? (lifecycle.learning.scaffolded_skill || lifecycle.learning.learned_runbook || lifecycle.learning.scaffolded_plan) ? 'complete' : 'pending'
@@ -269,11 +270,15 @@ export function IncidentLifecycleDrawer({ findingId, onClose }: IncidentLifecycl
                 <div className="flex items-center gap-2">
                   <span className={cn(
                     'text-xs px-1.5 py-0.5 rounded-sm font-medium',
-                    (lifecycle.verification?.status === 'verified' || lifecycle.action?.verificationStatus === 'verified')
+                    verificationBadge === 'verified'
                       ? 'bg-emerald-900/50 text-emerald-300'
-                      : 'bg-amber-900/50 text-amber-300',
+                      // Grey, not amber: the check could not read the cluster,
+                      // which is not the same as the fix having gone wrong.
+                      : verificationBadge === 'unverifiable'
+                        ? 'bg-slate-800 text-slate-400'
+                        : 'bg-amber-900/50 text-amber-300',
                   )}>
-                    {lifecycle.verification?.status || lifecycle.action?.verificationStatus}
+                    {verificationBadge}
                   </span>
                 </div>
                 {(lifecycle.verification?.evidence || lifecycle.action?.verificationEvidence) && (

--- a/src/kubeview/views/incidents/IncidentLifecycleDrawer.tsx
+++ b/src/kubeview/views/incidents/IncidentLifecycleDrawer.tsx
@@ -60,9 +60,15 @@ export function IncidentLifecycleDrawer({ findingId, onClose }: IncidentLifecycl
     : lifecycle.action.status === 'executing' ? 'in-progress'
     : 'pending'
     : 'pending';
+  // 'unverifiable' means the health check ran and could not get a clear
+  // reading. It is neither a passed nor a failed fix, so it maps to 'skipped'
+  // rather than 'failed' — reporting it as a failure asserts something the
+  // check never established, the mirror of the absence bug on the agent side.
   const verificationStatus: StageStatus = lifecycle.verification
-    ? lifecycle.verification.status === 'verified' ? 'complete' : 'failed'
+    ? lifecycle.verification.status === 'verified' ? 'complete'
+    : lifecycle.verification.status === 'unverifiable' ? 'skipped' : 'failed'
     : lifecycle.action?.verificationStatus === 'verified' ? 'complete'
+    : lifecycle.action?.verificationStatus === 'unverifiable' ? 'skipped'
     : lifecycle.action?.verificationStatus === 'still_failing' ? 'failed'
     : 'pending';
   const postmortemStatus: StageStatus = lifecycle.postmortem ? 'complete' : 'pending';

--- a/src/kubeview/views/mission-control/AgentHealth.tsx
+++ b/src/kubeview/views/mission-control/AgentHealth.tsx
@@ -178,6 +178,17 @@ function OutcomesCard({
             <span className="text-emerald-400 font-medium">{fixSummary.verification.resolved} resolved</span>
             <span className="text-slate-600">&middot;</span>
             <span className="text-amber-400">{fixSummary.verification.still_failing} still failing</span>
+            {(fixSummary.verification.unverifiable ?? 0) > 0 && (
+              <>
+                <span className="text-slate-600">&middot;</span>
+                <span
+                  className="text-slate-400 underline decoration-dotted underline-offset-2"
+                  title="The health check ran but could not get a clear reading — these are not counted as successful fixes."
+                >
+                  {fixSummary.verification.unverifiable} unverifiable
+                </span>
+              </>
+            )}
             {fixSummary.verification.pending > 0 && (
               <>
                 <span className="text-slate-600">&middot;</span>


### PR DESCRIPTION
Pairs with [pulse-agent#114](https://github.com/PulseSRE/pulse-agent/pull/114), which adds a third post-fix verification verdict.

The agent used to call a fix "verified" whenever the finding stopped appearing — which is also what happens when the workload was deleted. It now runs an affirmative health check and reports `unverifiable` when it cannot get a clear reading.

- `analyticsApi.ts` — types the new optional counter
- `AgentHealth.tsx` — renders it separately from `pending`, with a tooltip saying these are not counted as successful fixes
- `IncidentLifecycleDrawer.tsx` — maps it to a neutral stage rather than `failed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)