### PR TITLE
About page: what is running on this cluster, read from the cluster

### DIFF
--- a/src/kubeview/components/StatusBar.tsx
+++ b/src/kubeview/components/StatusBar.tsx
@@ -144,6 +144,13 @@ export function StatusBar() {
         {openTabCount > 0 && <span>{openTabCount} tab{openTabCount !== 1 ? 's' : ''}</span>}
         <span>{selectedNamespace === '*' ? 'all namespaces' : selectedNamespace}</span>
         <span>⌘K search · ⌘B browse</span>
+        <button
+          onClick={() => navigate('/about')}
+          className="px-1.5 py-0.5 rounded-sm text-slate-500 hover:text-slate-300 transition-colors"
+          title="About OpenShift Pulse — versions, images, links"
+        >
+          v{__APP_VERSION__}
+        </button>
       </div>
     </div>
   );

--- a/src/kubeview/engine/iconRegistry.ts
+++ b/src/kubeview/engine/iconRegistry.ts
@@ -62,6 +62,7 @@ import {
   Rocket,
   LayoutDashboard,
   Gauge,
+  Info,
 } from 'lucide-react';
 
 import type { LucideIcon } from 'lucide-react';
@@ -127,6 +128,7 @@ const iconRegistry: Record<string, LucideIcon> = {
   Rocket,
   LayoutDashboard,
   Gauge,
+  Info,
 };
 
 /**

--- a/src/kubeview/engine/navRegistry.ts
+++ b/src/kubeview/engine/navRegistry.ts
@@ -46,6 +46,7 @@ export const NAV_ITEMS: NavItem[] = [
   { id: 'admin', label: 'Administration', icon: 'Settings', path: '/admin', group: 'administration', subtitle: 'Config, updates, snapshots, quotas, certificates', keywords: ['config', 'updates', 'quotas', 'certificates', 'crds'], color: 'text-slate-400' },
   { id: 'identity', label: 'Identity & Access', icon: 'Shield', path: '/identity', group: 'administration', subtitle: 'Users, groups, RBAC, impersonation', keywords: ['users', 'groups', 'service', 'accounts', 'rbac', 'impersonation'], color: 'text-teal-400' },
   { id: 'readiness', label: 'Production Readiness', icon: 'Rocket', path: '/readiness', group: 'administration', subtitle: 'Readiness wizard — security, reliability, observability gates', keywords: ['readiness', 'wizard', 'reliability', 'observability', 'gates', 'production'], color: 'text-amber-400' },
+  { id: 'about', label: 'About Pulse', icon: 'Info', path: '/about', group: 'administration', subtitle: 'Versions, images, and links for everything Pulse runs on this cluster', keywords: ['about', 'version', 'release', 'image', 'operator', 'upgrade', 'github'], color: 'text-sky-400' },
 
   // Agent
   { id: 'agent', label: 'Pulse Agent', icon: 'Bot', path: '/agent', group: 'agent', subtitle: 'Configure, monitor, and understand the AI assistant', keywords: ['agent', 'ai', 'trust', 'skills', 'tools', 'analytics', 'memory', 'mcp'], color: 'text-violet-400' },

--- a/src/kubeview/routes/domainRoutes.tsx
+++ b/src/kubeview/routes/domainRoutes.tsx
@@ -20,6 +20,7 @@ const FleetAlertsView = lazy(() => import('../views/fleet/FleetAlertsView'));
 const DriftDetectorView = lazy(() => import('../views/fleet/DriftDetectorView').then(m => ({ default: m.DriftDetectorView })));
 const InboxPage = lazy(() => import('../views/InboxPage').then(m => ({ default: m.InboxPage })));
 const OnboardingView = lazy(() => import('../views/OnboardingView'));
+const AboutView = lazy(() => import('../views/AboutView'));
 const PulseAgentView = lazy(() => import('../views/PulseAgentView'));
 const ViewsManagement = lazy(() => import('../views/ViewsManagement'));
 const AlertsView = lazy(() => import('../views/AlertsView'));
@@ -64,6 +65,7 @@ export function domainRoutes() {
       <Route path="fleet/drift" element={<Lazy fallbackTitle="Drift Detector"><DriftDetectorView /></Lazy>} />
       <Route path="inbox" element={<Lazy fallbackTitle="Inbox"><InboxPage /></Lazy>} />
       <Route path="readiness" element={<Lazy fallbackTitle="Readiness"><OnboardingView /></Lazy>} />
+      <Route path="about" element={<Lazy fallbackTitle="About"><AboutView /></Lazy>} />
       <Route path="views" element={<Lazy fallbackTitle="Views"><ViewsManagement /></Lazy>} />
       <Route path="agent" element={<Lazy fallbackTitle="Agent"><PulseAgentView /></Lazy>} />
       <Route path="slo" element={<Lazy fallbackTitle="SLO"><SloView /></Lazy>} />

--- a/src/kubeview/views/AboutView.tsx
+++ b/src/kubeview/views/AboutView.tsx
@@ -1,0 +1,372 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import {
+  Info, Bot, Monitor, Cog, Database, Server, ExternalLink, Copy, Check,
+  BookOpen, Package, GitBranch, ShieldCheck, ShieldOff, RefreshCw,
+} from 'lucide-react';
+import { k8sList } from '../engine/query';
+import { agentFetch } from '../engine/safeQuery';
+import { useClusterStore } from '../store/clusterStore';
+import { Panel } from '../components/primitives/Panel';
+import { Badge } from '../components/primitives/Badge';
+
+/**
+ * What exactly is running on this cluster, and where it all comes from.
+ *
+ * Every version on this page is read from the cluster itself — the
+ * OpenShiftPulse CR (images, health, config), the operator's CSV, and the
+ * agent's own /version endpoint — rather than from anything baked into the
+ * bundle, except the console's own build version, which by definition is.
+ */
+
+const GITHUB_ORG = 'https://github.com/PulseSRE';
+const QUAY = 'https://quay.io/repository/amobrem';
+
+interface PulseCR {
+  metadata?: { namespace?: string };
+  spec?: {
+    agent?: {
+      image?: string;
+      trustLevel?: number;
+      allowWriteOperations?: boolean;
+      adminUsers?: string;
+      mcp?: { enabled?: boolean };
+    };
+    ui?: { image?: string; replicas?: number };
+    monitoring?: { enabled?: boolean };
+    vertexAI?: { projectId?: string; region?: string };
+  };
+  status?: {
+    phase?: string;
+    agentHealthy?: boolean;
+    agentVersion?: string;
+    databaseReady?: boolean;
+    uiAvailable?: boolean;
+    routeHost?: string;
+    upgradeStartedAt?: string;
+    lastHealthyAgentImage?: string;
+    lastHealthyUIImage?: string;
+    lastUpgradeDurationSeconds?: number;
+  };
+}
+
+interface DeploymentLite {
+  metadata?: { name?: string };
+  spec?: { replicas?: number };
+  status?: { replicas?: number; updatedReplicas?: number; readyReplicas?: number };
+}
+
+interface CSV {
+  metadata?: { name?: string };
+  spec?: { version?: string; displayName?: string };
+  status?: { phase?: string };
+}
+
+function imageTag(image?: string): string {
+  if (!image) return '';
+  const idx = image.lastIndexOf(':');
+  return idx > 0 ? image.slice(idx + 1) : '';
+}
+
+function CopyableImage({ image }: { image?: string }) {
+  const [copied, setCopied] = useState(false);
+  if (!image) return null;
+  return (
+    <button
+      onClick={() => {
+        navigator.clipboard?.writeText(image).then(() => {
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1500);
+        });
+      }}
+      className="group flex items-center gap-1.5 text-xs font-mono text-slate-500 hover:text-slate-300 min-w-0"
+      title="Copy image reference"
+    >
+      <span className="truncate">{image}</span>
+      {copied ? (
+        <Check className="w-3 h-3 text-emerald-400 shrink-0" />
+      ) : (
+        <Copy className="w-3 h-3 opacity-0 group-hover:opacity-100 shrink-0" />
+      )}
+    </button>
+  );
+}
+
+function LinkOut({ href, children }: { href: string; children: React.ReactNode }) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1 text-xs text-blue-400 hover:text-blue-300"
+    >
+      {children}
+      <ExternalLink className="w-3 h-3" />
+    </a>
+  );
+}
+
+function ComponentRow({
+  icon,
+  name,
+  version,
+  healthy,
+  image,
+  repo,
+  detail,
+}: {
+  icon: React.ReactNode;
+  name: string;
+  version: string;
+  healthy?: boolean;
+  image?: string;
+  repo?: string; // repo slug under the GitHub org, e.g. 'pulse-agent'
+  detail?: string;
+}) {
+  const tag = imageTag(image);
+  return (
+    <div className="flex items-start gap-3 py-3 border-b border-slate-800 last:border-0">
+      <div className="mt-0.5 text-violet-400">{icon}</div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-sm font-medium text-slate-100">{name}</span>
+          {version && <Badge variant="info">{version}</Badge>}
+          {healthy !== undefined && (
+            <Badge variant={healthy ? 'success' : 'error'}>{healthy ? 'Healthy' : 'Unhealthy'}</Badge>
+          )}
+        </div>
+        {detail && <div className="text-xs text-slate-500 mt-0.5">{detail}</div>}
+        <CopyableImage image={image} />
+        {repo && (
+          <div className="flex items-center gap-3 mt-1">
+            <LinkOut href={`${GITHUB_ORG}/${repo}`}>Source</LinkOut>
+            {tag && (
+              <LinkOut href={`${GITHUB_ORG}/${repo}/tree/${tag}`}>
+                <GitBranch className="w-3 h-3" /> Source at {tag}
+              </LinkOut>
+            )}
+            <LinkOut href={`${GITHUB_ORG}/${repo}/tags`}>Release history</LinkOut>
+            {image?.startsWith('quay.io/amobrem/') && (
+              <LinkOut href={`${QUAY}/${image.split('/')[2].split(':')[0]}?tab=tags`}>
+                <Package className="w-3 h-3" /> Image registry
+              </LinkOut>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function AboutView() {
+  const clusterVersion = useClusterStore((s) => s.clusterVersion);
+
+  const { data: cr } = useQuery({
+    queryKey: ['about', 'openshiftpulse-cr'],
+    queryFn: async () => {
+      const items = await k8sList<PulseCR>('/apis/pulse.ai/v1alpha1/openshiftpulses');
+      return items[0] ?? null;
+    },
+    // Poll fast while an upgrade is in flight so the banner tracks the
+    // rollout live, lazily otherwise.
+    refetchInterval: (query) => (query.state.data?.status?.phase === 'Upgrading' ? 5_000 : 60_000),
+  });
+
+  const crNamespace = cr?.metadata?.namespace;
+  const upgrading = cr?.status?.phase === 'Upgrading';
+
+  const { data: rollouts } = useQuery({
+    queryKey: ['about', 'deployments', crNamespace],
+    queryFn: async () => {
+      const items = await k8sList<DeploymentLite>(`/apis/apps/v1/namespaces/${crNamespace}/deployments`);
+      return items.filter((d) => (d.metadata?.name || '').startsWith('pulse'));
+    },
+    enabled: Boolean(crNamespace),
+    refetchInterval: upgrading ? 5_000 : 60_000,
+  });
+  const { data: csv } = useQuery({
+    queryKey: ['about', 'operator-csv', crNamespace],
+    queryFn: async () => {
+      const items = await k8sList<CSV>(
+        `/apis/operators.coreos.com/v1alpha1/namespaces/${crNamespace}/clusterserviceversions`
+      );
+      return items.find((c) => (c.metadata?.name || '').startsWith('pulse-operator')) ?? null;
+    },
+    enabled: Boolean(crNamespace),
+    staleTime: 300_000,
+  });
+
+  const { data: agentInfo } = useQuery({
+    queryKey: ['about', 'agent-version'],
+    queryFn: async () => {
+      const res = await agentFetch('/api/agent/version');
+      if (!res.ok) return null;
+      return res.json() as Promise<{ protocol?: number; agent?: string; tools?: number; skills?: number }>;
+    },
+    staleTime: 60_000,
+  });
+
+  const spec = cr?.spec;
+  const status = cr?.status;
+  const writeOps = Boolean(spec?.agent?.allowWriteOperations);
+
+  // Which components are actually changing, from→to, straight off the CR:
+  // the operator stamps lastHealthy*Image with what ran before the change.
+  const upgradeMoves: string[] = [];
+  if (upgrading) {
+    const agentFrom = imageTag(status?.lastHealthyAgentImage);
+    const agentTo = imageTag(spec?.agent?.image);
+    if (agentTo && agentFrom !== agentTo) upgradeMoves.push(`agent ${agentFrom || '?'} → ${agentTo}`);
+    const uiFrom = imageTag(status?.lastHealthyUIImage);
+    const uiTo = imageTag(spec?.ui?.image);
+    if (uiTo && uiFrom !== uiTo) upgradeMoves.push(`console ${uiFrom || '?'} → ${uiTo}`);
+  }
+  const upgradeElapsedS = status?.upgradeStartedAt
+    ? Math.max(0, Math.floor((Date.now() - Date.parse(status.upgradeStartedAt)) / 1000))
+    : null;
+  const activeRollouts = (rollouts ?? []).filter((d) => {
+    const want = d.spec?.replicas ?? 0;
+    const updated = d.status?.updatedReplicas ?? 0;
+    const ready = d.status?.readyReplicas ?? 0;
+    return want > 0 && (updated < want || ready < want);
+  });
+
+  return (
+    <div className="p-4 space-y-4 max-w-4xl">
+      <div className="flex items-center gap-3">
+        <Info className="w-5 h-5 text-sky-400" />
+        <div>
+          <h1 className="text-lg font-semibold text-slate-100">About OpenShift Pulse</h1>
+          <p className="text-xs text-slate-500">
+            What is running on this cluster, read live from the cluster itself
+            {status?.phase ? <> · phase: <span className="text-slate-300">{status.phase}</span></> : null}
+          </p>
+        </div>
+      </div>
+
+      {upgrading && (
+        <div className="rounded-md border border-blue-700/40 bg-blue-500/10 px-4 py-3">
+          <div className="flex items-center gap-2 text-sm text-blue-300 font-medium">
+            <RefreshCw className="w-4 h-4 animate-spin" />
+            Update in progress
+            {upgradeMoves.length > 0 && <span className="text-blue-200">— {upgradeMoves.join(', ')}</span>}
+          </div>
+          <div className="mt-1 text-xs text-blue-300/70">
+            {upgradeElapsedS !== null && <>Started {upgradeElapsedS}s ago. </>}
+            {status?.lastUpgradeDurationSeconds
+              ? `The previous upgrade took ${status.lastUpgradeDurationSeconds}s.`
+              : ''}
+          </div>
+          {activeRollouts.length > 0 && (
+            <div className="mt-2 space-y-1">
+              {activeRollouts.map((d) => (
+                <div key={d.metadata?.name} className="text-xs text-blue-200/80 font-mono">
+                  {d.metadata?.name}: {d.status?.updatedReplicas ?? 0}/{d.spec?.replicas ?? 0} updated,{' '}
+                  {d.status?.readyReplicas ?? 0} ready
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+      {!upgrading && status?.phase && status.phase !== 'Running' && (
+        <div className="rounded-md border border-amber-700/40 bg-amber-500/10 px-4 py-2.5 text-sm text-amber-300">
+          Pulse is <span className="font-medium">{status.phase}</span>
+          {activeRollouts.length > 0 &&
+            ` — ${activeRollouts.map((d) => `${d.metadata?.name} ${d.status?.readyReplicas ?? 0}/${d.spec?.replicas ?? 0} ready`).join(', ')}`}
+        </div>
+      )}
+
+      <Panel title="Components" icon={<Server className="w-4 h-4 text-violet-400" />}>
+        <ComponentRow
+          icon={<Monitor className="w-4 h-4" />}
+          name="Console (this UI)"
+          version={`v${__APP_VERSION__}`}
+          healthy={status?.uiAvailable}
+          image={spec?.ui?.image}
+          repo="pulse-ui"
+          detail={spec?.ui?.replicas ? `${spec.ui.replicas} replicas behind oauth-proxy` : undefined}
+        />
+        <ComponentRow
+          icon={<Bot className="w-4 h-4" />}
+          name="SRE Agent"
+          version={status?.agentVersion || agentInfo?.agent || ''}
+          healthy={status?.agentHealthy}
+          image={spec?.agent?.image}
+          repo="pulse-agent"
+          detail={
+            agentInfo
+              ? `Protocol v${agentInfo.protocol} · ${agentInfo.tools} tools · ${agentInfo.skills} skills`
+              : undefined
+          }
+        />
+        <ComponentRow
+          icon={<Cog className="w-4 h-4" />}
+          name="Pulse Operator"
+          version={csv?.spec?.version ? `v${csv.spec.version}` : ''}
+          healthy={csv ? csv.status?.phase === 'Succeeded' : undefined}
+          repo="pulse-operator"
+          detail={csv?.metadata?.name ? `CSV ${csv.metadata.name} — owns every deployment on this page` : undefined}
+        />
+        <ComponentRow
+          icon={<Database className="w-4 h-4" />}
+          name="PostgreSQL"
+          version=""
+          healthy={status?.databaseReady}
+          detail="Memory, fix history, episodes, learned skills — everything the agent knows survives here"
+        />
+        <ComponentRow
+          icon={<Server className="w-4 h-4" />}
+          name="OpenShift"
+          version={clusterVersion ? `v${clusterVersion}` : ''}
+          detail={status?.routeHost ? `Console served at ${status.routeHost}` : undefined}
+        />
+      </Panel>
+
+      <Panel title="Agent configuration" icon={<Bot className="w-4 h-4 text-violet-400" />}>
+        <div className="grid grid-cols-2 gap-3 text-xs">
+          <div className="flex items-center gap-2">
+            {writeOps ? (
+              <ShieldCheck className="w-4 h-4 text-emerald-400" />
+            ) : (
+              <ShieldOff className="w-4 h-4 text-amber-400" />
+            )}
+            <span className="text-slate-300">
+              Write operations {writeOps ? 'enabled' : 'disabled'}
+              <span className="text-slate-500"> — {writeOps ? 'approved fixes execute' : 'diagnose-only'}</span>
+            </span>
+          </div>
+          <div className="text-slate-300">
+            Trust level <span className="font-medium">{spec?.agent?.trustLevel ?? '—'}</span>
+            <span className="text-slate-500"> · MCP {spec?.agent?.mcp?.enabled ? 'enabled' : 'disabled'}</span>
+            <span className="text-slate-500"> · monitoring {spec?.monitoring?.enabled ? 'on' : 'off'}</span>
+          </div>
+          {spec?.agent?.adminUsers && (
+            <div className="text-slate-500">
+              Admins: <span className="text-slate-300">{spec.agent.adminUsers}</span>
+            </div>
+          )}
+          {spec?.vertexAI?.projectId && (
+            <div className="text-slate-500">
+              Model backend: <span className="text-slate-300">Vertex AI · {spec.vertexAI.projectId}</span>
+              {spec.vertexAI.region ? ` (${spec.vertexAI.region})` : ''}
+            </div>
+          )}
+        </div>
+      </Panel>
+
+      <Panel title="Project links" icon={<BookOpen className="w-4 h-4 text-violet-400" />}>
+        <div className="grid grid-cols-2 gap-x-6 gap-y-2">
+          <LinkOut href="https://pulsesre.github.io/pulse-ui/">Console documentation</LinkOut>
+          <LinkOut href="https://pulsesre.github.io/pulse-agent/">Agent documentation</LinkOut>
+          <LinkOut href={`${GITHUB_ORG}/pulse-ui`}>pulse-ui on GitHub</LinkOut>
+          <LinkOut href={`${GITHUB_ORG}/pulse-agent`}>pulse-agent on GitHub</LinkOut>
+          <LinkOut href={`${GITHUB_ORG}/pulse-operator`}>pulse-operator on GitHub</LinkOut>
+          <LinkOut href={`${QUAY}/openshiftpulse?tab=tags`}>UI images on Quay</LinkOut>
+          <LinkOut href={`${QUAY}/pulse-agent?tab=tags`}>Agent images on Quay</LinkOut>
+          <LinkOut href={`${GITHUB_ORG}/pulse-ui/issues/new`}>Report an issue</LinkOut>
+        </div>
+      </Panel>
+    </div>
+  );
+}

--- a/src/kubeview/views/__tests__/AboutView.test.tsx
+++ b/src/kubeview/views/__tests__/AboutView.test.tsx
@@ -1,0 +1,219 @@
+// @vitest-environment jsdom
+/**
+ * The About page answers "what exactly is running on this cluster" from the
+ * cluster itself: the OpenShiftPulse CR (images, health, config), the
+ * operator's CSV, and the agent's /version endpoint. Only the console's own
+ * build version is baked in.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+vi.mock('../../engine/query', () => ({ k8sList: vi.fn() }));
+vi.mock('../../engine/safeQuery', () => ({ agentFetch: vi.fn() }));
+
+import { k8sList } from '../../engine/query';
+import { agentFetch } from '../../engine/safeQuery';
+import AboutView from '../AboutView';
+
+const CR = {
+  metadata: { namespace: 'openshiftpulse' },
+  spec: {
+    agent: {
+      image: 'quay.io/amobrem/pulse-agent:v2.22.1',
+      trustLevel: 2,
+      allowWriteOperations: true,
+      adminUsers: 'kube:admin',
+      mcp: { enabled: true },
+    },
+    ui: { image: 'quay.io/amobrem/openshiftpulse:v2.21.1', replicas: 2 },
+    monitoring: { enabled: true },
+    vertexAI: { projectId: 'my-project', region: 'global' },
+  },
+  status: {
+    phase: 'Ready',
+    agentHealthy: true,
+    agentVersion: 'v2.22.1',
+    databaseReady: true,
+    uiAvailable: true,
+    routeHost: 'pulse.apps.example.com',
+  },
+};
+
+const CSV = {
+  metadata: { name: 'pulse-operator.v0.4.2' },
+  spec: { version: '0.4.2' },
+  status: { phase: 'Succeeded' },
+};
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <AboutView />
+    </QueryClientProvider>
+  );
+}
+
+describe('AboutView', () => {
+  beforeEach(() => {
+    vi.mocked(k8sList).mockImplementation(async (path: string) => {
+      if (path.includes('openshiftpulses')) return [CR];
+      if (path.includes('clusterserviceversions')) return [CSV];
+      return [];
+    });
+    vi.mocked(agentFetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ protocol: 2, agent: 'v2.22.1', tools: 105, skills: 8 }),
+    } as unknown as Response);
+  });
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('shows every component with the version the cluster reports', async () => {
+    renderPage();
+    // The row names are static; the versions arrive with the queries — wait
+    // on a version, not a label, or the assertions race the fetch.
+    await waitFor(() => expect(screen.getByText('v2.22.1')).toBeDefined());
+    await waitFor(() => expect(screen.getByText('v0.4.2')).toBeDefined());
+    expect(screen.getByText('Pulse Operator')).toBeDefined();
+    expect(screen.getByText('PostgreSQL')).toBeDefined();
+  });
+
+  it('shows the exact image references so an operator can copy them', async () => {
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText('quay.io/amobrem/pulse-agent:v2.22.1')).toBeDefined()
+    );
+    expect(screen.getByText('quay.io/amobrem/openshiftpulse:v2.21.1')).toBeDefined();
+  });
+
+  it('links each component to its source at the running tag', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Source at v2.22.1')).toBeDefined());
+    const link = screen.getByText('Source at v2.22.1').closest('a');
+    expect(link?.getAttribute('href')).toBe('https://github.com/PulseSRE/pulse-agent/tree/v2.22.1');
+  });
+
+  it('states the write-operations posture in plain words', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText(/Write operations enabled/)).toBeDefined());
+  });
+
+  it('says diagnose-only when write operations are off', async () => {
+    const readOnly = {
+      ...CR,
+      spec: { ...CR.spec, agent: { ...CR.spec.agent, allowWriteOperations: false } },
+    };
+    vi.mocked(k8sList).mockImplementation(async (path: string) =>
+      path.includes('openshiftpulses') ? [readOnly] : [CSV]
+    );
+    renderPage();
+    await waitFor(() => expect(screen.getByText(/Write operations disabled/)).toBeDefined());
+    expect(screen.getByText(/diagnose-only/)).toBeDefined();
+  });
+
+  it('summarizes the agent runtime from its /version endpoint', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText(/Protocol v2 · 105 tools · 8 skills/)).toBeDefined());
+  });
+
+  it('survives a cluster that will not answer', async () => {
+    vi.mocked(k8sList).mockRejectedValue(new Error('forbidden'));
+    vi.mocked(agentFetch).mockRejectedValue(new Error('agent offline'));
+    renderPage();
+    // The page still renders its skeleton — the console's own version is the
+    // one fact that needs no cluster.
+    await waitFor(() => expect(screen.getByText('Console (this UI)')).toBeDefined());
+    expect(screen.getByText('Project links')).toBeDefined();
+  });
+});
+
+describe('AboutView upgrade banner', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  function mockUpgrading() {
+    const upgradingCR = {
+      ...CR,
+      spec: { ...CR.spec, agent: { ...CR.spec.agent, image: 'quay.io/amobrem/pulse-agent:v2.23.0' } },
+      status: {
+        ...CR.status,
+        phase: 'Upgrading',
+        upgradeStartedAt: new Date(Date.now() - 30_000).toISOString(),
+        lastHealthyAgentImage: 'quay.io/amobrem/pulse-agent:v2.22.1',
+        lastHealthyUIImage: 'quay.io/amobrem/openshiftpulse:v2.21.1',
+        lastUpgradeDurationSeconds: 95,
+      },
+    };
+    const rollingDeploy = {
+      metadata: { name: 'pulse-openshift-sre-agent' },
+      spec: { replicas: 1 },
+      status: { replicas: 1, updatedReplicas: 0, readyReplicas: 0 },
+    };
+    vi.mocked(k8sList).mockImplementation(async (path: string) => {
+      if (path.includes('openshiftpulses')) return [upgradingCR];
+      if (path.includes('clusterserviceversions')) return [CSV];
+      if (path.includes('/deployments')) return [rollingDeploy];
+      return [];
+    });
+    vi.mocked(agentFetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ protocol: 2, agent: 'v2.22.1', tools: 105, skills: 8 }),
+    } as unknown as Response);
+  }
+
+  it('shows what is moving from where to where, with rollout progress', async () => {
+    mockUpgrading();
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Update in progress')).toBeDefined());
+    expect(screen.getByText(/agent v2\.22\.1 → v2\.23\.0/)).toBeDefined();
+    // JSX interpolation splits these lines into several text nodes — match
+    // on the whole element's textContent instead.
+    await waitFor(() =>
+      expect(
+        screen.getAllByText(
+          (_, el) => el?.textContent === 'pulse-openshift-sre-agent: 0/1 updated, 0 ready' && el?.tagName === 'DIV'
+        ).length
+      ).toBeGreaterThan(0)
+    );
+    expect(
+      screen.getAllByText(
+        (_, el) => (el?.textContent ?? '').includes('previous upgrade took 95s') && el?.tagName === 'DIV'
+      ).length
+    ).toBeGreaterThan(0);
+  });
+
+  it('a healthy cluster shows no upgrade banner', async () => {
+    vi.mocked(k8sList).mockImplementation(async (path: string) => {
+      if (path.includes('openshiftpulses')) return [{ ...CR, status: { ...CR.status, phase: 'Running' } }];
+      if (path.includes('clusterserviceversions')) return [CSV];
+      return [];
+    });
+    vi.mocked(agentFetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ protocol: 2, agent: 'v2.22.1', tools: 105, skills: 8 }),
+    } as unknown as Response);
+    renderPage();
+    await waitFor(() => expect(screen.getByText('v0.4.2')).toBeDefined());
+    expect(screen.queryByText('Update in progress')).toBeNull();
+  });
+
+  it('a degraded cluster is named, not hidden', async () => {
+    vi.mocked(k8sList).mockImplementation(async (path: string) => {
+      if (path.includes('openshiftpulses'))
+        return [{ ...CR, status: { ...CR.status, phase: 'Degraded', agentHealthy: false } }];
+      if (path.includes('clusterserviceversions')) return [CSV];
+      return [];
+    });
+    vi.mocked(agentFetch).mockResolvedValue({ ok: false } as unknown as Response);
+    renderPage();
+    // "Degraded" legitimately appears in both the banner and the phase line.
+    await waitFor(() => expect(screen.getAllByText('Degraded').length).toBeGreaterThan(0));
+  });
+});


### PR DESCRIPTION
New `/about` route + status-bar version chip. Components with versions/health/copyable images and per-component links (repo, source-at-tag, tag history, Quay); a live update banner driven by the operator's own upgrade model (phase, lastHealthy images → from/to, upgradeStartedAt, lastUpgradeDurationSeconds, per-deployment updated/ready counts at 5s polling); agent posture in plain words (write ops, trust level, MCP, model backend); project links. 10 new tests, 2,253 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)