### PR TITLE
Give the skill routing gates their human half in the Toolbox

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-OpenShift Pulse — a React/TypeScript dashboard for OpenShift Day-2 operations. All data comes from live Kubernetes APIs (no mock data in production code). v2.18.0, ~390 source files, 2,221 unit tests (182 files) + 56 E2E scenarios.
+OpenShift Pulse — a React/TypeScript dashboard for OpenShift Day-2 operations. All data comes from live Kubernetes APIs (no mock data in production code). v2.18.0, ~390 source files, 2,231 unit tests (183 files) + 56 E2E scenarios.
 
 ## Commands
 
@@ -154,7 +154,7 @@ Agent:          Mission Control (Trust Policy/Agent Health/Agent Accuracy/Capabi
 
 ### Toolbox (`/toolbox`) — 6 tabs
 - **Catalog**: all tools (native + MCP) with source badges, search, mode/source filter
-- **Skills**: skill packages with editor, version history, diff viewer, routing tester, investigation plan templates section, AI-generated skill badges
+- **Skills**: skill packages with editor, version history, diff viewer, routing tester, investigation plan templates section, AI-generated skill badges, routing-gate banners (approve/re-approve for unreviewed or agent-refreshed skills, quarantine/restore for misrouting ones — backed by POST /admin/skills/{name}/approve|quarantine|unquarantine), Quarantined badge on cards, "Learned From" incident type on auto-scaffolded skills
 - **Connections**: MCP server management with 11 toolset toggles
 - **Components**: 25 component kinds by category with mutation support
 - **Usage**: tool invocation audit log with source (native/mcp) column

--- a/src/kubeview/views/__tests__/SkillLifecycleUI.test.tsx
+++ b/src/kubeview/views/__tests__/SkillLifecycleUI.test.tsx
@@ -1,0 +1,163 @@
+// @vitest-environment jsdom
+/**
+ * UI for the skill lifecycle gates: a refreshed or newborn agent skill is out
+ * of automatic routing until a person approves it, and a misrouting skill can
+ * be quarantined (reversibly). The buttons here are the human half of the
+ * agent's learning loop — without them the gates are dead ends.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+vi.mock('@/lib/utils', () => ({ cn: (...args: unknown[]) => args.filter(Boolean).join(' ') }));
+
+import { SkillDetailDrawer } from '../toolbox/SkillDetailDrawer';
+import { SkillsTab } from '../toolbox/SkillsTab';
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+function renderWithProviders(ui: React.ReactElement) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+}
+
+function jsonResponse(body: unknown) {
+  return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(body) });
+}
+
+const baseSkill = {
+  name: 'crashloop-payments',
+  display_name: 'Crashloop Payments',
+  version: 1,
+  description: 'Auto-generated skill',
+  keywords: ['crashloop'],
+  categories: ['diagnostics'],
+  priority: 5,
+  write_tools: false,
+  requires_tools: [],
+  handoff_to: {},
+  configurable: [],
+  degraded: false,
+  builtin: false,
+  generated_by: 'auto',
+  reviewed: false,
+  quarantined: false,
+  incident_type: 'crashloop',
+  prompt_length: 500,
+  raw_content: '---\nname: crashloop-payments\n---\nBody',
+};
+
+function routeFetch(skill: Record<string, unknown>, calls: string[] = []) {
+  mockFetch.mockImplementation((input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : ((input as Request)?.url ?? String(input ?? ''));
+    if (init?.method === 'POST') {
+      calls.push(url);
+      return jsonResponse({ name: skill.name });
+    }
+    if (url.includes('/versions')) return jsonResponse({ versions: [] });
+    if (url.includes('/usage')) return jsonResponse({ runs: 0, skills: [] });
+    if (url.includes(`/skills/${skill.name}`)) return jsonResponse(skill);
+    if (url.includes('/skills')) return jsonResponse([skill]);
+    return jsonResponse({});
+  });
+}
+
+describe('SkillDetailDrawer routing gates', () => {
+  beforeEach(() => mockFetch.mockReset());
+  afterEach(cleanup);
+
+  it('unreviewed newborn skill shows the review banner with an approve action', async () => {
+    routeFetch({ ...baseSkill, reviewed: false, version: 1 });
+    renderWithProviders(<SkillDetailDrawer name="crashloop-payments" onClose={() => {}} />);
+    await waitFor(() => expect(screen.getByText(/Awaiting review/)).toBeDefined());
+    expect(screen.getByText('Approve for routing')).toBeDefined();
+  });
+
+  it('a refreshed skill (v>1) explains that re-review is needed, not first review', async () => {
+    routeFetch({ ...baseSkill, reviewed: false, version: 4 });
+    renderWithProviders(<SkillDetailDrawer name="crashloop-payments" onClose={() => {}} />);
+    await waitFor(() => expect(screen.getByText(/Awaiting re-review/)).toBeDefined());
+    expect(screen.getByText(/learned a new verified case/)).toBeDefined();
+  });
+
+  it('approve calls the approve endpoint', async () => {
+    const calls: string[] = [];
+    routeFetch({ ...baseSkill, reviewed: false }, calls);
+    renderWithProviders(<SkillDetailDrawer name="crashloop-payments" onClose={() => {}} />);
+    await waitFor(() => expect(screen.getByText('Approve for routing')).toBeDefined());
+    fireEvent.click(screen.getByText('Approve for routing'));
+    await waitFor(() =>
+      expect(calls).toContain('/api/agent/admin/skills/crashloop-payments/approve'),
+    );
+  });
+
+  it('a reviewed, healthy skill shows no gate banners', async () => {
+    routeFetch({ ...baseSkill, reviewed: true });
+    renderWithProviders(<SkillDetailDrawer name="crashloop-payments" onClose={() => {}} />);
+    await waitFor(() => expect(screen.getAllByText('crashloop-payments').length).toBeGreaterThan(0));
+    expect(screen.queryByText(/Awaiting review/)).toBeNull();
+    expect(screen.queryByText(/Quarantined/)).toBeNull();
+  });
+
+  it('quarantined skill shows the quarantine banner with a restore action', async () => {
+    const calls: string[] = [];
+    routeFetch({ ...baseSkill, reviewed: true, quarantined: true }, calls);
+    renderWithProviders(<SkillDetailDrawer name="crashloop-payments" onClose={() => {}} />);
+    await waitFor(() => expect(screen.getByText(/excluded from automatic routing/)).toBeDefined());
+    fireEvent.click(screen.getByText('Restore to routing'));
+    await waitFor(() =>
+      expect(calls).toContain('/api/agent/admin/skills/crashloop-payments/unquarantine'),
+    );
+  });
+
+  it('quarantine goes through a confirm dialog before calling the endpoint', async () => {
+    const calls: string[] = [];
+    routeFetch({ ...baseSkill, reviewed: true }, calls);
+    renderWithProviders(<SkillDetailDrawer name="crashloop-payments" onClose={() => {}} />);
+    await waitFor(() => expect(screen.getByText('Quarantine')).toBeDefined());
+    fireEvent.click(screen.getByText('Quarantine'));
+    // Nothing sent yet — the dialog is the gate.
+    expect(calls).toHaveLength(0);
+    await waitFor(() => expect(screen.getByText('Quarantine Skill')).toBeDefined());
+    // Two buttons say "Quarantine": the header action and the dialog's
+    // confirm. The dialog rendered last; its confirm is the final match.
+    const buttons = screen.getAllByRole('button', { name: 'Quarantine' });
+    fireEvent.click(buttons[buttons.length - 1]);
+    await waitFor(() =>
+      expect(calls).toContain('/api/agent/admin/skills/crashloop-payments/quarantine'),
+    );
+  });
+
+  it('no quarantine button while already quarantined', async () => {
+    routeFetch({ ...baseSkill, reviewed: true, quarantined: true });
+    renderWithProviders(<SkillDetailDrawer name="crashloop-payments" onClose={() => {}} />);
+    await waitFor(() => expect(screen.getByText('Restore to routing')).toBeDefined());
+    expect(screen.queryByText(/^Quarantine$/)).toBeNull();
+  });
+
+  it('shows what the skill was learned from when incident_type is present', async () => {
+    routeFetch({ ...baseSkill, reviewed: true });
+    renderWithProviders(<SkillDetailDrawer name="crashloop-payments" onClose={() => {}} />);
+    await waitFor(() => expect(screen.getByText('crashloop incidents')).toBeDefined());
+  });
+});
+
+describe('SkillsTab quarantine badge', () => {
+  beforeEach(() => mockFetch.mockReset());
+  afterEach(cleanup);
+
+  it('marks a quarantined skill on its card', async () => {
+    routeFetch({ ...baseSkill, reviewed: true, quarantined: true });
+    renderWithProviders(<SkillsTab />);
+    await waitFor(() => expect(screen.getByText('Quarantined')).toBeDefined());
+  });
+
+  it('healthy skills carry no quarantine badge', async () => {
+    routeFetch({ ...baseSkill, reviewed: true, quarantined: false });
+    renderWithProviders(<SkillsTab />);
+    await waitFor(() => expect(screen.getByText('Crashloop Payments')).toBeDefined());
+    expect(screen.queryByText('Quarantined')).toBeNull();
+  });
+});

--- a/src/kubeview/views/toolbox/SkillDetailDrawer.tsx
+++ b/src/kubeview/views/toolbox/SkillDetailDrawer.tsx
@@ -3,7 +3,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   Puzzle, RefreshCw, Save, Check, Copy, Trash2, X,
   FileText, History, GitCompareArrows, AlertTriangle,
-  ArrowRight, CheckCircle2, XCircle,
+  ArrowRight, CheckCircle2, XCircle, ShieldCheck, ShieldOff,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { agentFetch } from '../../engine/safeQuery';
@@ -40,6 +40,9 @@ export function SkillDetailDrawer({ name, onClose }: { name: string; onClose: ()
   const [cloneStatus, setCloneStatus] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [confirmQuarantine, setConfirmQuarantine] = useState(false);
+  const [gateBusy, setGateBusy] = useState(false);
+  const [gateError, setGateError] = useState<string | null>(null);
   const cloneInputRef = useRef<HTMLInputElement>(null);
 
   const { data: detail, isLoading } = useQuery({
@@ -144,6 +147,29 @@ export function SkillDetailDrawer({ name, onClose }: { name: string; onClose: ()
     }
   };
 
+  // approve restores an agent-refreshed skill to routing; quarantine pulls a
+  // misrouting one; unquarantine reverses that. All three are admin endpoints
+  // that rewrite skill.md frontmatter and hot-reload the registry.
+  const gateAction = async (action: 'approve' | 'quarantine' | 'unquarantine') => {
+    setGateBusy(true);
+    setGateError(null);
+    try {
+      const res = await agentFetch(`/api/agent/admin/skills/${name}/${action}`, { method: 'POST' });
+      if (res.ok) {
+        queryClient.invalidateQueries({ queryKey: ['admin', 'skill-detail', name] });
+        queryClient.invalidateQueries({ queryKey: ['admin', 'skills'] });
+      } else {
+        const err = await res.json().catch(() => ({ detail: `${action} failed` }));
+        setGateError(err.detail || `${action} failed`);
+      }
+    } catch {
+      setGateError('Network error');
+    } finally {
+      setGateBusy(false);
+      setConfirmQuarantine(false);
+    }
+  };
+
   const loadDiff = async (v1: string, v2: string) => {
     setDiffFiles({ v1, v2 });
     setDiffResult('Loading...');
@@ -209,6 +235,15 @@ export function SkillDetailDrawer({ name, onClose }: { name: string; onClose: ()
               >
                 <Copy className="w-3.5 h-3.5" /> Clone
               </button>
+              {detail && !detail.quarantined && (
+                <button
+                  onClick={() => { setConfirmQuarantine(true); setGateError(null); }}
+                  className="flex items-center gap-1 px-2 py-1.5 text-xs text-slate-400 hover:text-amber-400 hover:bg-slate-800 rounded-md"
+                  title="Pull this skill from automatic routing (reversible)"
+                >
+                  <ShieldOff className="w-3.5 h-3.5" /> Quarantine
+                </button>
+              )}
               {!['sre', 'security', 'view_designer'].includes(name) && (
                 <button
                   onClick={() => { setConfirmDelete(true); setDeleteError(null); }}
@@ -311,6 +346,70 @@ export function SkillDetailDrawer({ name, onClose }: { name: string; onClose: ()
           </div>
         )}
 
+        {gateError && (
+          <div className="mx-5 mt-2 flex items-center gap-2 px-3 py-2 text-xs rounded-md border bg-red-950/30 border-red-800/30 text-red-400">
+            <XCircle className="w-3.5 h-3.5" />
+            {gateError}
+            <button onClick={() => setGateError(null)} className="ml-auto text-slate-500 hover:text-slate-300"><X className="w-3 h-3" /></button>
+          </div>
+        )}
+
+        {/* Routing gate banners — visible whichever panel is open */}
+        {detail && Boolean(detail.quarantined) && (
+          <div className="mx-5 mt-3 flex items-center gap-2 px-3 py-2.5 bg-red-950/30 border border-red-800/40 rounded-md text-xs text-red-300">
+            <ShieldOff className="w-4 h-4 shrink-0 text-red-400" />
+            <div className="flex-1">
+              <span className="font-medium">Quarantined</span> — excluded from automatic routing (ORCA selection and
+              trigger patterns). Still loadable by name for debugging.
+            </div>
+            <button
+              onClick={() => gateAction('unquarantine')}
+              disabled={gateBusy}
+              className="flex items-center gap-1.5 px-3 py-1.5 bg-red-600 hover:bg-red-700 text-white rounded-md disabled:opacity-50 shrink-0"
+            >
+              {gateBusy ? <RefreshCw className="w-3.5 h-3.5 animate-spin" /> : <ShieldCheck className="w-3.5 h-3.5" />}
+              Restore to routing
+            </button>
+          </div>
+        )}
+        {detail && detail.generated_by === 'auto' && !detail.reviewed && (
+          <div className="mx-5 mt-3 flex items-center gap-2 px-3 py-2.5 bg-amber-950/30 border border-amber-800/40 rounded-md text-xs text-amber-300">
+            <AlertTriangle className="w-4 h-4 shrink-0 text-amber-400" />
+            <div className="flex-1">
+              {Number(detail.version) > 1 ? (
+                <>
+                  <span className="font-medium">Awaiting re-review</span> — this skill learned a new verified case
+                  (now v{Number(detail.version)}), so the content a person last approved has changed. It stays out
+                  of automatic routing until someone re-approves it.
+                </>
+              ) : (
+                <>
+                  <span className="font-medium">Awaiting review</span> — agent-authored skill, excluded from
+                  automatic routing until a person reads and approves it.
+                </>
+              )}
+            </div>
+            <button
+              onClick={() => gateAction('approve')}
+              disabled={gateBusy}
+              className="flex items-center gap-1.5 px-3 py-1.5 bg-emerald-600 hover:bg-emerald-700 text-white rounded-md disabled:opacity-50 shrink-0"
+            >
+              {gateBusy ? <RefreshCw className="w-3.5 h-3.5 animate-spin" /> : <ShieldCheck className="w-3.5 h-3.5" />}
+              Approve for routing
+            </button>
+          </div>
+        )}
+
+        <ConfirmDialog
+          open={confirmQuarantine}
+          onClose={() => setConfirmQuarantine(false)}
+          onConfirm={() => gateAction('quarantine')}
+          title="Quarantine Skill"
+          description={`Pull '${name}' from automatic routing? It stops serving ORCA selection and trigger-pattern pre-routes, but stays loadable by name and can be restored at any time.`}
+          confirmLabel="Quarantine"
+          variant="danger"
+        />
+
         <ConfirmDialog
           open={confirmDelete}
           onClose={() => setConfirmDelete(false)}
