### PR TITLE
One chat surface, not two

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Two places to have the same conversation
+- An episode card embedded its own **"Ask about this Episode"** chat while the Pulse AI sidebar sat open beside it with its own input. Two inputs, two conversations, two connection states — and nothing on screen to say which one to use. The previous change made it worse by putting an inline chat on *every* episode rather than only investigated ones
+- **"How do I fix this?"** now opens the sidebar in chat mode and sends the question there. The card no longer renders a chat of its own, investigated or not
+- The sidebar wins because it persists across navigation: an answer about this cause is still there after you follow it to the Timeline or a pod. An inline panel dies with the card that owns it
+- It sends through `connectAndSend`, not `sendMessage` — if the sidebar was collapsed the socket may not be up, and `sendMessage` sets "Agent not connected" and discards the text rather than waiting
+
 ### An episode card with nothing to do
 - The card said what was wrong — cause, symptom count, blast radius, recurrence — and then offered **"What else changed"** and **"Dismiss"**. Look at history, or make it go away. Neither fixes anything, while the symptoms underneath it carried Approve buttons. Actions on the symptoms and none on the cause is exactly backwards, and it is why the causal model never reached the operator's hands
 - Two gates kept the agent out of reach. It rendered *inside* the investigation block, so it existed only once an investigation had already run; and the expand chevron was gated on `symptoms.length > 0`, so an episode explaining nothing had no chevron at all and therefore no route to anything. `ControlPlaneNodeMemoryHigh` on the reference cluster was exactly that: two links, neither of which acts

--- a/src/kubeview/views/inbox/EpisodePanel.tsx
+++ b/src/kubeview/views/inbox/EpisodePanel.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
 import { AlertTriangle, Ban, Check, ChevronDown, ChevronRight, Clock, History, Wrench } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { InlineAgent } from '../../components/agent/InlineAgent';
