### PR TITLE
Rollback button on completed fixes in the History feed

### DIFF
--- a/src/kubeview/engine/__tests__/fixHistory.test.ts
+++ b/src/kubeview/engine/__tests__/fixHistory.test.ts
@@ -174,5 +174,22 @@ describe('fixHistory', () => {
         'Failed to request rollback: 409 Conflict',
       );
     });
+
+    it('surfaces the agent error message from the response body', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 400,
+          statusText: 'Bad Request',
+          json: () =>
+            Promise.resolve({ error: 'No rollback strategy for delete_pod actions' }),
+        }),
+      );
+
+      await expect(requestRollback('a1')).rejects.toThrow(
+        'No rollback strategy for delete_pod actions',
+      );
+    });
   });
 });

--- a/src/kubeview/engine/fixHistory.ts
+++ b/src/kubeview/engine/fixHistory.ts
@@ -122,13 +122,28 @@ export async function approveFix(actionId: string): Promise<ActionRecord> {
   return body as ActionRecord;
 }
 
-/** Request a rollback for a completed action. */
+/**
+ * Request a rollback for a completed action.
+ *
+ * Only actions with a pre-write snapshot (or restart_deployment, which rolls
+ * back by revision) can be rolled back — the agent answers 400 with a reason
+ * for anything else. That refusal is an answer, not a transport failure, so
+ * surface its message.
+ */
 export async function requestRollback(actionId: string): Promise<void> {
   const res = await agentFetch(
     `${AGENT_BASE}/fix-history/${encodeURIComponent(actionId)}/rollback`,
     { method: 'POST' },
   );
   if (!res.ok) {
-    throw new Error(`Failed to request rollback: ${res.status} ${res.statusText}`);
+    let body: { error?: string } | null = null;
+    try {
+      body = await res.json();
+    } catch {
+      // no JSON body — fall through to the status line
+    }
+    throw new Error(
+      body?.error || `Failed to request rollback: ${res.status} ${res.statusText}`,
+    );
   }
 }

--- a/src/kubeview/views/incidents/ActivityTab.tsx
+++ b/src/kubeview/views/incidents/ActivityTab.tsx
@@ -17,6 +17,8 @@ import { formatRelativeTime } from '../../engine/formatters';
 import { getDateKey } from '../../engine/dateUtils';
 import { fetchLearningFeed } from '../../engine/analyticsApi';
 import { agentFetch } from '../../engine/safeQuery';
+import { requestRollback, type ActionRecord } from '../../engine/fixHistory';
+import { ConfirmDialog } from '../../components/feedback/ConfirmDialog';
 import type { TimelineEntry, TimelineCategory, CorrelationGroup } from '../../engine/types/timeline';
 import { CorrelationGroupRow } from './shared/CorrelationGroupRow';
 import { HistoryEntryCard } from './shared/HistoryEntryCard';
@@ -56,6 +58,9 @@ export function ActivityTab() {
   );
   const [expandedGroup, setExpandedGroup] = useState<string | null>(null);
   const [lifecycleFindingId, setLifecycleFindingId] = useState<string | null>(null);
