### PR TITLE
Let the dev proxy forward a real identity to the agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,9 @@ OpenShift Pulse — a React/TypeScript dashboard for OpenShift Day-2 operations.
 ```bash
 # Dev server (requires `oc proxy --port=8001` running separately)
 pnpm dev                 # rspack dev server on port 9000
+# Admin-gated agent endpoints (fix approval, skill management) need a real
+# identity — the proxy's placeholder token hashes to user-<hash> and 403s:
+PULSE_USER_TOKEN=$(oc whoami -t) pnpm dev
 
 # Build
 pnpm build               # production build (~1s)

--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -201,7 +201,15 @@ export default defineConfig({
           ...(agentToken ? {
             headers: {
               'Authorization': `Bearer ${agentToken}`,
-              'X-Forwarded-Access-Token': 'e2e-test-user',
+              // The agent resolves the caller via TokenReview on this header.
+              // Against a real agent the placeholder literal fails that review
+              // and the caller becomes the pseudonym user-<hash> — which can
+              // never match PULSE_AGENT_ADMIN_USERS, so every admin-gated
+              // endpoint (fix approval, skill management) answers 403 in dev.
+              // Set PULSE_USER_TOKEN=$(oc whoami -t) to be yourself; the
+              // literal stays as the fallback for the e2e mock agent, which
+              // does not TokenReview.
+              'X-Forwarded-Access-Token': process.env.PULSE_USER_TOKEN || 'e2e-test-user',
             },
           } : {}),
         }];


### PR DESCRIPTION
The dev proxy's hardcoded `X-Forwarded-Access-Token: 'e2e-test-user'` fails TokenReview against a real agent and becomes the pseudonym `user-5451b787f74974ba` (= sha256 of the literal), which can never match `PULSE_AGENT_ADMIN_USERS` — so fix approval 403'd from `pnpm dev` regardless of who was signed in. `PULSE_USER_TOKEN=$(oc whoami -t) pnpm dev` now forwards the developer's own token; the literal stays as the e2e-mock fallback. Type-check + build verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)