### PR TITLE
Route every open-sidebar-and-ask call site through askPulse()

### DIFF
--- a/src/kubeview/components/ErrorBoundary.tsx
+++ b/src/kubeview/components/ErrorBoundary.tsx
@@ -139,12 +139,13 @@ export class ErrorBoundary extends React.Component<Props, State> {
               </button>
               <button
                 onClick={() => {
+                  // Lazy require, not a top-level import: ErrorBoundary is
+                  // imported nearly everywhere, and askPulse pulls in the
+                  // stores — a static import would recreate the cycle this
+                  // require pattern exists to avoid.
                   // eslint-disable-next-line @typescript-eslint/no-require-imports
-                  const { useUIStore } = require('../store/uiStore');
-                  // eslint-disable-next-line @typescript-eslint/no-require-imports
-                  const { useAgentStore } = require('../store/agentStore');
-                  useUIStore.getState().expandAISidebar(); useUIStore.getState().setAISidebarMode('chat');
-                  useAgentStore.getState().connectAndSend(
+                  const { askPulse } = require('../engine/askPulse');
+                  askPulse(
                     `The UI crashed with this error: "${this.state.error?.message}". What could cause this and how do I fix it?`
                   );
                   this.setState({ hasError: false, error: null });

--- a/src/kubeview/components/agent/ThinkingIndicator.tsx
+++ b/src/kubeview/components/agent/ThinkingIndicator.tsx
@@ -12,7 +12,7 @@ interface ThinkingIndicatorProps {
   completedTools?: Set<string>;
   /** Skills that completed (for checkmark display) */
   completedSkills?: Set<string>;
-  /** Compact mode for InlineAgent (no border glow, smaller) */
+  /** Compact mode (no border glow, smaller) */
   compact?: boolean;
 }
 

--- a/src/kubeview/components/feedback/Toast.tsx
+++ b/src/kubeview/components/feedback/Toast.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
 import { X, CheckCircle2, XCircle, AlertTriangle, Undo2, ShieldX, WifiOff, ServerCrash, Bot } from 'lucide-react';
 import { useUIStore } from '../../store/uiStore';
-import { useAgentStore } from '../../store/agentStore';
 import { cn } from '@/lib/utils';
+import { askPulse } from '../../engine/askPulse';
 
 interface ToastProps {
   id: string;
@@ -66,8 +66,7 @@ function Toast({ id: _id, type, title, detail, duration, action, category, sugge
   }[type];
 
   const handleAskAI = () => {
-    useUIStore.getState().expandAISidebar(); useUIStore.getState().setAISidebarMode('chat');
-    useAgentStore.getState().connectAndSend(
+    askPulse(
       `I got this error: "${title}". ${detail || ''}. What does this mean and how can I fix it?`
     );
     handleClose();

--- a/src/kubeview/components/onboarding/GateCard.tsx
+++ b/src/kubeview/components/onboarding/GateCard.tsx
@@ -4,10 +4,9 @@ import {
   Loader2, RefreshCw, ShieldCheck, Bot, ArrowRight,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { useUIStore } from '../../store/uiStore';
-import { useAgentStore } from '../../store/agentStore';
 import { useNavigateTab } from '../../hooks/useNavigateTab';
 import type { GateStatus, ReadinessGate, GateResult } from '../../engine/readiness/types';
+import { askPulse } from '../../engine/askPulse';
 
 interface GateCardProps {
   gate: ReadinessGate;
@@ -95,8 +94,7 @@ export function GateCard({ gate, result, waived, waiverReason, onReVerify, onWai
             {(status === 'failed' || status === 'needs_attention') && (
               <button
                 onClick={() => {
-                  useUIStore.getState().expandAISidebar(); useUIStore.getState().setAISidebarMode('chat');
-                  useAgentStore.getState().connectAndSend(
+                  askPulse(
                     `Fix this production readiness issue:\n\n"${gate.title}": ${result?.detail || gate.whyItMatters}\n\n${result?.fixGuidance || ''}\n\nPlease fix this or generate the required YAML configuration.`
                   );
                 }}

--- a/src/kubeview/components/onboarding/__tests__/GateCard.test.tsx
+++ b/src/kubeview/components/onboarding/__tests__/GateCard.test.tsx
@@ -146,7 +146,8 @@ describe('GateCard', () => {
     render(<GateCard gate={makeGate()} result={makeResult({ status: 'failed', detail: 'Bad config' })} />);
     fireEvent.click(screen.getByText('Fix with AI'));
     expect(mockOpenDock).toHaveBeenCalled();
-    expect(mockConnectAndSend).toHaveBeenCalledWith(expect.stringContaining('TLS Configured'));
+    // askPulse forwards an optional resource context; none applies here.
+    expect(mockConnectAndSend).toHaveBeenCalledWith(expect.stringContaining('TLS Configured'), undefined);
   });
 
   it('toggles expanded state on click', () => {

--- a/src/kubeview/hooks/useAgentSession.ts
+++ b/src/kubeview/hooks/useAgentSession.ts
@@ -108,7 +108,9 @@ const initialState: SessionState = {
  * Scoped agent session hook — each instance creates its own AgentClient
  * and WebSocket connection, independent from the global agentStore.
  *
- * Used by InlineAgent and AmbientInsight for isolated conversations.
+ * No in-tree consumers today (InlineAgent, its last importer, was removed
+ * in #104) — kept for surfaces that need a conversation isolated from the
+ * global agentStore.
  */
 export function useAgentSession(options: UseAgentSessionOptions = {}): AgentSession {
   const { mode = 'sre', autoConnect = true, context, maxMessages = 50 } = options;

--- a/src/kubeview/styles/index.css
+++ b/src/kubeview/styles/index.css
@@ -317,7 +317,7 @@
   flex-shrink: 0;
 }
 
-/* Glowing orb — compact (InlineAgent) */
+/* Glowing orb — compact (ThinkingIndicator compact mode) */
 .thinking-orb {
   width: 6px;
   height: 6px;

--- a/src/kubeview/views/CustomView.tsx
+++ b/src/kubeview/views/CustomView.tsx
@@ -4,7 +4,6 @@ import { useNavigateTab } from '../hooks/useNavigateTab';
 import { ChartEditPopover } from '../components/agent/ChartEditPopover';
 import { useCustomViewStore } from '../store/customViewStore';
 import { useUIStore } from '../store/uiStore';
-import { useAgentStore } from '../store/agentStore';
 import { AgentComponentRenderer } from '../components/agent/AgentComponentRenderer';
 import { EmptyState } from '../components/primitives/EmptyState';
 import { ErrorBoundary } from '../components/ErrorBoundary';
@@ -19,6 +18,7 @@ import { Responsive, verticalCompactor, useContainerWidth } from 'react-grid-lay
 import type { Layout, LayoutItem } from 'react-grid-layout';
 import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
+import { askPulse } from '../engine/askPulse';
 
 /* Layout is backend-authoritative. The engine computes positions
    via compute_layout() and the frontend renders them verbatim.
@@ -349,9 +349,7 @@ export default function CustomView() {
             </button>
             <button
               onClick={() => {
-                useUIStore.getState().expandAISidebar();
-                useUIStore.getState().setAISidebarMode('chat');
-                useAgentStore.getState().connectAndSend(`Update my view "${view.title}" (ID: ${view.id}). It has ${view.layout.length} widgets. Use get_view_details("${view.id}") to see the current widgets, then modify as needed.`);
+                askPulse(`Update my view "${view.title}" (ID: ${view.id}). It has ${view.layout.length} widgets. Use get_view_details("${view.id}") to see the current widgets, then modify as needed.`);
               }}
               className="p-1.5 rounded-sm bg-violet-700 hover:bg-violet-600 text-white transition-colors"
               title="Edit with AI"
@@ -383,9 +381,9 @@ export default function CustomView() {
             title="No widgets yet"
             description="Ask the agent to add widgets to this dashboard."
             aiPrompts={[
-              { label: 'Add a table of pods with high restart counts', onAsk: () => { useAgentStore.getState().connectAndSend('Add a data_table widget showing pods with the most restarts'); useUIStore.getState().expandAISidebar(); useUIStore.getState().setAISidebarMode('chat'); } },
-              { label: 'Show CPU and memory trends', onAsk: () => { useAgentStore.getState().connectAndSend('Add chart widgets showing CPU utilization and memory usage trends'); useUIStore.getState().expandAISidebar(); useUIStore.getState().setAISidebarMode('chat'); } },
-              { label: 'Add a deployment status grid', onAsk: () => { useAgentStore.getState().connectAndSend('Add a status_list widget showing all deployments with their health status'); useUIStore.getState().expandAISidebar(); useUIStore.getState().setAISidebarMode('chat'); } },
+              { label: 'Add a table of pods with high restart counts', onAsk: () => { askPulse('Add a data_table widget showing pods with the most restarts'); } },
+              { label: 'Show CPU and memory trends', onAsk: () => { askPulse('Add chart widgets showing CPU utilization and memory usage trends'); } },
+              { label: 'Add a deployment status grid', onAsk: () => { askPulse('Add a status_list widget showing all deployments with their health status'); } },
             ]}
           />
         ) : (

--- a/src/kubeview/views/SecurityView.tsx
+++ b/src/kubeview/views/SecurityView.tsx
@@ -14,10 +14,9 @@ import { Panel } from '../components/primitives/Panel';
 import type { K8sResource } from '../engine/renderers';
 import type { ClusterRoleBinding, Namespace, Subject } from '../engine/types';
 import { useClusterStore } from '../store/clusterStore';
-import { useUIStore } from '../store/uiStore';
-import { useAgentStore } from '../store/agentStore';
 import { MetricGrid } from '../components/primitives/MetricGrid';
 import { Card } from '../components/primitives/Card';
+import { askPulse } from '../engine/askPulse';
 
 interface SecurityAuditCheck {
   id: string;
@@ -301,11 +300,7 @@ export default function SecurityView() {
             ].map((prompt) => (
               <button
                 key={prompt}
-                onClick={() => {
-                  useUIStore.getState().expandAISidebar();
-                  useUIStore.getState().setAISidebarMode('chat');
-                  useAgentStore.getState().connectAndSend(prompt);
-                }}
+                onClick={() => askPulse(prompt)}
                 className="px-2.5 py-1 text-xs rounded-sm bg-slate-800 text-slate-300 hover:bg-indigo-900/40 hover:text-indigo-300 border border-slate-700 hover:border-indigo-700/50 transition-colors"
               >
                 {prompt}

--- a/src/kubeview/views/ViewsManagement.tsx
+++ b/src/kubeview/views/ViewsManagement.tsx
@@ -4,11 +4,11 @@ import { useNavigate } from 'react-router-dom';
 import { LayoutDashboard, Trash2, Share2, ExternalLink, Check, Bot, Loader2, History, Undo2, X, Download, Upload } from 'lucide-react';
 import { useCustomViewStore } from '../store/customViewStore';
 import { useUIStore } from '../store/uiStore';
-import { useAgentStore } from '../store/agentStore';
 import { EmptyState } from '../components/primitives/EmptyState';
 import { ConfirmDialog } from '../components/feedback/ConfirmDialog';
 import { formatRelativeTime } from '../engine/formatters';
 import type { ViewSpec } from '../engine/agentComponents';
+import { askPulse } from '../engine/askPulse';
 
 const AGENT_BASE = '/api/agent';
 
@@ -218,10 +218,10 @@ export default function ViewsManagement({ embedded = false }: { embedded?: boole
               title="No views yet"
               description="Ask the AI to build any dashboard you need."
               aiPrompts={[
-                { label: 'Node health dashboard', onAsk: () => { useAgentStore.getState().connectAndSend('Create a dashboard showing node health: CPU/memory utilization, pod density, and node conditions'); useUIStore.getState().expandAISidebar(); useUIStore.getState().setAISidebarMode('chat'); } },
-                { label: 'Workload overview', onAsk: () => { useAgentStore.getState().connectAndSend('Create a dashboard showing deployment status, pod restart trends, and OOM kills'); useUIStore.getState().expandAISidebar(); useUIStore.getState().setAISidebarMode('chat'); } },
-                { label: 'Security posture', onAsk: () => { useAgentStore.getState().connectAndSend('Create a dashboard showing security audit score, cluster-admin bindings, unprotected namespaces, and SCC usage'); useUIStore.getState().expandAISidebar(); useUIStore.getState().setAISidebarMode('chat'); } },
-                { label: 'Cost & capacity', onAsk: () => { useAgentStore.getState().connectAndSend('Create a dashboard showing resource utilization ratios, capacity projections, and idle workloads'); useUIStore.getState().expandAISidebar(); useUIStore.getState().setAISidebarMode('chat'); } },
+                { label: 'Node health dashboard', onAsk: () => { askPulse('Create a dashboard showing node health: CPU/memory utilization, pod density, and node conditions'); } },
+                { label: 'Workload overview', onAsk: () => { askPulse('Create a dashboard showing deployment status, pod restart trends, and OOM kills'); } },
+                { label: 'Security posture', onAsk: () => { askPulse('Create a dashboard showing security audit score, cluster-admin bindings, unprotected namespaces, and SCC usage'); } },
+                { label: 'Cost & capacity', onAsk: () => { askPulse('Create a dashboard showing resource utilization ratios, capacity projections, and idle workloads'); } },
               ]}
             />
           </div>

--- a/src/kubeview/views/admin/ErrorsTab.tsx
+++ b/src/kubeview/views/admin/ErrorsTab.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 import { AlertCircle, CheckCircle2, Trash2, Bot, ShieldX, WifiOff, ServerCrash, XCircle, Filter } from 'lucide-react';
 import { useErrorStore, type TrackedError } from '../../store/errorStore';
 import type { ErrorCategory } from '../../engine/errors';
-import { useUIStore } from '../../store/uiStore';
-import { useAgentStore } from '../../store/agentStore';
 import { cn } from '@/lib/utils';
+import { askPulse } from '../../engine/askPulse';
 
 const CATEGORY_CONFIG: Record<string, { label: string; icon: typeof AlertCircle; color: string }> = {
   permission: { label: 'Permission', icon: ShieldX, color: 'text-red-400' },
@@ -39,9 +38,7 @@ export function ErrorsTab() {
   const resolvedCount = errors.length - unresolvedCount;
 
   const handleAskAI = (error: TrackedError) => {
-    useUIStore.getState().expandAISidebar();
-    useUIStore.getState().setAISidebarMode('chat');
-    useAgentStore.getState().connectAndSend(
+    askPulse(
       `I got this error: "${error.userMessage}". ${error.message}. What does this mean and how can I fix it?`
     );
   };

--- a/src/kubeview/views/admin/__tests__/ErrorsTab.test.tsx
+++ b/src/kubeview/views/admin/__tests__/ErrorsTab.test.tsx
@@ -168,8 +168,10 @@ describe('ErrorsTab', () => {
 
     fireEvent.click(screen.getByText('Ask AI'));
     expect(mockExpandAISidebar).toHaveBeenCalled();
+    // askPulse forwards an optional resource context; none applies here.
     expect(mockConnectAndSend).toHaveBeenCalledWith(
       expect.stringContaining('Cannot list pods'),
+      undefined,
     );
   });
 

--- a/src/kubeview/views/inbox/TaskDetailDrawer.tsx
+++ b/src/kubeview/views/inbox/TaskDetailDrawer.tsx
@@ -18,7 +18,7 @@ import {
   type InvestigationReport,
 } from '../../engine/inboxApi';
 import { useInboxStore } from '../../store/inboxStore';
-import { useAgentStore } from '../../store/agentStore';
+import { askPulse } from '../../engine/askPulse';
 import { useUIStore } from '../../store/uiStore';
 import { useActionPlanStore, resolveStepStatus, isStepDone, type ActionPlanStep } from '../../store/actionPlanStore';
 import { InboxLifecycleStepper } from './InboxLifecycle';
@@ -143,9 +143,7 @@ function ActionPlanSection({
     useActionPlanStore.getState().startStep(stepIdx);
     advanceToInProgress();
     recordInboxStep(item.id, 'execute', stepIdx, steps[stepIdx]?.title ?? '').catch(() => {});
-    useAgentStore.getState().connectAndSend(prompt);
-    useUIStore.getState().expandAISidebar();
-    useUIStore.getState().setAISidebarMode('chat');
+    askPulse(prompt);
     onClose();
   };
 
@@ -356,11 +354,9 @@ export function TaskDetailDrawer({
 
   const handleInvestigate = () => {
     if (item.status === 'claimed') advanceStatus(item.id, 'in_progress');
-    useAgentStore.getState().connectAndSend(buildInvestigatePrompt(item));
+    askPulse(buildInvestigatePrompt(item));
     onClose();
     const uiState = useUIStore.getState();
-    uiState.expandAISidebar();
-    uiState.setAISidebarMode('chat');
     if (window.innerWidth < 1200) {
       uiState.setActiveTab('agent');
     }

--- a/src/kubeview/views/inbox/__tests__/EpisodePanel.test.tsx
+++ b/src/kubeview/views/inbox/__tests__/EpisodePanel.test.tsx
@@ -32,13 +32,6 @@ vi.mock('../../../engine/episodeApi', () => ({
   dismissEpisode: (...a: unknown[]) => dismissEpisode(...a),
 }));
 
-// The agent panel opens a WebSocket; not what these tests are about.
-vi.mock('../../../components/agent/InlineAgent', () => ({
-  InlineAgent: ({ initialPrompt }: { initialPrompt?: string }) => (
-    <div data-testid="inline-agent">{initialPrompt}</div>
-  ),
-}));
-
 const EPISODE = {
   id: 'ep-1',
   status: 'open' as const,

--- a/src/kubeview/views/pulse/ReportTab.tsx
+++ b/src/kubeview/views/pulse/ReportTab.tsx
@@ -11,8 +11,7 @@ import { cn } from '@/lib/utils';
 import { k8sList, k8sGet } from '../../engine/query';
 import { safeQuery } from '../../engine/safeQuery';
 import { AIIconStatic, AI_ACCENT, PromptPill } from '../../components/agent/AIBranding';
-import { useUIStore } from '../../store/uiStore';
-import { useAgentStore } from '../../store/agentStore';
+import { askPulse } from '../../engine/askPulse';
 import { generateSmartPrompts } from '../../engine/smartPrompts';
 import { parseResourceValue } from '../../engine/formatting';
 import { queryInstant } from '../../components/metrics/prometheus';
@@ -229,16 +228,10 @@ export function ReportTab({ nodes, allPods, deployments, pvcs, operators, go }: 
   const [showScoreDetails, setShowScoreDetails] = useState(false);
   const [expandedItems, setExpandedItems] = useState<Set<string>>(new Set());
   const [zenDismissed, setZenDismissed] = useState(() => sessionStorage.getItem('pulse-zen-dismissed') === 'true');
-  const expandAISidebar = useUIStore((s) => s.expandAISidebar);
-  const setAISidebarMode = useUIStore((s) => s.setAISidebarMode);
-  const connectAndSend = useAgentStore((s) => s.connectAndSend);
-
   /** Open AI sidebar in chat mode with a prompt */
   const askAgent = useCallback((prompt: string) => {
-    connectAndSend(prompt);
-    expandAISidebar();
-    setAISidebarMode('chat');
-  }, [connectAndSend, expandAISidebar, setAISidebarMode]);
+    askPulse(prompt);
+  }, []);
 
   const toggleExpanded = (key: string) => {
     setExpandedItems(prev => {


### PR DESCRIPTION
Applies the three review findings on #103/#104: migrates the ~12 hand-rolled expandAISidebar/setAISidebarMode/connectAndSend triples to the askPulse() helper (ErrorBoundary keeps its cycle-avoiding lazy require, now of askPulse), removes the dead InlineAgent mock from EpisodePanel.test.tsx, and fixes the three stale InlineAgent comments. pnpm verify green: 2,225 tests, type-check + lint clean, build compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)