+  const [rollbackTarget, setRollbackTarget] = useState<ActionRecord | null>(null);
+  const [rollbackBusy, setRollbackBusy] = useState(false);
+  const [rollbackError, setRollbackError] = useState<string | null>(null);
 
   const toggleCategory = (cat: ActivityCategory) => {
     setActiveCategories((prev) => {
@@ -147,6 +152,40 @@ export function ActivityTab() {
 
     return all;
   }, [timeline.entries, fixHistory, searchQuery, showAgent]);
+
+  // Completed fixes the agent can undo — keyed by action id, which is also the
+  // timeline entry id the merge above assigns them.
+  const rollbackableById = useMemo(() => {
+    const map = new Map<string, ActionRecord>();
+    for (const action of fixHistory) {
+      if (action.status === 'completed' && action.rollbackAvailable) map.set(action.id, action);
+    }
+    return map;
+  }, [fixHistory]);
+
+  const handleConfirmRollback = async () => {
+    if (!rollbackTarget) return;
+    setRollbackBusy(true);
+    setRollbackError(null);
+    try {
+      await requestRollback(rollbackTarget.id);
+      const res = rollbackTarget.resources?.[0];
+      useUIStore.getState().addToast({
+        type: 'success',
+        title: 'Rollback executed',
+        detail: res ? `${res.kind} ${res.name} restored to its pre-fix state` : undefined,
+        duration: 5000,
+      });
+      setRollbackTarget(null);
+      loadFixHistory();
+    } catch (e) {
+      // The agent refuses on purpose for action types without a snapshot —
+      // show what it said instead of a generic failure.
+      setRollbackError(e instanceof Error ? e.message : 'Rollback failed');
+    } finally {
+      setRollbackBusy(false);
+    }
+  };
 
   // Group by date for "by date" mode
   const groupedEntries = useMemo(() => {
@@ -392,9 +431,17 @@ export function ActivityTab() {
                     <h2 className="text-sm font-semibold text-slate-100 uppercase tracking-wide">{dateKey}</h2>
                   </div>
                   <div className="relative pl-6 border-l-2 border-slate-800 space-y-3">
-                    {dateEntries.map((entry) => (
-                      <HistoryEntryCard key={entry.id} entry={entry} onClick={() => handleEntryClick(entry)} />
-                    ))}
+                    {dateEntries.map((entry) => {
+                      const rollbackable = rollbackableById.get(entry.id);
+                      return (
+                        <HistoryEntryCard
+                          key={entry.id}
+                          entry={entry}
+                          onClick={() => handleEntryClick(entry)}
+                          onRollback={rollbackable ? () => { setRollbackError(null); setRollbackTarget(rollbackable); } : undefined}
+                        />
+                      );
+                    })}
                   </div>
                 </div>
               ))}
@@ -406,6 +453,25 @@ export function ActivityTab() {
       {lifecycleFindingId && (
         <IncidentLifecycleDrawer findingId={lifecycleFindingId} onClose={() => setLifecycleFindingId(null)} />
       )}
+
+      <ConfirmDialog
+        open={rollbackTarget !== null}
+        onClose={() => setRollbackTarget(null)}
+        onConfirm={handleConfirmRollback}
+        title="Roll back this fix?"
+        description={rollbackTarget ? (() => {
+          const res = rollbackTarget.resources?.[0];
+          const what = res ? `${res.kind} ${res.name}${res.namespace ? ` in ${res.namespace}` : ''}` : 'the affected resource';
+          return `The agent will restore ${what} to its state before "${rollbackTarget.tool || rollbackTarget.category}" ran. This writes to the cluster immediately.`;
+        })() : ''}
+        confirmLabel="Roll back"
+        variant="warning"
+        loading={rollbackBusy}
+      >
+        {rollbackError && (
+          <p className="mt-3 text-sm text-red-400" role="alert">{rollbackError}</p>
+        )}
+      </ConfirmDialog>
     </div>
   );
 }

--- a/src/kubeview/views/incidents/__tests__/ActivityTab.rollback.test.tsx
+++ b/src/kubeview/views/incidents/__tests__/ActivityTab.rollback.test.tsx
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+vi.mock('@/lib/utils', () => ({ cn: (...args: any[]) => args.filter(Boolean).join(' ') }));
+vi.mock('../../../hooks/useNavigateTab', () => ({ useNavigateTab: () => vi.fn() }));
+vi.mock('@tanstack/react-query', () => ({ useQuery: () => ({ data: undefined }) }));
+vi.mock('../../../engine/analyticsApi', () => ({ fetchLearningFeed: vi.fn() }));
+vi.mock('../../../engine/safeQuery', () => ({ agentFetch: vi.fn() }));
+vi.mock('../../../engine/gvr', () => ({ resourceDetailUrl: () => '/r/mock/resource' }));
+vi.mock('../IncidentLifecycleDrawer', () => ({ IncidentLifecycleDrawer: () => null }));
+vi.mock('../shared/InvestigationCard', () => ({ InvestigationCard: () => null }));
+vi.mock('../shared/PostmortemCard', () => ({ PostmortemCard: () => null }));
+vi.mock('../shared/CorrelationGroupRow', () => ({ CorrelationGroupRow: () => null }));
+
+const _uiState = {
+  selectedNamespace: '*',
+  addToast: vi.fn(),
+  expandAISidebar: vi.fn(),
+  setAISidebarMode: vi.fn(),
+};
+vi.mock('../../../store/uiStore', () => ({
+  useUIStore: Object.assign((selector: any) => selector(_uiState), {
+    getState: () => _uiState,
+  }),
+}));
+
+const _monitorState = {
+  investigations: [] as any[],
+  recentActions: [] as any[],
+  fixHistory: [] as any[],
+  loadFixHistory: vi.fn(),
+  findings: [] as any[],
+};
+vi.mock('../../../store/monitorStore', () => ({
+  useMonitorStore: Object.assign((selector: any) => selector(_monitorState), {
+    getState: () => _monitorState,
+  }),
+}));
+
+vi.mock('../../../store/agentStore', () => ({
+  useAgentStore: { getState: () => ({ sendMessage: vi.fn() }) },
+}));
+
+vi.mock('../../../hooks/useIncidentTimeline', () => ({
+  useIncidentTimeline: () => ({
+    entries: [],
+    correlationGroups: [],
+    counts: { alert: 0, event: 0, rollout: 0, config: 0 },
+    isLoading: false,
+  }),
+}));
+
+const requestRollback = vi.fn();
+vi.mock('../../../engine/fixHistory', () => ({
+  requestRollback: (...args: unknown[]) => requestRollback(...args),
+}));
+
+import { ActivityTab } from '../ActivityTab';
+
+function makeAction(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'act-1',
+    findingId: 'f1',
+    timestamp: Date.now(),
+    category: 'crashloop',
+    tool: 'restart_deployment',
+    input: {},
+    status: 'completed',
+    beforeState: '',
+    afterState: '',
+    reasoning: 'Restarted web deployment',
+    durationMs: 100,
+    rollbackAvailable: true,
+    resources: [{ kind: 'Deployment', name: 'web', namespace: 'default' }],
+    ...overrides,
+  };
+}
+
+describe('ActivityTab rollback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _monitorState.fixHistory = [];
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shows a Rollback button on completed fixes with rollbackAvailable', () => {
+    _monitorState.fixHistory = [makeAction()];
+    render(<ActivityTab />);
+    expect(screen.getByText('Rollback')).toBeDefined();
+  });
+
+  it('hides the Rollback button when rollback is not available', () => {
+    _monitorState.fixHistory = [makeAction({ rollbackAvailable: false })];
+    render(<ActivityTab />);
+    expect(screen.queryByText('Rollback')).toBeNull();
+  });
+
+  it('hides the Rollback button for non-completed actions', () => {
+    _monitorState.fixHistory = [makeAction({ status: 'failed' })];
+    render(<ActivityTab />);
+    expect(screen.queryByText('Rollback')).toBeNull();
+  });
+
+  it('confirms, calls the rollback endpoint, and refreshes the list', async () => {
+    _monitorState.fixHistory = [makeAction()];
+    requestRollback.mockResolvedValue(undefined);
+    render(<ActivityTab />);
+
+    fireEvent.click(screen.getByText('Rollback'));
+    expect(screen.getByText('Roll back this fix?')).toBeDefined();
+    expect(requestRollback).not.toHaveBeenCalled();
+
+    const callsBefore = _monitorState.loadFixHistory.mock.calls.length;
+    fireEvent.click(screen.getByText('Roll back'));
+
+    await waitFor(() => {
+      expect(requestRollback).toHaveBeenCalledWith('act-1');
+      expect(_monitorState.loadFixHistory.mock.calls.length).toBeGreaterThan(callsBefore);
+    });
+    expect(_uiState.addToast).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'success', title: 'Rollback executed' }),
+    );
+    expect(screen.queryByText('Roll back this fix?')).toBeNull();
+  });
+
+  it('does not call the endpoint when the dialog is cancelled', () => {
+    _monitorState.fixHistory = [makeAction()];
+    render(<ActivityTab />);
+
+    fireEvent.click(screen.getByText('Rollback'));
+    fireEvent.click(screen.getByText('Cancel'));
+
+    expect(requestRollback).not.toHaveBeenCalled();
+    expect(screen.queryByText('Roll back this fix?')).toBeNull();
+  });
+
+  it('surfaces the agent error in the dialog on failure', async () => {
+    _monitorState.fixHistory = [makeAction()];
+    requestRollback.mockRejectedValue(new Error('No rollback strategy for delete_pod actions'));
+    render(<ActivityTab />);
+
+    fireEvent.click(screen.getByText('Rollback'));
+    fireEvent.click(screen.getByText('Roll back'));
+
+    await waitFor(() => {
+      expect(screen.getByText('No rollback strategy for delete_pod actions')).toBeDefined();
+    });
+    // Dialog stays open so the operator can read the refusal
+    expect(screen.getByText('Roll back this fix?')).toBeDefined();
+    expect(_uiState.addToast).not.toHaveBeenCalled();
+  });
+});

