### PR TITLE
Teach the UI the 'expired' action status

### DIFF
--- a/src/kubeview/engine/fixHistory.ts
+++ b/src/kubeview/engine/fixHistory.ts
@@ -14,7 +14,9 @@ export interface ActionRecord {
   category: string;
   tool: string;
   input: Record<string, unknown>;
-  status: 'proposed' | 'executing' | 'completed' | 'failed' | 'rolled_back';
+  // 'expired' is a proposal nobody answered inside the approval window — the
+  // agent's most common trust-2 outcome. It is not a failure: the fix never ran.
+  status: 'proposed' | 'executing' | 'completed' | 'failed' | 'rolled_back' | 'expired';
   beforeState: string;
   afterState: string;
   error?: string;

--- a/src/kubeview/engine/monitorClient.ts
+++ b/src/kubeview/engine/monitorClient.ts
@@ -54,7 +54,9 @@ export interface ActionReport {
   findingId: string;
   tool: string;
   input: Record<string, unknown>;
-  status: 'proposed' | 'executing' | 'completed' | 'failed' | 'rolled_back';
+  // 'expired' is a proposal nobody answered inside the approval window — the
+  // agent's most common trust-2 outcome. It is not a failure: the fix never ran.
+  status: 'proposed' | 'executing' | 'completed' | 'failed' | 'rolled_back' | 'expired';
   beforeState?: string;
   afterState?: string;
   error?: string;

--- a/src/kubeview/views/incidents/IncidentLifecycleDrawer.tsx
+++ b/src/kubeview/views/incidents/IncidentLifecycleDrawer.tsx
@@ -54,10 +54,15 @@ export function IncidentLifecycleDrawer({ findingId, onClose }: IncidentLifecycl
   const investigationStatus: StageStatus = lifecycle.investigation
     ? lifecycle.investigation.status === 'completed' ? 'complete' : 'failed'
     : lifecycle.detection?.investigationPhases?.some((p) => p.status === 'running') ? 'in-progress' : 'pending';
+  // 'expired' is a proposal nobody answered — the fix never ran, so it is
+  // neither failed nor still pending. 'skipped' is the honest stage for it,
+  // the same mapping 'unverifiable' gets below and for the same reason:
+  // reporting it any other way asserts something that never happened.
   const actionStatus: StageStatus = lifecycle.action
     ? lifecycle.action.status === 'completed' ? 'complete'
     : lifecycle.action.status === 'failed' ? 'failed'
     : lifecycle.action.status === 'executing' ? 'in-progress'
+    : lifecycle.action.status === 'expired' ? 'skipped'
     : 'pending'
     : 'pending';
   // 'unverifiable' means the health check ran and could not get a clear


### PR DESCRIPTION
UI counterpart to PulseSRE/pulse-agent#119 and PulseSRE/pulse-agent#120: `expired` is now the recorded status for a fix proposal nobody answered inside the approval window — the most common trust-2 outcome (281/368 on the dev cluster). The UI's status unions omitted it and the incident lifecycle drawer rendered it as a perpetually pending stage.

- `ActionRecord` (fixHistory.ts) and `ActionReport` (monitorClient.ts) status unions gain `'expired'`
- Lifecycle drawer maps `expired` → `skipped` (the fix never ran: neither failed nor pending — same reasoning as the existing `unverifiable` mapping)

`pnpm verify` green: type-check, lint, 2,231 tests, production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)