### PR TITLE
Add About Pulse to the user menu

### DIFF
--- a/src/kubeview/components/CommandBar.tsx
+++ b/src/kubeview/components/CommandBar.tsx
@@ -373,6 +373,12 @@ export function CommandBar() {
                 >
                   User Management
                 </button>
+                <button
+                  onClick={() => { setShowUserMenu(false); go('/about', 'About Pulse'); }}
+                  className="w-full px-3 py-2 text-left text-sm text-slate-300 hover:bg-slate-700 transition-colors"
+                >
+                  About Pulse
+                </button>
                 {impersonateUser ? (
                   <button
                     onClick={() => {


### PR DESCRIPTION
The user menu is where people habitually look for an about page — adds the entry alongside the Administration nav item and the status-bar version chip. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)