### PR TITLE
The queue shows its math, its chronic offenders, and their way out

### DIFF
--- a/src/kubeview/engine/inboxApi.ts
+++ b/src/kubeview/engine/inboxApi.ts
@@ -80,6 +80,23 @@ async function _fetch<T>(url: string, init?: RequestInit): Promise<T> {
   return res.json();
 }
 
+/**
+ * Draft a runbook skill from an investigated item.
+ *
+ * The closure path for chronic work: the item's investigation is folded into
+ * the skill lifecycle and lands as an unreviewed draft in Toolbox → Skills.
+ * A 409 means the item has no investigation yet — that's an answer, not an
+ * error, so surface the server's message.
+ */
+export async function createRunbookFromItem(id: string): Promise<{ skill: string; path: string }> {
+  const res = await agentFetch(`${AGENT_BASE}/inbox/${encodeURIComponent(id)}/runbook`, { method: 'POST' });
+  const body = await res.json().catch(() => null);
+  if (!res.ok) {
+    throw new Error(body?.detail || `Runbook draft failed: ${res.status} ${res.statusText}`);
+  }
+  return body as { skill: string; path: string };
+}
+
 export async function fetchInbox(filters: InboxFilters = {}): Promise<InboxResponse> {
   const params = new URLSearchParams();
   for (const [key, value] of Object.entries(filters)) {

--- a/src/kubeview/views/inbox/InboxItem.tsx
+++ b/src/kubeview/views/inbox/InboxItem.tsx
@@ -46,6 +46,60 @@ function getSourceLabel(createdBy: string): string {
   return 'Manual';
 }
 
+/**
+ * One worded chip for the agent's relationship to this item.
+ *
+ * This used to be up to six same-sized colored dots (reviewing, cleared,
+ * triaged, review-failed, pending-approval, archived) whose meanings lived
+ * only in hover tooltips — color was the sole channel, and at a glance they
+ * were indistinguishable. One state wins, it gets a word, and the detail
+ * stays in the tooltip.
+ */
+function agentStateChip(item: InboxItemType): { label: string; cls: string; tooltip: string; pulse?: boolean } | null {
+  const md = item.metadata || {};
+  if (item.status === 'agent_reviewing') {
+    return { label: 'Reviewing…', cls: 'bg-violet-900/40 text-violet-300 border-violet-700/40', tooltip: 'Agent is investigating', pulse: true };
+  }
+  if (item.status === 'agent_review_failed') {
+    return { label: 'Review failed', cls: 'bg-red-900/40 text-red-300 border-red-700/40', tooltip: String(md.agent_error || 'Agent analysis failed') };
+  }
+  if (item.status === 'agent_cleared') {
+    return { label: 'Cleared', cls: 'bg-emerald-900/30 text-emerald-400 border-emerald-800/30', tooltip: String(md.dismiss_reason || 'Cleared by agent') };
+  }
+  if (md.has_pending_approval) {
+    return { label: 'Approval waiting', cls: 'bg-orange-900/40 text-orange-300 border-orange-700/40', tooltip: 'A proposed fix is waiting on you' };
+  }
+  if (item.status === 'archived' && md.archived_reason) {
+    return { label: 'Archived', cls: 'bg-slate-800 text-slate-400 border-slate-700', tooltip: String(md.archived_reason) };
+  }
+  if (md.triaged) {
+    return { label: `Triaged · ${String(md.triage_urgency || 'can-wait')}`, cls: 'bg-violet-900/30 text-violet-300 border-violet-800/30', tooltip: `AI: ${String(md.triage_action || 'triaged')}` };
+  }
+  return null;
+}
+
+function ordinal(n: number): string {
+  const s = ['th', 'st', 'nd', 'rd'];
+  const v = n % 100;
+  return n + (s[(v - 20) % 10] || s[v] || s[0]);
+}
+
+/** The math behind the rank, so line one can explain itself. */
+function priorityTooltip(factors: Record<string, unknown>): string {
+  const f = (k: string) => Number(factors[k] ?? 0);
+  const lines = [
+    `${String(factors.severity)} ×${f('severity_weight')} · ${String(factors.layer)} layer ×${f('layer_weight')}`,
+    `confidence ${f('confidence')} · noise ${f('noise_score')} → base ${f('base')}`,
+  ];
+  const bonuses: string[] = [];
+  if (f('age_bonus') > 0) bonuses.push(`age +${f('age_bonus')}`);
+  if (f('novelty_bonus') > 0) bonuses.push(`novelty +${f('novelty_bonus')}`);
+  if (f('due_bonus') > 0) bonuses.push(`due +${f('due_bonus')}`);
+  if (bonuses.length) lines.push(bonuses.join(' · '));
+  lines.push(`priority ${f('total')}`);
+  return lines.join('\n');
+}
+
 export function InboxItem({
   item,
   focused,
@@ -64,7 +118,10 @@ export function InboxItem({
   const severity: InboxSeverity = (item.severity as InboxSeverity) || 'info';
   const SeverityIcon = SEVERITY_ICON[severity] || Info;
   const isPinned = item.pinned_by.length > 0;
-  const hasApproval = !!item.metadata?.has_pending_approval;
+  const stateChip = agentStateChip(item);
+  const recurrence = Number(item.metadata?.recurrence_30d ?? 0);
+  const sloImpact = (item.metadata?.slo_impact as Array<{ service: string; slo_type: string }> | undefined) ?? [];
+  const priorityFactors = item.metadata?.priority_factors as Record<string, unknown> | undefined;
 
   const handleDismiss = () => {
     setConfirmDismiss(false);
@@ -100,34 +157,32 @@ export function InboxItem({
               {item.namespace && (
                 <Badge variant="outline" className="text-xs">{item.namespace}</Badge>
               )}
-              {item.status === 'agent_reviewing' && (
-                <Tooltip content="Agent is investigating">
-                  <span className="w-2 h-2 rounded-full bg-violet-500 animate-pulse shrink-0" />
+              {stateChip && (
+                <Tooltip content={stateChip.tooltip}>
+                  <span
+                    className={cn(
+                      'text-[10px] px-1.5 py-0.5 rounded-full border shrink-0 whitespace-nowrap',
+                      stateChip.cls,
+                      stateChip.pulse && 'animate-pulse',
+                    )}
+                  >
+                    {stateChip.label}
+                  </span>
                 </Tooltip>
               )}
-              {item.status === 'agent_cleared' && (
-                <Tooltip content={String(item.metadata?.dismiss_reason || 'Cleared by agent')}>
-                  <span className="w-2 h-2 rounded-full bg-emerald-500 shrink-0" />
+              {recurrence >= 2 && (
+                <Tooltip content={`This condition has come back — ${ordinal(recurrence)} visit in 30 days. Chronic work deserves a runbook, not another triage.`}>
+                  <span className="text-[10px] px-1.5 py-0.5 rounded-full border bg-amber-900/40 text-amber-300 border-amber-700/40 shrink-0 whitespace-nowrap">
+                    {ordinal(recurrence)} in 30d
+                  </span>
                 </Tooltip>
               )}
-              {item.status === 'archived' && !!item.metadata?.archived_reason && (
-                /* Work that moved on its own has to say why it moved. */
-                <Tooltip content={String(item.metadata.archived_reason)}>
-                  <span className="w-2 h-2 rounded-full bg-slate-500 shrink-0" />
+              {sloImpact.length > 0 && (
+                <Tooltip content={`Backs a registered SLO: ${sloImpact.map((s) => `${s.service} ${s.slo_type}`).join(', ')}`}>
+                  <span className="text-[10px] px-1.5 py-0.5 rounded-full border bg-sky-900/40 text-sky-300 border-sky-700/40 shrink-0 whitespace-nowrap">
+                    SLO · {String(sloImpact[0].service)}
+                  </span>
                 </Tooltip>
-              )}
-              {item.status === 'agent_review_failed' && (
-                <Tooltip content={String(item.metadata?.agent_error || 'Agent analysis failed')}>
-                  <span className="w-2 h-2 rounded-full bg-red-500 shrink-0" />
-                </Tooltip>
-              )}
-              {item.status !== 'agent_reviewing' && item.status !== 'agent_cleared' && !!item.metadata?.triaged && (
-                <Tooltip content={`AI: ${String(item.metadata.triage_action || 'triaged')} · ${String(item.metadata.triage_urgency || '')}`}>
-                  <span className="w-2 h-2 rounded-full bg-violet-500 shrink-0" />
-                </Tooltip>
-              )}
-              {hasApproval && (
-                <span className="w-2 h-2 rounded-full bg-orange-500 shrink-0" title="Pending approval" />
               )}
               {isPinned && (
                 <Pin className="w-3.5 h-3.5 text-yellow-500 shrink-0" />
@@ -151,6 +206,16 @@ export function InboxItem({
               <Tooltip content="Green = done · Purple = current · Gray = upcoming" side="bottom">
                 <span><InboxLifecycleBadge itemType={item.item_type} status={item.status} /></span>
               </Tooltip>
+              {priorityFactors && (
+                <>
+                  <span>·</span>
+                  {/* Why this rank. A queue whose line one can't explain itself
+                      doesn't get trusted — the score's inputs are one hover away. */}
+                  <Tooltip content={<span className="whitespace-pre-line">{priorityTooltip(priorityFactors)}</span>} side="bottom">
+                    <span className="tabular-nums cursor-default">P {Number(priorityFactors.total ?? item.priority_score).toFixed(1)}</span>
+                  </Tooltip>
+                </>
+              )}
             </div>
             {(item.status === 'resolved' || item.status === 'agent_cleared') && item.metadata?.dismiss_reason ? (
               <p className="text-xs text-emerald-500/70 mt-1 line-clamp-1">

--- a/src/kubeview/views/inbox/TaskDetailDrawer.tsx
+++ b/src/kubeview/views/inbox/TaskDetailDrawer.tsx
@@ -3,7 +3,7 @@ import {
   Clock, User, Calendar, Tag, Bot, Loader2,
   ArrowRight, RotateCcw, Archive, Search, CheckCircle2, ShieldCheck,
   ChevronDown, ChevronRight, Play, SkipForward, XCircle, AlertTriangle,
-  MessageSquare, RefreshCw,
+  MessageSquare, RefreshCw, BookOpen,
 } from 'lucide-react';
 import { DrawerShell } from '../../components/primitives/DrawerShell';
 import { Badge } from '../../components/primitives/Badge';
@@ -12,6 +12,7 @@ import { Tooltip } from '../../components/primitives/Tooltip';
 import { ConfirmDialog } from '../../components/feedback/ConfirmDialog';
 import { formatRelativeTime } from '../../engine/formatters';
 import {
+  createRunbookFromItem,
   fetchInboxInvestigation,
   recordInboxStep,
   type InboxItem,
@@ -329,6 +330,7 @@ export function TaskDetailDrawer({
   const advanceStatus = useInboxStore((s) => s.advanceStatus);
 
   const [confirmDismiss, setConfirmDismiss] = useState(false);
+  const [runbookBusy, setRunbookBusy] = useState(false);
   const [investigation, setInvestigation] = useState<InvestigationReport | null>(null);
 
   useEffect(() => {
@@ -363,6 +365,28 @@ export function TaskDetailDrawer({
   };
 
   const handleAdvance = (status: string) => advanceStatus(item.id, status);
+
+  const hasInvestigation = Boolean(item.metadata?.investigation_summary || item.metadata?.suspected_cause);
+
+  const handleCreateRunbook = async () => {
+    setRunbookBusy(true);
+    try {
+      const result = await createRunbookFromItem(item.id);
+      useUIStore.getState().addToast({
+        type: 'success',
+        title: `Runbook drafted as skill '${result.skill}'`,
+        detail: 'It stays out of routing until approved — review it in Toolbox → Skills.',
+      });
+    } catch (e) {
+      useUIStore.getState().addToast({
+        type: 'error',
+        title: 'Runbook draft failed',
+        detail: e instanceof Error ? e.message : 'Unknown error',
+      });
+    } finally {
+      setRunbookBusy(false);
+    }
+  };
 
   const handleResolve = () => {
     resolve(item.id);
@@ -566,6 +590,16 @@ export function TaskDetailDrawer({
             <Button size="sm" onClick={handleInvestigate}>
               <Bot className="w-4 h-4 mr-1" />
               Investigate with AI
+            </Button>
+          )}
+
+          {/* Closure for chronic work: an investigated item can leave the
+              queue as a durable skill instead of returning as a fresh
+              incident. The draft lands unreviewed in Toolbox → Skills. */}
+          {hasInvestigation && (
+            <Button size="sm" variant="ghost" onClick={handleCreateRunbook} disabled={runbookBusy}>
+              <BookOpen className="w-4 h-4 mr-1" />
+              {runbookBusy ? 'Drafting…' : 'Create Runbook'}
             </Button>
           )}
 

--- a/src/kubeview/views/inbox/__tests__/InboxProofClosure.test.tsx
+++ b/src/kubeview/views/inbox/__tests__/InboxProofClosure.test.tsx
@@ -1,0 +1,198 @@
+// @vitest-environment jsdom
+/**
+ * Proof and closure on the inbox queue.
+ *
+ * Proof: the ranked list showed an ordering the operator could not
+ * interrogate — the priority factors now ride in metadata and render as a
+ * hoverable "P n.n" on the card. The six status dots whose meanings lived
+ * only in tooltips collapse into one worded chip.
+ *
+ * Closure: a chronic condition looked new on every visit; it now carries its
+ * 30-day visit ordinal, and an investigated item can leave the queue as a
+ * draft runbook skill through the existing approval gate.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+
+vi.mock('@/lib/utils', () => ({ cn: (...args: unknown[]) => args.filter(Boolean).join(' ') }));
+
+const addToast = vi.fn();
+vi.mock('../../../store/inboxStore', () => ({
+  useInboxStore: vi.fn((selector: (s: Record<string, unknown>) => unknown) => {
+    const state = {
+      setSelectedItem: vi.fn(),
+      acknowledge: vi.fn(),
+      claim: vi.fn(),
+      snooze: vi.fn(),
+      dismiss: vi.fn(),
+      pin: vi.fn(),
+      resolve: vi.fn(),
+      restore: vi.fn(),
+      advanceStatus: vi.fn(),
+    };
+    return selector(state);
+  }),
+}));
+vi.mock('../../../store/agentStore', () => ({
+  useAgentStore: { getState: () => ({ connectAndSend: vi.fn() }) },
+}));
+vi.mock('../../../store/uiStore', () => ({
+  useUIStore: {
+    getState: () => ({
+      expandAISidebar: vi.fn(),
+      setAISidebarMode: vi.fn(),
+      addToast,
+      setActiveTab: vi.fn(),
+      // agentFetch's checkAuth() reads these on every response.
+      addDegradedReason: vi.fn(),
+      removeDegradedReason: vi.fn(),
+    }),
+  },
+}));
+
+import { InboxItem } from '../InboxItem';
+import type { InboxItem as InboxItemType } from '../../../engine/inboxApi';
+
+function makeItem(overrides: Partial<InboxItemType> = {}): InboxItemType {
+  return {
+    id: 'i-1',
+    item_type: 'task',
+    status: 'new',
+    title: 'Pod crashlooping',
+    summary: 'restarts',
+    severity: 'critical',
+    priority_score: 7.2,
+    confidence: 0.9,
+    noise_score: 0,
+    namespace: 'production',
+    resources: [],
+    correlation_key: 'crashloop:x',
+    claimed_by: null,
+    claimed_at: null,
+    created_by: 'system:monitor',
+    due_date: null,
+    finding_id: null,
+    view_id: null,
+    pinned_by: [],
+    metadata: {},
+    created_at: Math.floor(Date.now() / 1000) - 60,
+    updated_at: Math.floor(Date.now() / 1000),
+    ...overrides,
+  } as InboxItemType;
+}
+
+describe('one worded chip instead of dot soup', () => {
+  afterEach(cleanup);
+
+  it('agent_cleared renders a worded chip, not a bare dot', () => {
+    render(<InboxItem item={makeItem({ status: 'agent_cleared', metadata: { dismiss_reason: 'noise' } })} />);
+    expect(screen.getByText('Cleared')).toBeDefined();
+  });
+
+  it('reviewing wins over triaged when both apply', () => {
+    render(
+      <InboxItem
+        item={makeItem({ status: 'agent_reviewing', metadata: { triaged: true, triage_urgency: 'soon' } })}
+      />,
+    );
+    expect(screen.getByText('Reviewing…')).toBeDefined();
+    expect(screen.queryByText(/Triaged/)).toBeNull();
+  });
+
+  it('triaged carries its urgency as a word', () => {
+    render(<InboxItem item={makeItem({ metadata: { triaged: true, triage_urgency: 'soon' } })} />);
+    expect(screen.getByText('Triaged · soon')).toBeDefined();
+  });
+
+  it('a plain new item shows no state chip at all', () => {
+    render(<InboxItem item={makeItem()} />);
+    expect(screen.queryByText(/Reviewing|Cleared|Triaged|Approval|Archived/)).toBeNull();
+  });
+});
+
+describe('proof: the rank explains itself', () => {
+  afterEach(cleanup);
+
+  it('renders the priority with its factors one hover away', () => {
+    render(
+      <InboxItem
+        item={makeItem({
+          metadata: {
+            priority_factors: {
+              severity: 'critical', severity_weight: 4, layer: 'infrastructure', layer_weight: 2,
+              confidence: 0.9, noise_score: 0, base: 7.2, age_bonus: 0.1, novelty_bonus: 1.4, due_bonus: 0, total: 8.7,
+            },
+          },
+        })}
+      />,
+    );
+    expect(screen.getByText('P 8.7')).toBeDefined();
+  });
+
+  it('no factors, no unexplained number', () => {
+    render(<InboxItem item={makeItem()} />);
+    expect(screen.queryByText(/^P \d/)).toBeNull();
+  });
+
+  it('shows which SLO the item backs', () => {
+    render(
+      <InboxItem
+        item={makeItem({ metadata: { slo_impact: [{ service: 'payment-api', slo_type: 'availability' }] } })}
+      />,
+    );
+    expect(screen.getByText('SLO · payment-api')).toBeDefined();
+  });
+});
+
+describe('closure: chronic work is named as chronic', () => {
+  afterEach(cleanup);
+
+  it('a repeat visit carries its ordinal', () => {
+    render(<InboxItem item={makeItem({ metadata: { recurrence_30d: 3 } })} />);
+    expect(screen.getByText('3rd in 30d')).toBeDefined();
+  });
+
+  it('a first visit claims nothing', () => {
+    render(<InboxItem item={makeItem({ metadata: { recurrence_30d: 1 } })} />);
+    expect(screen.queryByText(/in 30d/)).toBeNull();
+  });
+});
+
+describe('closure: create runbook from the drawer', () => {
+  beforeEach(() => {
+    addToast.mockClear();
+    global.fetch = vi.fn() as unknown as typeof fetch;
+  });
+  afterEach(cleanup);
+
+  async function renderDrawer(metadata: Record<string, unknown>) {
+    (global.fetch as ReturnType<typeof vi.fn>).mockImplementation((url: string | Request) => {
+      const u = typeof url === 'string' ? url : url.url;
+      if (u.includes('/runbook')) {
+        return Promise.resolve({
+          ok: true, status: 200,
+          json: () => Promise.resolve({ skill: 'crashloop-payments', path: '/skills/crashloop-payments/skill.md' }),
+        });
+      }
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ steps: [] }) });
+    });
+    const { TaskDetailDrawer } = await import('../TaskDetailDrawer');
+    render(<TaskDetailDrawer item={makeItem({ metadata })} onClose={() => {}} />);
+  }
+
+  it('an investigated item offers Create Runbook and reports the draft', async () => {
+    await renderDrawer({ investigation_summary: 'OOM under peak load', suspected_cause: 'limit too low' });
+    const btn = await screen.findByText('Create Runbook');
+    fireEvent.click(btn);
+    await waitFor(() => expect(addToast).toHaveBeenCalled());
+    const toast = addToast.mock.calls[0][0];
+    expect(toast.type).toBe('success');
+    expect(toast.title).toContain('crashloop-payments');
+  });
+
+  it('an uninvestigated item does not offer it', async () => {
+    await renderDrawer({});
+    expect(screen.queryByText('Create Runbook')).toBeNull();
+  });
+});


### PR DESCRIPTION
UI half of PulseSRE/pulse-agent#122 (Proof + Closure blockers from the inbox deep dive), with the chip consolidation from the UX review folded in: one worded agent-state chip replaces the six tooltip-only dots, a hoverable 'P n.n' exposes the priority factors, 'SLO · service' and recurrence-ordinal chips surface impact and chronicity, and the drawer gains Create Runbook wired to the new endpoint. 11 new tests; pnpm verify green (2,236 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)