### PR TITLE
Give an episode card a way to act on the cause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### An episode card with nothing to do
+- The card said what was wrong — cause, symptom count, blast radius, recurrence — and then offered **"What else changed"** and **"Dismiss"**. Look at history, or make it go away. Neither fixes anything, while the symptoms underneath it carried Approve buttons. Actions on the symptoms and none on the cause is exactly backwards, and it is why the causal model never reached the operator's hands
+- Two gates kept the agent out of reach. It rendered *inside* the investigation block, so it existed only once an investigation had already run; and the expand chevron was gated on `symptoms.length > 0`, so an episode explaining nothing had no chevron at all and therefore no route to anything. `ControlPlaneNodeMemoryHigh` on the reference cluster was exactly that: two links, neither of which acts
+- Every episode now carries **"How do I fix this?"**, which opens the agent with what the card already knows — cause, symptom count, namespaces, recurrence, and what changed just before — so it is not paid to re-derive any of it before answering the one question the deterministic layer cannot
+- The chevron is available whenever there is something to collapse, so an agent opened on a symptomless episode can be closed again
+
 ### Removed the legacy dock adapter, two dead components, and a stale redirect
 - `uiStore` carried a "Legacy adapter — DEPRECATED" block: seven members (`dockPanel`, `dockWidth`, `dockFullscreen`, `openDock`, `closeDock`, `setDockWidth`, `toggleDockFullscreen`) with a comment listing seven files still to migrate. **All seven had zero callsites** — the migration was finished and only the adapter was left. Gone, along with the now-unused `DockPanel` type
 - Two components nothing imported: `PredictionCard.tsx` (145 lines) and `NodeTable.tsx` (132 lines)

--- a/src/kubeview/views/inbox/EpisodePanel.tsx
+++ b/src/kubeview/views/inbox/EpisodePanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { AlertTriangle, Ban, Check, ChevronDown, ChevronRight, Clock, History } from 'lucide-react';
+import { AlertTriangle, Ban, Check, ChevronDown, ChevronRight, Clock, History, Wrench } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { InlineAgent } from '../../components/agent/InlineAgent';
 import { formatElapsed, formatShortDuration } from '../../engine/dateUtils';