@@ -333,6 +432,9 @@ export function SkillDetailDrawer({ name, onClose }: { name: string; onClose: ()
                   <MetaCard label="Categories" value={detail.categories?.join(', ') || 'none'} />
                   <MetaCard label="Priority" value={detail.priority} />
                   <MetaCard label="Write Tools" value={detail.write_tools ? 'Yes' : 'No'} />
+                  {detail.incident_type && (
+                    <MetaCard label="Learned From" value={`${detail.incident_type} incidents`} />
+                  )}
                 </div>
 
                 {detail.degraded && (

--- a/src/kubeview/views/toolbox/SkillsTab.tsx
+++ b/src/kubeview/views/toolbox/SkillsTab.tsx
@@ -128,7 +128,7 @@ export function SkillsTab() {
                 onClick={() => setSelectedSkill(String(skill.name))}
                 className={cn(
                   'bg-slate-900 border rounded-lg p-4 space-y-2 text-left transition-colors hover:border-blue-700/50 hover:bg-slate-900/80 cursor-pointer',
-                  skill.degraded ? 'border-amber-800/50' : 'border-slate-800',
+                  skill.quarantined ? 'border-red-800/50' : skill.degraded ? 'border-amber-800/50' : 'border-slate-800',
                 )}
               >
                 <div className="flex items-center justify-between gap-2">
@@ -138,6 +138,11 @@ export function SkillsTab() {
                     <span className="text-[10px] px-1.5 py-0.5 bg-slate-800 rounded-sm text-slate-500 shrink-0">v{Number(skill.version)}</span>
                   </div>
                   <div className="flex items-center gap-1.5 shrink-0">
+                    {Boolean(skill.quarantined) && (
+                      <span className="text-[10px] px-1.5 py-0.5 bg-red-900/40 text-red-300 rounded-sm border border-red-700/40">
+                        Quarantined
+                      </span>
+                    )}
                     {skill.generated_by === 'auto' && !skill.reviewed && (
                       <span className="text-[10px] px-1.5 py-0.5 bg-amber-900/40 text-amber-300 rounded-sm border border-amber-700/40">
                         AI-generated · Needs review


### PR DESCRIPTION
## What

UI counterpart to the agent-side skill lifecycle work (PulseSRE/pulse-agent#117, writeup in PulseSRE/pulse-agent#118): the backend holds refreshed or newborn agent-authored skills out of automatic routing until a person approves them, and added quarantine endpoints for skills people keep overriding. Both gates were dead ends reachable only by curl — this PR gives them their human half in the Toolbox.

### Skill detail drawer
- **Routing-gate banner** whenever a skill is out of routing, phrased in the right tense: a v1 skill is *"Awaiting review"* (nobody has read it yet); a v>1 skill is *"Awaiting re-review — this skill learned a new verified case"*. One-click **Approve for routing**.
- **Quarantine** header action behind a confirm dialog → `POST /admin/skills/{name}/quarantine`. While quarantined: red banner with one-click **Restore to routing**, and the quarantine button hides so it can't be double-applied.
- **Learned From** meta card showing the incident category an auto-scaffolded skill was learned from.

### Skills grid
- Red **Quarantined** badge + border tint on affected cards.

## Testing
- 10 new tests (`SkillLifecycleUI.test.tsx`): both gates, endpoint wiring, confirm-dialog flow, banner tense, badge presence/absence.
- `pnpm verify` green: 2,231 tests / 183 files, type-check + lint clean, production build compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)