--- a/src/kubeview/views/incidents/shared/HistoryEntryCard.tsx
+++ b/src/kubeview/views/incidents/shared/HistoryEntryCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Bell, Activity, RefreshCw, Settings } from 'lucide-react';
+import { Bell, Activity, RefreshCw, Settings, Undo2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { TimelineEntry, TimelineCategory } from '../../../engine/types/timeline';
 
@@ -10,7 +10,11 @@ export const CATEGORY_CONFIG: Record<TimelineCategory, { label: string; icon: Re
   config: { label: 'Config', icon: Settings, color: 'text-amber-400' },
 };
 
-export function HistoryEntryCard({ entry, onClick }: { entry: TimelineEntry; onClick: () => void }) {
+export function HistoryEntryCard({ entry, onClick, onRollback }: {
+  entry: TimelineEntry;
+  onClick: () => void;
+  onRollback?: () => void;
+}) {
   const cfg = CATEGORY_CONFIG[entry.category];
   const Icon = cfg.icon;
   const hasResource = !!entry.resource;
@@ -69,6 +73,18 @@ export function HistoryEntryCard({ entry, onClick }: { entry: TimelineEntry; onC
           <div className="text-sm font-medium text-slate-200">{entry.title}</div>
           {entry.detail && <div className="text-sm text-slate-400 mt-0.5 line-clamp-2">{entry.detail}</div>}
         </div>
+
+        {onRollback && (
+          <button
+            onClick={(e) => { e.stopPropagation(); onRollback(); }}
+            onKeyDown={(e) => e.stopPropagation()}
+            className="shrink-0 flex items-center gap-1.5 px-2.5 py-1 text-xs rounded-sm border border-slate-700 text-slate-300 hover:bg-slate-800 hover:text-slate-100 transition-colors"
+            aria-label={`Roll back: ${entry.title}`}
+          >
+            <Undo2 className="w-3.5 h-3.5" />
+            Rollback
+          </button>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## What changed

- **Incident Center → History** ([ActivityTab.tsx](../blob/claude/nice-wilson-9be185/src/kubeview/views/incidents/ActivityTab.tsx)): fix-history rows whose action is `completed` with `rollbackAvailable: true` now render a **Rollback** button. It opens a `ConfirmDialog` (warning variant) naming the resource and the tool that ran, calls `POST /api/agent/fix-history/{id}/rollback` on confirm, shows a success toast, and refreshes the list via `loadFixHistory()`.
- **HistoryEntryCard**: new optional `onRollback` prop renders the button; click/keydown propagation is stopped so it doesn't trigger the card's navigate-to-resource action.
- **`requestRollback()`** in `engine/fixHistory.ts` now parses the agent's `{error}` response body and throws that message instead of a bare `400 Bad Request` status line.

## Why

As of pulse-agent 61f06d4 the rollback endpoint actually executes rollbacks (snapshot restore, or revision rollback for `restart_deployment`), but `requestRollback()` was exported and never called from any view — the capability had no UI.

Action types without a pre-write snapshot are **refused by design**, so on failure the dialog stays open and shows the agent's own message rather than treating the refusal as a transport failure — same pattern as the approve flow in `ProposedFixes.tsx`.

## Reviewer notes

- **OutcomesDrawer** was considered as a second surface but its rows come from `fetchResolutions()`, whose `ResolutionRecord` has no `rollbackAvailable` (or action status), so nothing can gate the button there without a backend change.
- Rollback candidates are keyed by action id, which is also the timeline-entry id the History merge assigns fix rows.
- Tests: new `ActivityTab.rollback.test.tsx` (button gating, confirm→call→refresh, cancel, error-stays-in-dialog) plus a `fixHistory.test.ts` case for the surfaced error body. `pnpm verify` is fully green (2,268 tests, 0 lint errors, build OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)