@@ -59,6 +59,7 @@ export function timelineRangeFor(startedAtSeconds: number, nowSeconds = Date.now
 
 function EpisodeCard({ episode, onChanged }: { episode: Episode; onChanged: () => void }) {
   const [expanded, setExpanded] = useState(true);
+  const [askOpen, setAskOpen] = useState(false);
   const [symptoms, setSymptoms] = useState<EpisodeSymptom[]>([]);
   const [symptomsLoaded, setSymptomsLoaded] = useState(false);
   const [changes, setChanges] = useState<EpisodeChange[]>([]);
@@ -183,6 +184,14 @@ function EpisodeCard({ episode, onChanged }: { episode: Episode; onChanged: () =
             )}
           </div>
         </div>
+        <button
+          onClick={() => { setAskOpen(true); setExpanded(true); }}
+          title="Ask the agent what to do about this cause"
+          className="shrink-0 inline-flex items-center gap-1 rounded-sm px-1.5 py-1 text-[11px] font-medium text-violet-300 transition-colors hover:bg-violet-500/15 hover:text-violet-200"
+        >
+          <Wrench className="h-3 w-3" />
+          How do I fix this?
+        </button>
         <a
           href={`/timeline?range=${timelineRangeFor(episode.cause_started_at ?? episode.started_at)}`}
           title="See alerts, events, rollouts and config changes from when this cause began"
@@ -199,7 +208,7 @@ function EpisodeCard({ episode, onChanged }: { episode: Episode; onChanged: () =
           <Check className="h-3 w-3" />
           Dismiss
         </button>
-        {symptoms.length > 0 && (
+        {(symptoms.length > 0 || investigation || askOpen) && (
           <button
             onClick={() => setExpanded((e) => !e)}
             aria-expanded={expanded}
@@ -237,12 +246,24 @@ function EpisodeCard({ episode, onChanged }: { episode: Episode; onChanged: () =
               )}
             </div>
           )}
-          {/* The prompt carries everything the card already knows, so the
-              agent is not paid to re-derive the cause, the blast radius and
-              the recent changes before answering the only question the
-              deterministic layer cannot: what to do about it. */}
+        </div>
+      )}
+
+      {/* The one thing the card was missing: a way to act on the cause.
+          It offered "What else changed" and "Dismiss" — look at history, or
+          make it go away — while the symptoms underneath it got Approve
+          buttons. Actions on the symptoms and none on the cause is backwards.
+
+          The agent used to render inside the investigation block, so it was
+          reachable only once an investigation had already run, and the expand
+          control was itself gated on having symptoms — so an episode that
+          explained nothing had no chevron at all and no route to anything.
+          The prompt carries what the card already knows, so the agent is not
+          paid to re-derive the cause, the blast radius and the recent changes
+          before answering the only question the deterministic layer cannot. */}
+      {expanded && (investigation || askOpen) && (
+        <div className="border-t border-red-500/15 px-3 py-2">
           <InlineAgent
-            className="mt-2"
             context={{ kind: 'Episode', name: episode.id, namespace: episode.namespaces[0] }}
             initialPrompt={askPrompt}
             quickPrompts={[

--- a/src/kubeview/views/inbox/__tests__/EpisodePanel.test.tsx
+++ b/src/kubeview/views/inbox/__tests__/EpisodePanel.test.tsx
@@ -449,3 +449,86 @@ describe('an episode points at what else changed', () => {
     expect(link.closest('a')?.getAttribute('href')).toMatch(/^\/timeline\?range=/);
   });
 });
+
+/**
+ * An episode card with nothing to do.
+ *
+ * The card said what was wrong — cause, symptom count, blast radius,
+ * recurrence — and then offered "What else changed" and "Dismiss". Look at
+ * history, or make it go away. Neither fixes anything.
+ *
+ * Meanwhile the symptoms underneath got Approve buttons. Actions on the
+ * symptoms and none on the cause is exactly backwards, and it is the reason
+ * the product's causal model did not reach the operator's hands.
+ *
+ * Two gates kept the agent out of reach: it rendered inside the investigation
+ * block, so it required an investigation to already exist, and the expand
+ * control was gated on `symptoms.length > 0`, so an episode explaining nothing
+ * had no chevron at all — which is what `ControlPlaneNodeMemoryHigh` looked
+ * like on the reference cluster.
+ */
+describe('an episode card offers a way to act on the cause', () => {
+  const EMPTY_EP = { ...EPISODE, id: 'ep-none', cause_title: 'ControlPlaneNodeMemoryHigh', symptom_count: 0, namespaces: [] };
+
+  afterEach(cleanup);
+
+  it('offers a fix action even with no symptoms and no investigation', async () => {
+    fetchOpenEpisodes.mockResolvedValue([EMPTY_EP]);
+    fetchEpisode.mockResolvedValue({ episode: EMPTY_EP, symptoms: [] });
+    render(<EpisodePanel />);
+    expect(await screen.findByText(/How do I fix this\?/)).toBeDefined();
+  });
+
+  it('reaches the agent from an episode that explains nothing', async () => {
+    // Previously impossible: no chevron, so no expand, so no agent.
+    fetchOpenEpisodes.mockResolvedValue([EMPTY_EP]);
+    fetchEpisode.mockResolvedValue({ episode: EMPTY_EP, symptoms: [] });
+    render(<EpisodePanel />);
+    fireEvent.click(await screen.findByText(/How do I fix this\?/));
+    expect(await screen.findByTestId('inline-agent')).toBeDefined();
+  });
+
+  it('hands the agent what the card already knows', async () => {
+    fetchOpenEpisodes.mockResolvedValue([EMPTY_EP]);
+    fetchEpisode.mockResolvedValue({ episode: EMPTY_EP, symptoms: [] });
+    render(<EpisodePanel />);
+    fireEvent.click(await screen.findByText(/How do I fix this\?/));
+    const agent = await screen.findByTestId('inline-agent');
+    expect(agent.textContent).toContain('ControlPlaneNodeMemoryHigh');
+    expect(agent.textContent).toContain('What should I do about it?');
+  });
+
+  it('does not open the agent until asked', async () => {
+    fetchOpenEpisodes.mockResolvedValue([EMPTY_EP]);
+    fetchEpisode.mockResolvedValue({ episode: EMPTY_EP, symptoms: [] });
+    render(<EpisodePanel />);
+    await screen.findByText(/How do I fix this\?/);
+    expect(screen.queryByTestId('inline-agent')).toBeNull();
+  });
+
+  it('can be closed again once opened', async () => {
+    // The expand control was gated on having symptoms, so on an episode that
+    // explains nothing the agent could be opened and then never collapsed.
+    fetchOpenEpisodes.mockResolvedValue([EMPTY_EP]);
+    fetchEpisode.mockResolvedValue({ episode: EMPTY_EP, symptoms: [] });
+    render(<EpisodePanel />);
+    fireEvent.click(await screen.findByText(/How do I fix this\?/));
+    await screen.findByTestId('inline-agent');
+
+    const collapse = screen.getByRole('button', { expanded: true });
+    fireEvent.click(collapse);
+    expect(screen.queryByTestId('inline-agent')).toBeNull();
+  });
+
+  it('still shows the agent automatically when an investigation exists', async () => {
+    // The existing behaviour for investigated episodes must not regress.
+    fetchOpenEpisodes.mockResolvedValue([{ ...EPISODE, symptom_count: 2 }]);
+    fetchEpisode.mockResolvedValue({
+      episode: EPISODE,
+      symptoms: SYMPTOMS,
+      investigation: { summary: 'etcd is thrashing', failed: false, recommended_fix: 'add memory' },
+    });
+    render(<EpisodePanel />);
+    expect(await screen.findByTestId('inline-agent')).toBeDefined();
+  });
+});


### PR DESCRIPTION
Raised from the screenshot: *"What is the user supposed to do to fix this issue?"*

The answer was **nothing**.

```
⚠ CAUSE  HighOverallControlPlaneMemory                 What else changed  ✓ Dismiss  ›
  alerts · started 24h ago · 2 symptoms across 2 namespaces · 5 times in 2d

⚠ CAUSE  ControlPlaneNodeMemoryHigh                    What else changed  ✓ Dismiss
  alerts · started 19h ago · explains nothing yet · 8 times in 2d
```

The card states the cause, the blast radius and the recurrence, then offers *look at history* or *make it go away*. Meanwhile the symptoms underneath it carry **Approve** buttons. Actions on the symptoms and none on the cause is exactly backwards — and it is why the causal model never reached the operator's hands.

## Why the agent was unreachable

There is an `InlineAgent` on this card already, primed with a good prompt. Two gates hid it:

```tsx
{expanded && investigation && (      // needs an investigation to already exist
   … <InlineAgent … />
{symptoms.length > 0 && (            // gates the expand chevron itself
   <button onClick={() => setExpanded(…)}>
```

So for `ControlPlaneNodeMemoryHigh` — zero symptoms — there is **no chevron at all**, which is why the second card in the screenshot has no `›`. No expand, no agent, no action. Even for the first card, the agent appears only if an investigation happened to have run.

## The change

Every episode card now carries **"How do I fix this?"**. It opens the agent with everything the card already knows — cause title, symptom count, namespaces, recurrence, and what changed just before it started — so the agent is not paid to re-derive all of that before answering the one question the deterministic layer cannot.

The chevron is now available whenever there is something to collapse, so an agent opened on a symptomless episode can be closed again.

## Tests

Six added. Mutations checked:

| mutation | result |
|---|---|
| remove the action button | 4 failed |
| re-gate the agent behind `investigation` | 2 failed |
| `askOpen` defaults to true (agent always open) | 5 failed |
| re-gate the chevron on `symptoms.length > 0` | **passed → gap, test added** |

The last one is worth noting: my tests reached the agent through the button, so nothing covered the *collapse* control. Reverting that guard kept everything green while leaving an operator able to open the agent on a symptomless episode and never close it. There is now a test for it.

`2221 passed`, tsc clean.

## What this does not do

It routes the operator to the agent; it does not propose a deterministic fix for the cause itself. For `HighOverallControlPlaneMemory` the real remediation is capacity or a memory limit, which is not something to auto-propose. A cause-level fix proposal — the counterpart to the symptom-level ones that already exist — is a larger piece of work and I would rather scope it deliberately than bolt it on here.
