### PR TITLE
Always-on Pulse health indicator in the header

### DIFF
--- a/src/kubeview/components/CommandBar.tsx
+++ b/src/kubeview/components/CommandBar.tsx
@@ -329,9 +329,11 @@ export function CommandBar() {
           )}
         </div>
 
-        {/* Update-in-progress chip — visible while the operator rolls new
-            images, gone the moment the CR is back to Running. */}
-        {pulseUpgrade.upgrading && (
+        {/* Pulse health indicator — always present once the CR answers:
+            quiet green dot when healthy, animated blue chip mid-upgrade,
+            red chip naming the phase when something is wrong. 'unknown'
+            (CR unreadable) shows nothing rather than crying wolf. */}
+        {pulseUpgrade.health === 'updating' && (
           <button
             onClick={() => go('/about', 'About Pulse')}
             className="flex items-center gap-1.5 px-2 py-1 rounded-md text-xs bg-blue-500/15 border border-blue-500/40 text-blue-300 hover:bg-blue-500/25 transition-colors"
@@ -339,6 +341,26 @@ export function CommandBar() {
           >
             <RefreshCw className="w-3 h-3 animate-spin" />
             Updating…
+          </button>
+        )}
+        {pulseUpgrade.health === 'unhealthy' && (
+          <button
+            onClick={() => go('/about', 'About Pulse')}
+            className="flex items-center gap-1.5 px-2 py-1 rounded-md text-xs bg-red-500/15 border border-red-500/40 text-red-300 hover:bg-red-500/25 transition-colors"
+            title={pulseUpgrade.detail}
+          >
+            <span className="w-2 h-2 rounded-full bg-red-400 animate-pulse" />
+            Pulse {pulseUpgrade.phase}
+          </button>
+        )}
+        {pulseUpgrade.health === 'healthy' && (
+          <button
+            onClick={() => go('/about', 'About Pulse')}
+            className="flex items-center gap-1.5 px-1.5 py-1 rounded-md text-xs text-slate-500 hover:text-slate-300 hover:bg-slate-700/50 transition-colors"
+            title={pulseUpgrade.detail}
+            aria-label="Pulse healthy"
+          >
+            <span className="w-2 h-2 rounded-full bg-emerald-500" />
           </button>
         )}
 

--- a/src/kubeview/hooks/__tests__/usePulseStatus.test.tsx
+++ b/src/kubeview/hooks/__tests__/usePulseStatus.test.tsx
@@ -70,3 +70,30 @@ describe('usePulseUpgrade', () => {
     expect(result.current.moves).toEqual([]);
   });
 });
+
+describe('healthFor', () => {
+  it('maps the operator phases onto three actionable states', async () => {
+    const { healthFor } = await import('../usePulseStatus');
+    expect(healthFor({ status: { phase: 'Running' } })).toBe('healthy');
+    expect(healthFor({ status: { phase: 'Upgrading' } })).toBe('updating');
+    expect(healthFor({ status: { phase: 'Degraded' } })).toBe('unhealthy');
+    expect(healthFor({ status: { phase: 'Installing' } })).toBe('unhealthy');
+  });
+
+  it('an unreadable CR is unknown, never healthy or unhealthy', async () => {
+    const { healthFor } = await import('../usePulseStatus');
+    expect(healthFor(null)).toBe('unknown');
+    expect(healthFor(undefined)).toBe('unknown');
+    expect(healthFor({})).toBe('unknown');
+  });
+});
+
+describe('healthDetailFor', () => {
+  it('names each component state in one tooltip line', async () => {
+    const { healthDetailFor } = await import('../usePulseStatus');
+    const detail = healthDetailFor({
+      status: { phase: 'Degraded', agentHealthy: false, databaseReady: true, uiAvailable: true },
+    });
+    expect(detail).toBe('Degraded — agent unhealthy · database ready · console available');
+  });
+});

--- a/src/kubeview/hooks/usePulseStatus.ts
+++ b/src/kubeview/hooks/usePulseStatus.ts
@@ -55,11 +55,17 @@ export function usePulseCR(): PulseCR | null | undefined {
   return data;
 }
 
+export type PulseHealth = 'healthy' | 'updating' | 'unhealthy' | 'unknown';
+
 export interface PulseUpgradeStatus {
   phase: string;
   upgrading: boolean;
   /** Human-readable moves, e.g. "agent v2.22.0 → v2.22.1". */
   moves: string[];
+  /** Rolled-up health for the header indicator. */
+  health: PulseHealth;
+  /** One line of per-component detail for tooltips. */
+  detail: string;
 }
 
 /**
@@ -78,6 +84,31 @@ export function upgradeMovesFor(cr: PulseCR | null | undefined): string[] {
   return moves;
 }
 
+/**
+ * Roll the operator's phase up to one of three states an operator can act
+ * on — plus 'unknown' when the CR is unreadable, which must never be
+ * painted as either healthy or unhealthy: absence of an answer is not an
+ * answer.
+ */
+export function healthFor(cr: PulseCR | null | undefined): PulseHealth {
+  const phase = cr?.status?.phase;
+  if (!phase) return 'unknown';
+  if (phase === 'Running') return 'healthy';
+  if (phase === 'Upgrading') return 'updating';
+  return 'unhealthy'; // Degraded, Installing, anything the operator invents later
+}
+
+export function healthDetailFor(cr: PulseCR | null | undefined): string {
+  const s = cr?.status;
+  if (!s?.phase) return 'Pulse status unavailable';
+  const parts = [
+    `agent ${s.agentHealthy ? 'healthy' : 'unhealthy'}`,
+    `database ${s.databaseReady ? 'ready' : 'not ready'}`,
+    `console ${s.uiAvailable ? 'available' : 'unavailable'}`,
+  ];
+  return `${s.phase} — ${parts.join(' · ')}`;
+}
+
 export function usePulseUpgrade(): PulseUpgradeStatus {
   const cr = usePulseCR();
   const phase = cr?.status?.phase ?? '';
@@ -85,5 +116,7 @@ export function usePulseUpgrade(): PulseUpgradeStatus {
     phase,
     upgrading: phase === 'Upgrading',
     moves: upgradeMovesFor(cr),
+    health: healthFor(cr),
+    detail: healthDetailFor(cr),
   };
 }


### PR DESCRIPTION
Three-state header indicator off the operator's phase: quiet green dot when Running (per-component tooltip), the animated Updating… chip mid-upgrade, red pulsing chip naming any other phase; unreadable CR shows nothing. All click through to /about. 3 new tests; 2,261 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)