### PR TITLE
Close half-open WebSockets without shouting about it

### DIFF
--- a/src/kubeview/engine/agentClient.ts
+++ b/src/kubeview/engine/agentClient.ts
@@ -8,6 +8,7 @@
  */
 
 import type { ComponentSpec } from './agentComponents';
+import { closeQuietly } from './wsClose';
 
 export type AgentMode = 'sre' | 'security' | 'monitor' | 'auto';
 
@@ -229,7 +230,7 @@ export class AgentClient {
     }
     this.reconnectAttempts = MAX_RECONNECT_ATTEMPTS; // prevent reconnect
     if (this.ws) {
-      this.ws.close();
+      closeQuietly(this.ws);
       this.ws = null;
     }
     this._connected = false;

--- a/src/kubeview/engine/monitorClient.ts
+++ b/src/kubeview/engine/monitorClient.ts
@@ -7,6 +7,8 @@
  * reduces polling frequency when the tab is hidden.
  */
 
+import { closeQuietly } from './wsClose';
+
 // ---- Types ----
 
 export interface ResourceRef {
@@ -208,7 +210,7 @@ export class MonitorClient {
     this.autoFixCategories = autoFixCategories;
 
     if (this.ws) {
-      this.ws.close();
+      closeQuietly(this.ws);
       this.ws = null;
     }
 
@@ -338,7 +340,7 @@ export class MonitorClient {
       this.visibilityHandler = null;
     }
     if (this.ws) {
-      this.ws.close();
+      closeQuietly(this.ws);
       this.ws = null;
     }
     this._connected = false;

--- a/src/kubeview/engine/watch.ts
+++ b/src/kubeview/engine/watch.ts
@@ -5,6 +5,7 @@
 
 import { K8S_BASE as BASE } from './gvr';
 import { getClusterBase } from './clusterConnection';
+import { closeQuietly } from './wsClose';
 const HEARTBEAT_INTERVAL = 45000; // 45 seconds
 const MAX_BACKOFF = 30000; // 30 seconds
 
@@ -287,9 +288,12 @@ export class WatchManager {
 
     this.stopHeartbeat(connection);
 
-    // Close WebSocket
+    // closeQuietly, not close(): StrictMode's dev double-mount tears down
+    // every first mount's watch while its socket is still CONNECTING, and a
+    // raw close() there logs "closed before the connection is established"
+    // for every watched resource on every page load.
     if (connection.ws) {
-      connection.ws.close();
+      closeQuietly(connection.ws);
       connection.ws = null;
     }
 

--- a/src/kubeview/engine/wsClose.ts
+++ b/src/kubeview/engine/wsClose.ts
@@ -1,0 +1,21 @@
+/**
+ * Close a WebSocket without console noise.
+ *
+ * Calling close() on a socket that is still CONNECTING is legal, but the
+ * browser logs "WebSocket is closed before the connection is established" —
+ * and React StrictMode's dev double-mount tears down every first mount's
+ * subscription exactly in that state, spamming the console with alarming
+ * non-errors on every page load (and sending at least one operator on a
+ * debugging detour). Deferring the close to onopen silences it; handlers are
+ * detached first so the throwaway socket can't deliver events.
+ */
+export function closeQuietly(ws: WebSocket): void {
+  if (ws.readyState === WebSocket.CONNECTING) {
+    ws.onmessage = null;
+    ws.onerror = null;
+    ws.onclose = null;
+    ws.onopen = () => ws.close();
+  } else {
+    ws.close();
+  }
+}


### PR DESCRIPTION
StrictMode's dev double-mount tears down first-mount subscriptions while their sockets are still CONNECTING; raw close() there logs 'closed before the connection is established' per watched resource per page load — harmless, but it reads like an outage (and caused a real debugging detour today). New `closeQuietly()` defers close to onopen and detaches handlers; all four teardown sites use it. pnpm verify green (2,236 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)