### PR TITLE
chore: bump version to 2.18.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-OpenShift Pulse — a React/TypeScript dashboard for OpenShift Day-2 operations. All data comes from live Kubernetes APIs (no mock data in production code). v2.17.1, ~200 source files, 2,128 unit tests (175 files) + 57 E2E scenarios.
+OpenShift Pulse — a React/TypeScript dashboard for OpenShift Day-2 operations. All data comes from live Kubernetes APIs (no mock data in production code). v2.18.0, ~390 source files, 2,221 unit tests (182 files) + 56 E2E scenarios.
 
 ## Commands
 
@@ -128,7 +128,7 @@ Agent:          Mission Control (Trust Policy/Agent Health/Agent Accuracy/Capabi
 - **Confirmation flow**: `confirm_request` with nonce → UI shows dialog → `confirm_response` with nonce echoed back
 - **Degraded mode**: `engine/degradedMode.ts` — 5 failure reasons, displayed via `DegradedBanner`
 - **Auto-fix**: at trust level 3/4, monitor fixes crashloop (pod delete) and workloads (deployment restart) WITHOUT confirmation gate. Has safety guardrails: max 3/scan, 5min cooldown, no bare pods.
-- **Agent version**: v2.17.1 (Protocol v2, 104 native tools + MCP, 27 scanners)
+- **Agent version**: v2.18.0 (Protocol v2, 104 native tools + MCP, 27 scanners)
 - **Episodes**: an open episode appears above the queue in the Inbox and above every tile on Cluster Pulse — a cause with the findings it explains folded underneath, plus what changed just before it and how often it has returned. Symptoms are collapsed out of the list and the count is shown, because work vanishing from a queue with no explanation is its own trust problem. Every symptom carries a "Not related" control wired to the detach endpoint; that correction is the only ground truth the agent gets about its own correlation
 - **Time formatting**: `formatShortDuration(seconds)` and `formatElapsed(unixSeconds)` in `dateUtils` return one coarse unit with no suffix. Distinct from the older `formatDuration(startISO, endISO)` and `formatAge(Date)` in the same file — check which you want before adding a third
 - **MCP integration**: OpenShift MCP server with 11 toolsets, 36 tools including Prometheus queries and Helm management

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openshift-pulse",
-  "version": "2.17.1",
+  "version": "2.18.0",
   "description": "OpenShift Pulse — Next-generation OpenShift Console",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Release bump for the 9 commits since `v2.17.1`.

**Minor, not patch** — user-facing behaviour changed:

- episode cards gained a **"How do I fix this?"** action; previously a cause offered only "Dismiss" and a timeline link
- the trust ladder is relabelled (level 1 is no longer called "Confirm")
- Alerts, Administration and Fleet stopped reporting unknown data as zero
- the map is bounded and its loading skeleton no longer jumps the page
- episodes are ranked by what they explain

## CLAUDE.md was stale

| | was | now |
|---|---|---|
| version | v2.17.1 | v2.18.0 |
| unit tests | 2,128 (175 files) | 2,221 (182 files) |
| source files | ~200 | ~390 |
| E2E scenarios | 57 | 56 |
| **Agent version** | **v2.17.1** | **v2.18.0** |

That last row was wrong in kind, not just out of date: it recorded the *UI's* version under "Agent version". The agent was on 2.17.8 at the time, so the two lines had been copied from each other at some point and then drifted independently.

Counts verified against the tree rather than estimated — `find src -name '*.test.ts*'` for files, the suite output for tests, `grep -c` over `e2e/` for scenarios.

`2221 passed`.

## Note on tag lineage

The newest tags by version sort are `v6.x`, but those are abandoned — cut in **April 2026**. The live lineage is `v2.x`: `v2.17.1` is the latest by date and matches the deployed image `openshiftpulse:v2.17.1`. The release tag for this is `v2.18.0`.