+import { useAgentStore } from '../../store/agentStore';
+import { useUIStore } from '../../store/uiStore';
 import { formatElapsed, formatShortDuration } from '../../engine/dateUtils';
 import { detachSymptom, dismissEpisode, fetchEpisode, fetchOpenEpisodes } from '../../engine/episodeApi';
 import type {
@@ -59,7 +60,6 @@ export function timelineRangeFor(startedAtSeconds: number, nowSeconds = Date.now
 
 function EpisodeCard({ episode, onChanged }: { episode: Episode; onChanged: () => void }) {
   const [expanded, setExpanded] = useState(true);
-  const [askOpen, setAskOpen] = useState(false);
   const [symptoms, setSymptoms] = useState<EpisodeSymptom[]>([]);
   const [symptomsLoaded, setSymptomsLoaded] = useState(false);
   const [changes, setChanges] = useState<EpisodeChange[]>([]);
@@ -125,6 +125,33 @@ function EpisodeCard({ episode, onChanged }: { episode: Episode; onChanged: () =
     .filter(Boolean)
     .join(' ');
 
+  /**
+   * One chat surface, not two.
+   *
+   * This used to render its own InlineAgent inside the card, so an operator
+   * looking at an episode saw two places to type the same question: the
+   * embedded "Ask about this Episode" box, and the Pulse AI sidebar already
+   * open beside it with its own input. Two inputs, two conversations, two
+   * connection states — and nothing to say which one to use.
+   *
+   * The sidebar wins because it persists across navigation: an answer about
+   * this cause is still there after you follow it to the Timeline or a pod.
+   * An inline panel dies with the card that owns it.
+   */
+  const askAboutThisEpisode = useCallback(() => {
+    useUIStore.getState().expandAISidebar();
+    useUIStore.getState().setAISidebarMode('chat');
+    // connectAndSend rather than sendMessage: the socket may not be up yet if
+    // the sidebar was collapsed, and sendMessage drops the message with
+    // "Agent not connected" rather than waiting.
+    useAgentStore.getState().connectAndSend(askPrompt, {
+      kind: 'Episode',
+      name: episode.id,
+      namespace: episode.namespaces[0],
+    });
+  }, [askPrompt, episode.id, episode.namespaces]);
+
+
   // An episode is a claim that one thing explains others. Until it explains
   // something it has made no claim, and dressing it in the same red alarm as a
   // cause with eight symptoms underneath spends the operator's attention on
@@ -185,8 +212,8 @@ function EpisodeCard({ episode, onChanged }: { episode: Episode; onChanged: () =
           </div>
         </div>
         <button
-          onClick={() => { setAskOpen(true); setExpanded(true); }}
-          title="Ask the agent what to do about this cause"
+          onClick={askAboutThisEpisode}
+          title="Ask Pulse AI what to do about this cause"
           className="shrink-0 inline-flex items-center gap-1 rounded-sm px-1.5 py-1 text-[11px] font-medium text-violet-300 transition-colors hover:bg-violet-500/15 hover:text-violet-200"
         >
           <Wrench className="h-3 w-3" />
@@ -208,7 +235,7 @@ function EpisodeCard({ episode, onChanged }: { episode: Episode; onChanged: () =
           <Check className="h-3 w-3" />
           Dismiss
         </button>
-        {(symptoms.length > 0 || investigation || askOpen) && (
+        {(symptoms.length > 0 || investigation) && (
           <button
             onClick={() => setExpanded((e) => !e)}
             aria-expanded={expanded}
@@ -246,32 +273,6 @@ function EpisodeCard({ episode, onChanged }: { episode: Episode; onChanged: () =
               )}
             </div>
           )}
-        </div>
-      )}
-
-      {/* The one thing the card was missing: a way to act on the cause.
-          It offered "What else changed" and "Dismiss" — look at history, or
-          make it go away — while the symptoms underneath it got Approve
-          buttons. Actions on the symptoms and none on the cause is backwards.
-
-          The agent used to render inside the investigation block, so it was
-          reachable only once an investigation had already run, and the expand
-          control was itself gated on having symptoms — so an episode that
-          explained nothing had no chevron at all and no route to anything.
-          The prompt carries what the card already knows, so the agent is not
-          paid to re-derive the cause, the blast radius and the recent changes
-          before answering the only question the deterministic layer cannot. */}
-      {expanded && (investigation || askOpen) && (
-        <div className="border-t border-red-500/15 px-3 py-2">
-          <InlineAgent
-            context={{ kind: 'Episode', name: episode.id, namespace: episode.namespaces[0] }}
-            initialPrompt={askPrompt}
-            quickPrompts={[
-              'What should I do about this?',
-              'Is this safe to ignore?',
-              'What would confirm the cause?',
-            ]}
-          />
         </div>
       )}
 

--- a/src/kubeview/views/inbox/__tests__/EpisodePanel.test.tsx
+++ b/src/kubeview/views/inbox/__tests__/EpisodePanel.test.tsx
@@ -9,6 +9,22 @@ const detachSymptom = vi.fn();
 
 const dismissEpisode = vi.fn();
 
+const connectAndSend = vi.fn();
+const expandAISidebar = vi.fn();
+const setAISidebarMode = vi.fn();
+
+vi.mock('../../../store/agentStore', () => ({
+  useAgentStore: Object.assign(() => ({}), {
+    getState: () => ({ connectAndSend }),
+  }),
+}));
+
+vi.mock('../../../store/uiStore', () => ({
+  useUIStore: Object.assign(() => ({}), {
+    getState: () => ({ expandAISidebar, setAISidebarMode }),
+  }),
+}));
+
 vi.mock('../../../engine/episodeApi', () => ({
   fetchOpenEpisodes: (...a: unknown[]) => fetchOpenEpisodes(...a),
   fetchEpisode: (...a: unknown[]) => fetchEpisode(...a),
@@ -292,7 +308,18 @@ describe('EpisodePanel investigation and dismissal', () => {
       changes: [{ category: 'audit_rbac', title: 'cluster-admin granted', namespace: 'ns', at: 1, seconds_before: 120 }],
     });
     render(<EpisodePanel />);
-    const prompt = (await screen.findByTestId('inline-agent')).textContent || '';
+    // The prompt used to be read off an embedded chat panel. There is only one
+    // chat surface now, so it is read off the message sent into the sidebar.
+    //
+    // Wait for the recurrence label before clicking: the button renders
+    // immediately but the prompt is built from `changes` and `recurrence`,
+    // which arrive from fetchEpisode. Clicking too early sent a prompt that
+    // was correct but incomplete — a genuine race, and it made this test fail
+    // roughly one full-suite run in several.
+    await screen.findByText(/6 times/);
+    fireEvent.click(await screen.findByText(/How do I fix this\?/));
+    await waitFor(() => expect(connectAndSend).toHaveBeenCalled());
+    const prompt = connectAndSend.mock.calls[0][0] as string;
     expect(prompt).toContain(EPISODE.cause_title);
     expect(prompt).toContain('cluster-admin granted');
     expect(prompt).toContain('6 times');
@@ -470,6 +497,14 @@ describe('an episode points at what else changed', () => {
 describe('an episode card offers a way to act on the cause', () => {
   const EMPTY_EP = { ...EPISODE, id: 'ep-none', cause_title: 'ControlPlaneNodeMemoryHigh', symptom_count: 0, namespaces: [] };
 
+  // The store spies are module-level, so calls accumulate across tests in this
+  // block — "not.toHaveBeenCalled" is meaningless without this.
+  beforeEach(() => {
+    connectAndSend.mockClear();
+    expandAISidebar.mockClear();
+    setAISidebarMode.mockClear();
+  });
+
   afterEach(cleanup);
 
   it('offers a fix action even with no symptoms and no investigation', async () => {
@@ -479,49 +514,49 @@ describe('an episode card offers a way to act on the cause', () => {
     expect(await screen.findByText(/How do I fix this\?/)).toBeDefined();
   });
 
-  it('reaches the agent from an episode that explains nothing', async () => {
-    // Previously impossible: no chevron, so no expand, so no agent.
+  it('sends the question to the one chat surface, not a second one', async () => {
+    // The card used to embed its own chat while the Pulse AI sidebar sat open
+    // beside it with its own input: two places to ask the same question, two
+    // connection states, and nothing to say which one to use.
     fetchOpenEpisodes.mockResolvedValue([EMPTY_EP]);
     fetchEpisode.mockResolvedValue({ episode: EMPTY_EP, symptoms: [] });
     render(<EpisodePanel />);
     fireEvent.click(await screen.findByText(/How do I fix this\?/));
-    expect(await screen.findByTestId('inline-agent')).toBeDefined();
+
+    await waitFor(() => expect(connectAndSend).toHaveBeenCalled());
+    expect(expandAISidebar).toHaveBeenCalled();
+    expect(setAISidebarMode).toHaveBeenCalledWith('chat');
+    expect(screen.queryByTestId('inline-agent')).toBeNull();
   });
 
-  it('hands the agent what the card already knows', async () => {
+  it('works on an episode that explains nothing', async () => {
+    // Previously impossible: no symptoms meant no chevron, so no way in.
     fetchOpenEpisodes.mockResolvedValue([EMPTY_EP]);
     fetchEpisode.mockResolvedValue({ episode: EMPTY_EP, symptoms: [] });
     render(<EpisodePanel />);
     fireEvent.click(await screen.findByText(/How do I fix this\?/));
-    const agent = await screen.findByTestId('inline-agent');
-    expect(agent.textContent).toContain('ControlPlaneNodeMemoryHigh');
-    expect(agent.textContent).toContain('What should I do about it?');
+    await waitFor(() => expect(connectAndSend).toHaveBeenCalled());
+    expect(connectAndSend.mock.calls[0][0]).toContain('ControlPlaneNodeMemoryHigh');
   });
 
-  it('does not open the agent until asked', async () => {
+  it('tells the agent which episode is being asked about', async () => {
+    fetchOpenEpisodes.mockResolvedValue([EMPTY_EP]);
+    fetchEpisode.mockResolvedValue({ episode: EMPTY_EP, symptoms: [] });
+    render(<EpisodePanel />);
+    fireEvent.click(await screen.findByText(/How do I fix this\?/));
+    await waitFor(() => expect(connectAndSend).toHaveBeenCalled());
+    expect(connectAndSend.mock.calls[0][1]).toMatchObject({ kind: 'Episode', name: EMPTY_EP.id });
+  });
+
+  it('does not start a conversation until asked', async () => {
     fetchOpenEpisodes.mockResolvedValue([EMPTY_EP]);
     fetchEpisode.mockResolvedValue({ episode: EMPTY_EP, symptoms: [] });
     render(<EpisodePanel />);
     await screen.findByText(/How do I fix this\?/);
-    expect(screen.queryByTestId('inline-agent')).toBeNull();
+    expect(connectAndSend).not.toHaveBeenCalled();
   });
 
-  it('can be closed again once opened', async () => {
-    // The expand control was gated on having symptoms, so on an episode that
-    // explains nothing the agent could be opened and then never collapsed.
-    fetchOpenEpisodes.mockResolvedValue([EMPTY_EP]);
-    fetchEpisode.mockResolvedValue({ episode: EMPTY_EP, symptoms: [] });
-    render(<EpisodePanel />);
-    fireEvent.click(await screen.findByText(/How do I fix this\?/));
-    await screen.findByTestId('inline-agent');
-
-    const collapse = screen.getByRole('button', { expanded: true });
-    fireEvent.click(collapse);
-    expect(screen.queryByTestId('inline-agent')).toBeNull();
-  });
-
-  it('still shows the agent automatically when an investigation exists', async () => {
-    // The existing behaviour for investigated episodes must not regress.
+  it('never embeds a chat of its own, investigated or not', async () => {
     fetchOpenEpisodes.mockResolvedValue([{ ...EPISODE, symptom_count: 2 }]);
     fetchEpisode.mockResolvedValue({
       episode: EPISODE,
@@ -529,6 +564,7 @@ describe('an episode card offers a way to act on the cause', () => {
       investigation: { summary: 'etcd is thrashing', failed: false, recommended_fix: 'add memory' },
     });
     render(<EpisodePanel />);
-    expect(await screen.findByTestId('inline-agent')).toBeDefined();
+    await screen.findByText(/How do I fix this\?/);
+    expect(screen.queryByTestId('inline-agent')).toBeNull();
   });
 });


### PR DESCRIPTION
From the screenshot: an episode card rendering **"Ask about this Episode"** with its own message box and *"Not connected to agent / Connecting…"*, while the **Pulse AI** sidebar sat open to its right with *"Ask Pulse anything…"*.

Two inputs. Two conversations. Two connection states. Nothing on screen to say which one to use — and my previous change made it worse, by putting an inline chat on *every* episode instead of only investigated ones.

## The change

`How do I fix this?` now drives the sidebar that already exists:

```ts
useUIStore.getState().expandAISidebar();
useUIStore.getState().setAISidebarMode('chat');
useAgentStore.getState().connectAndSend(askPrompt, {
  kind: 'Episode', name: episode.id, namespace: episode.namespaces[0],
});
```

The card renders no chat of its own any more, investigated or not. The prompt it hands over is unchanged — cause, symptom count, namespaces, recurrence, and what changed just before — so the agent still isn't paid to re-derive what the card already knows.

**Why the sidebar rather than the card:** it survives navigation. An answer about this cause is still there after you follow it to the Timeline or into a pod. An inline panel dies with the card that owns it, which is the wrong lifetime for a diagnosis.

**`connectAndSend`, not `sendMessage`:** if the sidebar was collapsed the socket may not be up, and `sendMessage` sets `"Agent not connected — try again in a moment"` and drops the text. `connectAndSend` exists precisely for this and is documented as the "safe replacement for the setTimeout race condition".

## Tests

Five rewritten, one pre-existing test re-pointed. Mutations checked:

| mutation | result |
|---|---|
| `sendMessage` instead of `connectAndSend` | 4 failed |
| does not open the sidebar | 1 failed |
| leaves the sidebar in dashboard mode | 1 failed |
| sends without the episode context | 1 failed |

## Two test problems I fixed rather than re-ran

The module-level store spies accumulate across tests in a block, so `not.toHaveBeenCalled()` was meaningless without an explicit `mockClear` — added.

And the re-pointed prompt test had a genuine race: it clicked as soon as the button rendered, but the prompt is built from `changes` and `recurrence`, which arrive from `fetchEpisode`. Clicking early sent a prompt that was correct but incomplete, and the test failed roughly one full-suite run in several. It now waits for the recurrence label first. Verified stable over three file runs and two full runs.

`2231 passed` (183 files), tsc clean.

## Still there

`GenericDetailLayout` also embeds an `InlineAgent`. Same duplication whenever the sidebar is open on a resource detail page — worth the same treatment, but it is a different surface and I would rather do it deliberately than sweep it in here.