### PR TITLE
Surface chat-approved writes distinctly in fix-history views

### DIFF
--- a/src/kubeview/engine/__tests__/fixHistory.test.ts
+++ b/src/kubeview/engine/__tests__/fixHistory.test.ts
@@ -4,6 +4,7 @@ import {
   fetchFixHistory,
   fetchActionDetail,
   requestRollback,
+  actionCategoryLabel,
 } from '../fixHistory';
 
 const mockAction = {
@@ -173,6 +174,17 @@ describe('fixHistory', () => {
       await expect(requestRollback('a1')).rejects.toThrow(
         'Failed to request rollback: 409 Conflict',
       );
+    });
+  });
+
+  describe('actionCategoryLabel', () => {
+    it('labels chat_action as user-initiated', () => {
+      expect(actionCategoryLabel('chat_action')).toBe('User-initiated');
+    });
+
+    it('passes scanner categories through unchanged', () => {
+      expect(actionCategoryLabel('crashloop')).toBe('crashloop');
+      expect(actionCategoryLabel('image_pull')).toBe('image_pull');
     });
   });
 });

--- a/src/kubeview/engine/analyticsApi.ts
+++ b/src/kubeview/engine/analyticsApi.ts
@@ -187,7 +187,9 @@ export interface ResolutionRecord {
   tool: string;
   status: string;
   reasoning: string;
-  outcome: 'verified' | 'still_failing' | 'improved';
+  // 'pending' (probe not run yet) and 'unverifiable' (probe could not read the
+  // cluster) reach this list too — any non-null verification status does.
+  outcome: 'verified' | 'still_failing' | 'improved' | 'pending' | 'unverifiable';
   evidence: string;
   timestamp: number;
   verifiedAt: number | null;

--- a/src/kubeview/engine/fixHistory.ts
+++ b/src/kubeview/engine/fixHistory.ts
@@ -32,6 +32,22 @@ export interface ActionRecord {
   rollbackAvailable: boolean;
   rollbackAction?: { tool: string; input: Record<string, unknown> };
   resources: ResourceRef[];
+  // 'pending' is the initial state of a contracted write whose postcondition
+  // probe has not run yet — a scheduled check, not a stuck one.
+  verificationStatus?: 'pending' | 'verified' | 'still_failing' | 'improved' | 'unverifiable';
+  verificationEvidence?: string;
+  verificationTimestamp?: number;
+}
+
+/**
+ * Human label for a fix-history action category.
+ *
+ * Most categories are scanner names shown as-is. 'chat_action' is different in
+ * kind, not just in name: the operator approved it in chat, the agent did not
+ * act on its own — so it must never read as an auto-fix.
+ */
+export function actionCategoryLabel(category: string): string {
+  return category === 'chat_action' ? 'User-initiated' : category;
 }
 
 export interface FixHistoryFilters {

--- a/src/kubeview/engine/monitorClient.ts
+++ b/src/kubeview/engine/monitorClient.ts
@@ -67,7 +67,9 @@ export interface ActionReport {
   durationMs?: number;
   confidence?: number;
   rollbackAvailable?: boolean;
-  verificationStatus?: 'verified' | 'still_failing' | 'improved' | 'unverifiable';
+  // 'pending' is the initial state of a contracted write whose postcondition
+  // probe has not run yet — a scheduled check, not a stuck one.
+  verificationStatus?: 'pending' | 'verified' | 'still_failing' | 'improved' | 'unverifiable';
   verificationEvidence?: string;
   verificationTimestamp?: number;
   fixStrategy?: string;

--- a/src/kubeview/views/incidents/ActivityTab.tsx
+++ b/src/kubeview/views/incidents/ActivityTab.tsx
@@ -16,6 +16,7 @@ import { resourceDetailUrl } from '../../engine/gvr';
 import { formatRelativeTime } from '../../engine/formatters';
 import { getDateKey } from '../../engine/dateUtils';
 import { fetchLearningFeed } from '../../engine/analyticsApi';
+import { actionCategoryLabel } from '../../engine/fixHistory';
 import { agentFetch } from '../../engine/safeQuery';
 import type { TimelineEntry, TimelineCategory, CorrelationGroup } from '../../engine/types/timeline';
 import { CorrelationGroupRow } from './shared/CorrelationGroupRow';
@@ -120,12 +121,15 @@ export function ActivityTab() {
 
     if (showAgent) {
       for (const action of fixHistory) {
+        // A chat_action row is a write the operator approved in chat — labeling
+        // it a plain "Fix" would make a human decision read as an autonomous one.
+        const prefix = action.category === 'chat_action' ? 'User-approved fix' : 'Fix';
         all.push({
           id: action.id,
           timestamp: new Date(action.timestamp).toISOString(),
           category: 'event' as TimelineCategory,
           severity: (action.status === 'failed' ? 'warning' : 'normal') as 'warning' | 'normal',
-          title: `Fix: ${action.tool || action.category} — ${action.status}`,
+          title: `${prefix}: ${action.tool || actionCategoryLabel(action.category)} — ${action.status}`,
           detail: action.reasoning || action.afterState || '',
           namespace: action.resources?.[0]?.namespace,
           resource: action.resources?.[0]

--- a/src/kubeview/views/incidents/IncidentLifecycleDrawer.tsx
+++ b/src/kubeview/views/incidents/IncidentLifecycleDrawer.tsx
@@ -277,9 +277,10 @@ export function IncidentLifecycleDrawer({ findingId, onClose }: IncidentLifecycl
                     'text-xs px-1.5 py-0.5 rounded-sm font-medium',
                     verificationBadge === 'verified'
                       ? 'bg-emerald-900/50 text-emerald-300'
-                      // Grey, not amber: the check could not read the cluster,
-                      // which is not the same as the fix having gone wrong.
-                      : verificationBadge === 'unverifiable'
+                      // Grey, not amber: 'unverifiable' means the check could
+                      // not read the cluster, and 'pending' means the probe has
+                      // not run yet — neither is the fix having gone wrong.
+                      : verificationBadge === 'unverifiable' || verificationBadge === 'pending'
                         ? 'bg-slate-800 text-slate-400'
                         : 'bg-amber-900/50 text-amber-300',
                   )}>

--- a/src/kubeview/views/mission-control/OutcomesDrawer.tsx
+++ b/src/kubeview/views/mission-control/OutcomesDrawer.tsx
@@ -5,6 +5,7 @@ import {
 import { useQuery } from '@tanstack/react-query';
 import { cn } from '@/lib/utils';
 import { fetchResolutions, fetchFixHistorySummary } from '../../engine/analyticsApi';
+import { actionCategoryLabel } from '../../engine/fixHistory';
 import { formatRelativeTime } from '../../engine/formatters';
 import { IncidentLifecycleDrawer } from '../incidents/IncidentLifecycleDrawer';
 
@@ -62,6 +63,8 @@ export function OutcomesDrawer({ onClose }: { onClose: () => void }) {
       case 'verified': return 'Resolved';
       case 'improved': return 'Improved';
       case 'still_failing': return 'Still Failing';
+      case 'pending': return 'Pending';
+      case 'unverifiable': return 'Unverifiable';
       default: return outcome;
     }
   };
@@ -160,11 +163,22 @@ export function OutcomesDrawer({ onClose }: { onClose: () => void }) {
                       'text-[10px] px-1.5 py-0.5 rounded-sm font-medium',
                       r.outcome === 'verified' ? 'bg-emerald-900/40 text-emerald-300' :
                       r.outcome === 'improved' ? 'bg-blue-900/40 text-blue-300' :
+                      // Grey, not amber: a probe that has not run (pending) or
+                      // could not read the cluster (unverifiable) is not a fix
+                      // having gone wrong.
+                      r.outcome === 'pending' || r.outcome === 'unverifiable' ? 'bg-slate-800 text-slate-400' :
                       'bg-amber-900/40 text-amber-300',
                     )}>
                       {outcomeLabel(r.outcome)}
                     </span>
-                    <span className="text-[10px] px-1.5 py-0.5 bg-slate-800 text-slate-400 rounded-sm">{r.category}</span>
+                    {/* Violet, not slate: this fix was approved by a person in
+                        chat, and must not blend in with autonomous fixes. */}
+                    <span className={cn(
+                      'text-[10px] px-1.5 py-0.5 rounded-sm',
+                      r.category === 'chat_action' ? 'bg-violet-900/40 text-violet-300' : 'bg-slate-800 text-slate-400',
+                    )}>
+                      {actionCategoryLabel(r.category)}
+                    </span>
                   </div>
                   {r.reasoning && (
                     <p className="text-xs text-slate-400 mb-1 line-clamp-2">{r.reasoning}</p>
@@ -190,7 +204,7 @@ export function OutcomesDrawer({ onClose }: { onClose: () => void }) {
               <div className="space-y-1.5">
                 {summary.by_category.map((cat) => (
                   <div key={cat.category} className="flex items-center justify-between text-xs">
-                    <span className="text-slate-300">{cat.category}</span>
+                    <span className="text-slate-300">{actionCategoryLabel(cat.category)}</span>
                     <div className="flex items-center gap-2">
                       <span className="text-emerald-400">{cat.success_count}/{cat.count}</span>
                       {cat.auto_fixed > 0 && <span className="text-slate-500">{cat.auto_fixed} auto</span>}

--- a/src/kubeview/views/toolbox/OrcaAnalyticsSection.tsx
+++ b/src/kubeview/views/toolbox/OrcaAnalyticsSection.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Target, Layers, Cable, FileText, ArrowRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { safeQuery } from '../../engine/safeQuery';
+import { actionCategoryLabel } from '../../engine/fixHistory';
 import {
   fetchTopologySummary, fetchPlanTemplates, fetchPostmortemCount,
   fetchFixHistorySummary, fetchFixStrategies, fetchLearningFeed,
@@ -141,7 +142,7 @@ export function OrcaAnalyticsSection() {
             <div className="mt-3 space-y-1">
               {fixSummary.by_category.slice(0, 5).map((c) => (
                 <div key={c.category} className="flex items-center justify-between text-xs">
-                  <span className="text-slate-300">{c.category}</span>
+                  <span className="text-slate-300">{actionCategoryLabel(c.category)}</span>
                   <span className="text-slate-400">
                     {c.success_count}/{c.count} fixed
                   </span>


### PR DESCRIPTION
## What changed

pulse-agent 61f06d4 puts the five most-used interactive write tools (`restart_deployment`, `scale_deployment`, `delete_pod`, `rollback_deployment`, `cordon_node`) under verification contracts: each chat-approved write now lands in fix-history as a row with `category: "chat_action"` and a `verificationStatus` that starts at `"pending"` until the postcondition probe runs. This PR teaches the fix-history views about both.

- **Chat actions are labeled and visually distinct from auto-fixes.** New `actionCategoryLabel()` in `engine/fixHistory.ts` maps `chat_action` → "User-initiated" (scanner categories pass through unchanged), applied in the OutcomesDrawer row badge (violet, vs. the neutral slate all auto-fix categories share), its By Category breakdown, and the Toolbox analytics category list. In the Incident Center History feed, these rows are titled "User-approved fix: …" instead of "Fix: …".
- **`pending` verification state handled.** Added `'pending'` to the `verificationStatus` unions on `ActionReport` (monitorClient) and `ActionRecord` (fixHistory — which was also missing the verification fields the REST rows already carry). The IncidentLifecycleDrawer badge for `pending` now renders grey like `unverifiable`, instead of falling through to the amber still-failing styling.
- **OutcomesDrawer handles pending/unverifiable outcomes.** The agent's resolutions query returns any row with a non-null verification status, so contracted writes now appear in that list before their probe runs; they previously would have shown a raw slug in amber. Widened `ResolutionRecord.outcome` accordingly and added labels + grey styling.

## Why

A write the operator approved in chat must never read as an autonomous fix, and a probe that hasn't run yet (or ran in CLI mode where no monitor loop exists) is not a fix having gone wrong — the amber fallback styling asserted exactly that.

## Notes for reviewers

- No hardcoded fix-history category filter list existed to extend — the `category` filter is a free-form query param no view sets — so the labeling happens at render sites instead.
- The CLI-mode evidence string ("monitor loop not running in this process — no probe will run") arrives with status `unverifiable` and renders as plain wrapped text; no special-casing needed.
- No UI text claimed rollback was restart_deployment-only; `requestRollback()` remains unused (wiring a rollback button is spun off as a separate task).
- Verified with `pnpm type-check`, `pnpm lint` (0 errors), and the full unit suite (2,263 passed); 2 new tests cover the label helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)