### PR TITLE
Header chip and user-menu row while Pulse is updating

### DIFF
--- a/src/kubeview/components/CommandBar.tsx
+++ b/src/kubeview/components/CommandBar.tsx
@@ -9,12 +9,14 @@ import { isMultiCluster } from '../engine/clusterConnection';
 import { cn } from '@/lib/utils';
 import { agentFetch } from '../engine/safeQuery';
 import { performLogout } from '../engine/auth';
+import { usePulseUpgrade } from '../hooks/usePulseStatus';
 
 export function CommandBar() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [showNsDropdown, setShowNsDropdown] = useState(false);
   const [showUserMenu, setShowUserMenu] = useState(false);
+  const pulseUpgrade = usePulseUpgrade();
   const [nsFilter, setNsFilter] = useState('');
   const [showImpersonateInput, setShowImpersonateInput] = useState(false);
   const [impersonateInput, setImpersonateInput] = useState('');
@@ -327,6 +329,19 @@ export function CommandBar() {
           )}
         </div>
 
+        {/* Update-in-progress chip — visible while the operator rolls new
+            images, gone the moment the CR is back to Running. */}
+        {pulseUpgrade.upgrading && (
+          <button
+            onClick={() => go('/about', 'About Pulse')}
+            className="flex items-center gap-1.5 px-2 py-1 rounded-md text-xs bg-blue-500/15 border border-blue-500/40 text-blue-300 hover:bg-blue-500/25 transition-colors"
+            title={pulseUpgrade.moves.join(', ') || 'Pulse is updating'}
+          >
+            <RefreshCw className="w-3 h-3 animate-spin" />
+            Updating…
+          </button>
+        )}
+
         {/* Notification bell */}
         <button
           onClick={() => go('/inbox', 'Inbox')}
@@ -379,6 +394,22 @@ export function CommandBar() {
                 >
                   About Pulse
                 </button>
+                {pulseUpgrade.upgrading && (
+                  <button
+                    onClick={() => { setShowUserMenu(false); go('/about', 'About Pulse'); }}
+                    className="w-full px-3 py-2 text-left text-sm text-blue-300 hover:bg-slate-700 transition-colors"
+                  >
+                    <span className="flex items-center gap-2">
+                      <RefreshCw className="w-3.5 h-3.5 animate-spin shrink-0" />
+                      <span className="min-w-0">
+                        Update in progress
+                        {pulseUpgrade.moves.length > 0 && (
+                          <span className="block text-xs text-blue-300/70 truncate">{pulseUpgrade.moves.join(', ')}</span>
+                        )}
+                      </span>
+                    </span>
+                  </button>
+                )}
                 {impersonateUser ? (
                   <button
                     onClick={() => {

--- a/src/kubeview/hooks/__tests__/usePulseStatus.test.tsx
+++ b/src/kubeview/hooks/__tests__/usePulseStatus.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+/**
+ * The shared CR hook behind the About page and the header's update chip.
+ * upgradeMovesFor derives "what is moving from where to where" from the
+ * operator's lastHealthy*Image stamps.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook, waitFor, cleanup } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+vi.mock('../../engine/query', () => ({ k8sList: vi.fn() }));
+import { k8sList } from '../../engine/query';
+import { upgradeMovesFor, usePulseUpgrade, imageTag } from '../usePulseStatus';
+
+const UPGRADING = {
+  spec: {
+    agent: { image: 'quay.io/amobrem/pulse-agent:v2.23.0' },
+    ui: { image: 'quay.io/amobrem/openshiftpulse:v2.22.1' },
+  },
+  status: {
+    phase: 'Upgrading',
+    lastHealthyAgentImage: 'quay.io/amobrem/pulse-agent:v2.22.1',
+    lastHealthyUIImage: 'quay.io/amobrem/openshiftpulse:v2.22.1',
+  },
+};
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('imageTag', () => {
+  it('extracts the tag and tolerates registries with ports', () => {
+    expect(imageTag('quay.io/a/b:v1.2.3')).toBe('v1.2.3');
+    expect(imageTag(undefined)).toBe('');
+  });
+});
+
+describe('upgradeMovesFor', () => {
+  it('names only the components that are actually changing', () => {
+    // UI images match — only the agent is moving.
+    expect(upgradeMovesFor(UPGRADING)).toEqual(['agent v2.22.1 → v2.23.0']);
+  });
+
+  it('is empty unless the operator says Upgrading', () => {
+    expect(upgradeMovesFor({ ...UPGRADING, status: { ...UPGRADING.status, phase: 'Running' } })).toEqual([]);
+    expect(upgradeMovesFor(null)).toEqual([]);
+  });
+});
+
+describe('usePulseUpgrade', () => {
+  it('reports an in-flight upgrade with its moves', async () => {
+    vi.mocked(k8sList).mockResolvedValue([UPGRADING]);
+    const { result } = renderHook(() => usePulseUpgrade(), { wrapper });
+    await waitFor(() => expect(result.current.upgrading).toBe(true));
+    expect(result.current.moves).toEqual(['agent v2.22.1 → v2.23.0']);
+  });
+
+  it('stays quiet on a healthy cluster', async () => {
+    vi.mocked(k8sList).mockResolvedValue([{ ...UPGRADING, status: { phase: 'Running' } }]);
+    const { result } = renderHook(() => usePulseUpgrade(), { wrapper });
+    await waitFor(() => expect(result.current.phase).toBe('Running'));
+    expect(result.current.upgrading).toBe(false);
+    expect(result.current.moves).toEqual([]);
+  });
+});

--- a/src/kubeview/hooks/usePulseStatus.ts
+++ b/src/kubeview/hooks/usePulseStatus.ts
@@ -1,0 +1,89 @@
+import { useQuery } from '@tanstack/react-query';
+import { k8sList } from '../engine/query';
+
+/**
+ * The OpenShiftPulse CR, shared between the About page and the update
+ * indicator in the user menu. One query key, so however many places watch
+ * it, the cluster answers once — and while an upgrade is in flight the
+ * poll tightens to 5s so indicators track the rollout live.
+ */
+
+export interface PulseCR {
+  metadata?: { namespace?: string };
+  spec?: {
+    agent?: {
+      image?: string;
+      trustLevel?: number;
+      allowWriteOperations?: boolean;
+      adminUsers?: string;
+      mcp?: { enabled?: boolean };
+    };
+    ui?: { image?: string; replicas?: number };
+    monitoring?: { enabled?: boolean };
+    vertexAI?: { projectId?: string; region?: string };
+  };
+  status?: {
+    phase?: string;
+    agentHealthy?: boolean;
+    agentVersion?: string;
+    databaseReady?: boolean;
+    uiAvailable?: boolean;
+    routeHost?: string;
+    upgradeStartedAt?: string;
+    lastHealthyAgentImage?: string;
+    lastHealthyUIImage?: string;
+    lastUpgradeDurationSeconds?: number;
+  };
+}
+
+/** The tag portion of an image reference, '' when there is none. */
+export function imageTag(image?: string): string {
+  if (!image) return '';
+  const idx = image.lastIndexOf(':');
+  return idx > 0 ? image.slice(idx + 1) : '';
+}
+
+export function usePulseCR(): PulseCR | null | undefined {
+  const { data } = useQuery({
+    queryKey: ['about', 'openshiftpulse-cr'],
+    queryFn: async () => {
+      const items = await k8sList<PulseCR>('/apis/pulse.ai/v1alpha1/openshiftpulses');
+      return items[0] ?? null;
+    },
+    refetchInterval: (query) => (query.state.data?.status?.phase === 'Upgrading' ? 5_000 : 60_000),
+  });
+  return data;
+}
+
+export interface PulseUpgradeStatus {
+  phase: string;
+  upgrading: boolean;
+  /** Human-readable moves, e.g. "agent v2.22.0 → v2.22.1". */
+  moves: string[];
+}
+
+/**
+ * What's changing right now, from→to, straight off the CR: the operator
+ * stamps lastHealthy*Image with what ran before the change.
+ */
+export function upgradeMovesFor(cr: PulseCR | null | undefined): string[] {
+  if (cr?.status?.phase !== 'Upgrading') return [];
+  const moves: string[] = [];
+  const agentFrom = imageTag(cr.status?.lastHealthyAgentImage);
+  const agentTo = imageTag(cr.spec?.agent?.image);
+  if (agentTo && agentFrom !== agentTo) moves.push(`agent ${agentFrom || '?'} → ${agentTo}`);
+  const uiFrom = imageTag(cr.status?.lastHealthyUIImage);
+  const uiTo = imageTag(cr.spec?.ui?.image);
+  if (uiTo && uiFrom !== uiTo) moves.push(`console ${uiFrom || '?'} → ${uiTo}`);
+  return moves;
+}
+
+export function usePulseUpgrade(): PulseUpgradeStatus {
+  const cr = usePulseCR();
+  const phase = cr?.status?.phase ?? '';
+  return {
+    phase,
+    upgrading: phase === 'Upgrading',
+    moves: upgradeMovesFor(cr),
+  };
+}

--- a/src/kubeview/views/AboutView.tsx
+++ b/src/kubeview/views/AboutView.tsx
@@ -6,6 +6,8 @@ import {
 } from 'lucide-react';
 import { k8sList } from '../engine/query';
 import { agentFetch } from '../engine/safeQuery';
+import { imageTag, upgradeMovesFor, usePulseCR } from '../hooks/usePulseStatus';
+import type { PulseCR } from '../hooks/usePulseStatus';
 import { useClusterStore } from '../store/clusterStore';
 import { Panel } from '../components/primitives/Panel';
 import { Badge } from '../components/primitives/Badge';
@@ -22,34 +24,6 @@ import { Badge } from '../components/primitives/Badge';
 const GITHUB_ORG = 'https://github.com/PulseSRE';
 const QUAY = 'https://quay.io/repository/amobrem';
 
-interface PulseCR {
-  metadata?: { namespace?: string };
-  spec?: {
-    agent?: {
-      image?: string;
-      trustLevel?: number;
-      allowWriteOperations?: boolean;
-      adminUsers?: string;
-      mcp?: { enabled?: boolean };
-    };
-    ui?: { image?: string; replicas?: number };
-    monitoring?: { enabled?: boolean };
-    vertexAI?: { projectId?: string; region?: string };
-  };
-  status?: {
-    phase?: string;
-    agentHealthy?: boolean;
-    agentVersion?: string;
-    databaseReady?: boolean;
-    uiAvailable?: boolean;
-    routeHost?: string;
-    upgradeStartedAt?: string;
-    lastHealthyAgentImage?: string;
-    lastHealthyUIImage?: string;
-    lastUpgradeDurationSeconds?: number;
-  };
-}
-
 interface DeploymentLite {
   metadata?: { name?: string };
   spec?: { replicas?: number };
@@ -60,12 +34,6 @@ interface CSV {
   metadata?: { name?: string };
   spec?: { version?: string; displayName?: string };
   status?: { phase?: string };
-}
-
-function imageTag(image?: string): string {
-  if (!image) return '';
-  const idx = image.lastIndexOf(':');
-  return idx > 0 ? image.slice(idx + 1) : '';
 }
 
 function CopyableImage({ image }: { image?: string }) {
@@ -161,16 +129,7 @@ function ComponentRow({
 export default function AboutView() {
   const clusterVersion = useClusterStore((s) => s.clusterVersion);
 
-  const { data: cr } = useQuery({
-    queryKey: ['about', 'openshiftpulse-cr'],
-    queryFn: async () => {
-      const items = await k8sList<PulseCR>('/apis/pulse.ai/v1alpha1/openshiftpulses');
-      return items[0] ?? null;
-    },
-    // Poll fast while an upgrade is in flight so the banner tracks the
-    // rollout live, lazily otherwise.
-    refetchInterval: (query) => (query.state.data?.status?.phase === 'Upgrading' ? 5_000 : 60_000),
-  });
+  const cr: PulseCR | null | undefined = usePulseCR();
 
   const crNamespace = cr?.metadata?.namespace;
   const upgrading = cr?.status?.phase === 'Upgrading';
@@ -210,17 +169,7 @@ export default function AboutView() {
   const status = cr?.status;
   const writeOps = Boolean(spec?.agent?.allowWriteOperations);
 
-  // Which components are actually changing, from→to, straight off the CR:
-  // the operator stamps lastHealthy*Image with what ran before the change.
-  const upgradeMoves: string[] = [];
-  if (upgrading) {
-    const agentFrom = imageTag(status?.lastHealthyAgentImage);
-    const agentTo = imageTag(spec?.agent?.image);
-    if (agentTo && agentFrom !== agentTo) upgradeMoves.push(`agent ${agentFrom || '?'} → ${agentTo}`);
-    const uiFrom = imageTag(status?.lastHealthyUIImage);
-    const uiTo = imageTag(spec?.ui?.image);
-    if (uiTo && uiFrom !== uiTo) upgradeMoves.push(`console ${uiFrom || '?'} → ${uiTo}`);
-  }
+  const upgradeMoves = upgradeMovesFor(cr);
   const upgradeElapsedS = status?.upgradeStartedAt
     ? Math.max(0, Math.floor((Date.now() - Date.parse(status.upgradeStartedAt)) / 1000))
     : null;


### PR DESCRIPTION
Animated `Updating…` chip in the header (tooltip carries the from→to moves, click opens /about) plus an "Update in progress" row in the user menu — both driven by a new shared `usePulseStatus` hook on the About page's query key (one cluster request, 5s polling while Upgrading). AboutView refactored onto the hook. 2,258 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)