### PR TITLE
Render verified-then-recurred fixes as warnings, not successes

### DIFF
--- a/src/kubeview/engine/__tests__/fixHistory.test.ts
+++ b/src/kubeview/engine/__tests__/fixHistory.test.ts
@@ -5,6 +5,7 @@ import {
   fetchActionDetail,
   requestRollback,
   actionCategoryLabel,
+  verificationStatusLabel,
 } from '../fixHistory';
 
 const mockAction = {
@@ -202,6 +203,18 @@ describe('fixHistory', () => {
     it('passes scanner categories through unchanged', () => {
       expect(actionCategoryLabel('crashloop')).toBe('crashloop');
       expect(actionCategoryLabel('image_pull')).toBe('image_pull');
+    });
+  });
+
+  describe('verificationStatusLabel', () => {
+    it('spells out the recurrence arc instead of the raw token', () => {
+      expect(verificationStatusLabel('verified_then_recurred')).toBe('verified, then recurred');
+    });
+
+    it('passes every other status through unchanged', () => {
+      expect(verificationStatusLabel('verified')).toBe('verified');
+      expect(verificationStatusLabel('still_failing')).toBe('still_failing');
+      expect(verificationStatusLabel('unverifiable')).toBe('unverifiable');
     });
   });
 });

--- a/src/kubeview/engine/analyticsApi.ts
+++ b/src/kubeview/engine/analyticsApi.ts
@@ -28,6 +28,12 @@ export interface FixHistorySummary {
     improved: number;
     /** Health check ran but could not get a clear reading — not the same as pending. */
     unverifiable?: number;
+    /**
+     * Fixes that verified and were then retroactively downgraded because the
+     * same condition returned within the recurrence window. Counts against the
+     * success rate. Absent on older agents.
+     */
+    recurred?: number;
     pending: number;
     resolution_rate: number;
   };
@@ -188,8 +194,9 @@ export interface ResolutionRecord {
   status: string;
   reasoning: string;
   // 'pending' (probe not run yet) and 'unverifiable' (probe could not read the
-  // cluster) reach this list too — any non-null verification status does.
-  outcome: 'verified' | 'still_failing' | 'improved' | 'pending' | 'unverifiable';
+  // cluster) reach this list too — any non-null verification status does,
+  // including the retroactive 'verified_then_recurred' downgrade.
+  outcome: 'verified' | 'still_failing' | 'improved' | 'pending' | 'unverifiable' | 'verified_then_recurred';
   evidence: string;
   timestamp: number;
   verifiedAt: number | null;

--- a/src/kubeview/engine/fixHistory.ts
+++ b/src/kubeview/engine/fixHistory.ts
@@ -34,7 +34,10 @@ export interface ActionRecord {
   resources: ResourceRef[];
   // 'pending' is the initial state of a contracted write whose postcondition
   // probe has not run yet — a scheduled check, not a stuck one.
-  verificationStatus?: 'pending' | 'verified' | 'still_failing' | 'improved' | 'unverifiable';
+  // 'verified_then_recurred' is a retroactive downgrade: the fix verified, then
+  // the same condition returned within the recurrence window. Never render it
+  // as a success.
+  verificationStatus?: 'pending' | 'verified' | 'still_failing' | 'improved' | 'unverifiable' | 'verified_then_recurred';
   verificationEvidence?: string;
   verificationTimestamp?: number;
 }
@@ -48,6 +51,17 @@ export interface ActionRecord {
  */
 export function actionCategoryLabel(category: string): string {
   return category === 'chat_action' ? 'User-initiated' : category;
+}
+
+/**
+ * Human label for a verification status.
+ *
+ * 'verified_then_recurred' is the one that needs translating: the raw token
+ * reads like jargon, and truncating it to "verified" would flip its meaning —
+ * the fix looked good and then the same condition came back.
+ */
+export function verificationStatusLabel(status: string): string {
+  return status === 'verified_then_recurred' ? 'verified, then recurred' : status;
 }
 
 export interface FixHistoryFilters {

--- a/src/kubeview/engine/monitorClient.ts
+++ b/src/kubeview/engine/monitorClient.ts
@@ -69,7 +69,10 @@ export interface ActionReport {
   rollbackAvailable?: boolean;
   // 'pending' is the initial state of a contracted write whose postcondition
   // probe has not run yet — a scheduled check, not a stuck one.
-  verificationStatus?: 'pending' | 'verified' | 'still_failing' | 'improved' | 'unverifiable';
+  // 'verified_then_recurred' is a retroactive downgrade: the fix verified, then
+  // the same condition returned within the recurrence window. Never render it
+  // as a success.
+  verificationStatus?: 'pending' | 'verified' | 'still_failing' | 'improved' | 'unverifiable' | 'verified_then_recurred';
   verificationEvidence?: string;
   verificationTimestamp?: number;
   fixStrategy?: string;
@@ -114,9 +117,12 @@ export interface InvestigationReport {
 
 export interface VerificationReport {
   id: string;
+  // On 'verified_then_recurred' this is the ORIGINAL action's id while
+  // findingId is the NEW finding that brought the condition back — the report
+  // retroactively downgrades an earlier 'verified' verdict.
   actionId: string;
   findingId: string;
-  status: 'verified' | 'still_failing' | 'improved' | 'unverifiable';
+  status: 'verified' | 'still_failing' | 'improved' | 'unverifiable' | 'verified_then_recurred';
   evidence: string;
   timestamp: number;
 }

--- a/src/kubeview/views/incidents/ActivityTab.tsx
+++ b/src/kubeview/views/incidents/ActivityTab.tsx
@@ -129,12 +129,16 @@ export function ActivityTab() {
         // A chat_action row is a write the operator approved in chat — labeling
         // it a plain "Fix" would make a human decision read as an autonomous one.
         const prefix = action.category === 'chat_action' ? 'User-approved fix' : 'Fix';
+        // A recurred fix completed and even verified once, but the agent
+        // withdrew that verdict — showing it as a plain completed fix would
+        // keep asserting a success the agent no longer claims.
+        const recurred = action.verificationStatus === 'verified_then_recurred';
         all.push({
           id: action.id,
           timestamp: new Date(action.timestamp).toISOString(),
           category: 'event' as TimelineCategory,
-          severity: (action.status === 'failed' ? 'warning' : 'normal') as 'warning' | 'normal',
-          title: `${prefix}: ${action.tool || actionCategoryLabel(action.category)} — ${action.status}`,
+          severity: (action.status === 'failed' || recurred ? 'warning' : 'normal') as 'warning' | 'normal',
+          title: `${prefix}: ${action.tool || actionCategoryLabel(action.category)} — ${recurred ? `${action.status} (verified, then recurred)` : action.status}`,
           detail: action.reasoning || action.afterState || '',
           namespace: action.resources?.[0]?.namespace,
           resource: action.resources?.[0]

--- a/src/kubeview/views/incidents/IncidentLifecycleDrawer.tsx
+++ b/src/kubeview/views/incidents/IncidentLifecycleDrawer.tsx
@@ -7,6 +7,7 @@ import { cn } from '@/lib/utils';
 import { useQuery } from '@tanstack/react-query';
 import { formatRelativeTime } from '../../engine/formatters';
 import { fetchConfidenceCalibration } from '../../engine/analyticsApi';
+import { verificationStatusLabel } from '../../engine/fixHistory';
 import { useIncidentLifecycle } from '../../hooks/useIncidentLifecycle';
 
 type StageStatus = 'complete' | 'in-progress' | 'pending' | 'failed' | 'skipped';
@@ -69,12 +70,17 @@ export function IncidentLifecycleDrawer({ findingId, onClose }: IncidentLifecycl
   // reading. It is neither a passed nor a failed fix, so it maps to 'skipped'
   // rather than 'failed' — reporting it as a failure asserts something the
   // check never established, the mirror of the absence bug on the agent side.
+  // 'verified_then_recurred' maps to 'failed' even though the fix once
+  // verified: the verdict was retroactively downgraded because the same
+  // condition returned, and a green check here would re-assert the verdict
+  // the agent itself withdrew.
   const verificationStatus: StageStatus = lifecycle.verification
     ? lifecycle.verification.status === 'verified' ? 'complete'
     : lifecycle.verification.status === 'unverifiable' ? 'skipped' : 'failed'
     : lifecycle.action?.verificationStatus === 'verified' ? 'complete'
     : lifecycle.action?.verificationStatus === 'unverifiable' ? 'skipped'
     : lifecycle.action?.verificationStatus === 'still_failing' ? 'failed'
+    : lifecycle.action?.verificationStatus === 'verified_then_recurred' ? 'failed'
     : 'pending';
   const verificationBadge = lifecycle.verification?.status || lifecycle.action?.verificationStatus;
   const postmortemStatus: StageStatus = lifecycle.postmortem ? 'complete' : 'pending';
@@ -284,7 +290,7 @@ export function IncidentLifecycleDrawer({ findingId, onClose }: IncidentLifecycl
                         ? 'bg-slate-800 text-slate-400'
                         : 'bg-amber-900/50 text-amber-300',
                   )}>
-                    {verificationBadge}
+                    {verificationStatusLabel(verificationBadge!)}
                   </span>
                 </div>
                 {(lifecycle.verification?.evidence || lifecycle.action?.verificationEvidence) && (

--- a/src/kubeview/views/incidents/__tests__/RecurredFix.test.tsx
+++ b/src/kubeview/views/incidents/__tests__/RecurredFix.test.tsx
@@ -1,0 +1,231 @@
+// @vitest-environment jsdom
+// A "verified, then recurred" fix is a verdict the agent retroactively
+// withdrew: it must render as a warning everywhere, never as a success.
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+vi.mock('../../../hooks/useNavigateTab', () => ({ useNavigateTab: () => vi.fn() }));
+vi.mock('../../../engine/safeQuery', () => ({ agentFetch: vi.fn() }));
+vi.mock('../../../engine/gvr', () => ({ resourceDetailUrl: () => '/r/mock/resource' }));
+vi.mock('../shared/InvestigationCard', () => ({ InvestigationCard: () => null }));
+vi.mock('../shared/PostmortemCard', () => ({ PostmortemCard: () => null }));
+vi.mock('../shared/CorrelationGroupRow', () => ({ CorrelationGroupRow: () => null }));
+
+// One dispatch table for every component under test: OutcomesDrawer asks for
+// the summary and the resolutions list, the lifecycle drawer for calibration.
+const queryData: Record<string, unknown> = {};
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: ({ queryKey }: { queryKey: unknown[] }) => ({
+    data: queryData[String(queryKey[0])],
+    isLoading: false,
+  }),
+}));
+vi.mock('../../../engine/analyticsApi', () => ({
+  fetchLearningFeed: vi.fn(),
+  fetchResolutions: vi.fn(),
+  fetchFixHistorySummary: vi.fn(),
+  fetchConfidenceCalibration: vi.fn(),
+}));
+
+const _uiState = {
+  selectedNamespace: '*',
+  addToast: vi.fn(),
+  expandAISidebar: vi.fn(),
+  setAISidebarMode: vi.fn(),
+};
+vi.mock('../../../store/uiStore', () => ({
+  useUIStore: Object.assign((selector: any) => selector(_uiState), {
+    getState: () => _uiState,
+  }),
+}));
+
+const _monitorState = {
+  investigations: [] as any[],
+  recentActions: [] as any[],
+  fixHistory: [] as any[],
+  loadFixHistory: vi.fn(),
+  findings: [] as any[],
+};
+vi.mock('../../../store/monitorStore', () => ({
+  useMonitorStore: Object.assign((selector: any) => selector(_monitorState), {
+    getState: () => _monitorState,
+  }),
+}));
+
+vi.mock('../../../store/agentStore', () => ({
+  useAgentStore: { getState: () => ({ sendMessage: vi.fn() }) },
+}));
+
+vi.mock('../../../hooks/useIncidentTimeline', () => ({
+  useIncidentTimeline: () => ({
+    entries: [],
+    correlationGroups: [],
+    counts: { alert: 0, event: 0, rollout: 0, config: 0 },
+    isLoading: false,
+  }),
+}));
+
+const _lifecycle = {
+  detection: null as unknown,
+  impact: null,
+  investigation: null,
+  action: null as unknown,
+  verification: null as unknown,
+  postmortem: null,
+  learning: null,
+  isLoading: false,
+};
+vi.mock('../../../hooks/useIncidentLifecycle', () => ({
+  useIncidentLifecycle: () => _lifecycle,
+}));
+
+import { ActivityTab } from '../ActivityTab';
+import { IncidentLifecycleDrawer } from '../IncidentLifecycleDrawer';
+import { OutcomesDrawer } from '../../mission-control/OutcomesDrawer';
+
+function makeAction(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'act-1',
+    findingId: 'f1',
+    timestamp: Date.now(),
+    category: 'crashloop',
+    tool: 'restart_deployment',
+    input: {},
+    status: 'completed',
+    beforeState: '',
+    afterState: '',
+    reasoning: 'Restarted web deployment',
+    durationMs: 100,
+    rollbackAvailable: false,
+    resources: [{ kind: 'Deployment', name: 'web', namespace: 'default' }],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  _monitorState.fixHistory = [];
+  _lifecycle.action = null;
+  _lifecycle.verification = null;
+  for (const k of Object.keys(queryData)) delete queryData[k];
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('ActivityTab recurred fixes', () => {
+  it('flags a recurred fix in the title and downgrades it to a warning', () => {
+    _monitorState.fixHistory = [makeAction({ verificationStatus: 'verified_then_recurred' })];
+    render(<ActivityTab />);
+    const title = screen.getByText(/verified, then recurred/);
+    expect(title.textContent).toContain('completed (verified, then recurred)');
+    // The severity chip is the element labeled with the category config label.
+    const chip = screen.getByText('Events', { selector: 'span' });
+    expect(chip.className).toContain('bg-amber-900/50');
+  });
+
+  it('leaves a plainly verified fix as a normal entry', () => {
+    _monitorState.fixHistory = [makeAction({ verificationStatus: 'verified' })];
+    render(<ActivityTab />);
+    expect(screen.queryByText(/then recurred/)).toBeNull();
+    const chip = screen.getByText('Events', { selector: 'span' });
+    expect(chip.className).toContain('bg-slate-800');
+  });
+});
+
+describe('IncidentLifecycleDrawer recurred verification', () => {
+  it('renders the recurred badge as an amber warning, not a success', () => {
+    _lifecycle.action = makeAction({ verificationStatus: 'verified_then_recurred' });
+    render(<IncidentLifecycleDrawer findingId="f1" onClose={() => {}} />);
+    const badge = screen.getByText('verified, then recurred');
+    expect(badge.className).toContain('bg-amber-900/50');
+    expect(badge.className).not.toContain('emerald');
+  });
+
+  it('renders a live verification_report with recurred status the same way', () => {
+    _lifecycle.verification = {
+      id: 'v1',
+      actionId: 'act-1',
+      findingId: 'f1',
+      status: 'verified_then_recurred',
+      evidence: 'Condition returned 12 min after verification',
+      timestamp: Date.now(),
+    };
+    render(<IncidentLifecycleDrawer findingId="f1" onClose={() => {}} />);
+    const badge = screen.getByText('verified, then recurred');
+    expect(badge.className).toContain('bg-amber-900/50');
+    expect(screen.getByText('Condition returned 12 min after verification')).toBeDefined();
+  });
+});
+
+describe('OutcomesDrawer recurred outcomes', () => {
+  const summary = {
+    total_actions: 10,
+    completed: 8,
+    failed: 1,
+    rolled_back: 1,
+    success_rate: 0.8,
+    rollback_rate: 0.1,
+    avg_resolution_ms: 60000,
+    by_category: [],
+    trend: { current_week: 5, previous_week: 5, delta: 0 },
+    verification: {
+      resolved: 5,
+      still_failing: 1,
+      improved: 0,
+      recurred: 2,
+      pending: 2,
+      resolution_rate: 0.5,
+    },
+  };
+
+  const recurredResolution = {
+    id: 'r1',
+    findingId: 'f2',
+    category: 'crashloop',
+    tool: 'restart_deployment',
+    status: 'completed',
+    reasoning: 'Restarted web deployment',
+    outcome: 'verified_then_recurred',
+    evidence: 'Same condition returned 12 min after verification',
+    timestamp: Date.now(),
+    verifiedAt: Date.now(),
+    durationMs: 100,
+    timeToVerifyMs: 30_000,
+  };
+
+  const verifiedResolution = {
+    ...recurredResolution,
+    id: 'r2',
+    findingId: 'f3',
+    outcome: 'verified',
+    evidence: 'No active findings',
+  };
+
+  it('shows the recurred count and labels the outcome as a warning', () => {
+    queryData['fix-history-summary'] = summary;
+    queryData['resolutions'] = { resolutions: [recurredResolution, verifiedResolution], total: 2 };
+    render(<OutcomesDrawer onClose={() => {}} />);
+
+    expect(screen.getByText('2 recurred')).toBeDefined();
+    const badge = screen.getByText('Verified, then recurred');
+    expect(badge.className).toContain('bg-amber-900/40');
+    expect(badge.className).not.toContain('emerald');
+  });
+
+  it('filters to only recurred outcomes via the Recurred chip', () => {
+    queryData['fix-history-summary'] = summary;
+    queryData['resolutions'] = { resolutions: [recurredResolution, verifiedResolution], total: 2 };
+    render(<OutcomesDrawer onClose={() => {}} />);
+
+    fireEvent.click(screen.getByText('Recurred'));
+    expect(screen.getByText('Verified, then recurred')).toBeDefined();
+    expect(screen.queryByText('Resolved', { selector: 'span' })).toBeNull();
+  });
+});

--- a/src/kubeview/views/mission-control/AgentHealth.tsx
+++ b/src/kubeview/views/mission-control/AgentHealth.tsx
@@ -178,6 +178,17 @@ function OutcomesCard({
             <span className="text-emerald-400 font-medium">{fixSummary.verification.resolved} resolved</span>
             <span className="text-slate-600">&middot;</span>
             <span className="text-amber-400">{fixSummary.verification.still_failing} still failing</span>
+            {(fixSummary.verification.recurred ?? 0) > 0 && (
+              <>
+                <span className="text-slate-600">&middot;</span>
+                <span
+                  className="text-amber-400 underline decoration-dotted underline-offset-2"
+                  title="These fixes verified healthy, then the same condition returned within the recurrence window — counted against the success rate, not as successes."
+                >
+                  {fixSummary.verification.recurred} recurred
+                </span>
+              </>
+            )}
             {(fixSummary.verification.unverifiable ?? 0) > 0 && (
               <>
                 <span className="text-slate-600">&middot;</span>

--- a/src/kubeview/views/mission-control/OutcomesDrawer.tsx
+++ b/src/kubeview/views/mission-control/OutcomesDrawer.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import {
-  X, CheckCircle, XCircle, ArrowUp, Clock,
+  X, CheckCircle, XCircle, ArrowUp, Clock, RotateCcw,
 } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
 import { cn } from '@/lib/utils';
@@ -9,13 +9,14 @@ import { actionCategoryLabel } from '../../engine/fixHistory';
 import { formatRelativeTime } from '../../engine/formatters';
 import { IncidentLifecycleDrawer } from '../incidents/IncidentLifecycleDrawer';
 
-type OutcomeFilter = 'all' | 'verified' | 'still_failing' | 'improved';
+type OutcomeFilter = 'all' | 'verified' | 'still_failing' | 'improved' | 'verified_then_recurred';
 
 const FILTERS: { id: OutcomeFilter; label: string; color: string }[] = [
   { id: 'all', label: 'All', color: 'text-slate-300' },
   { id: 'verified', label: 'Resolved', color: 'text-emerald-400' },
   { id: 'still_failing', label: 'Still Failing', color: 'text-amber-400' },
   { id: 'improved', label: 'Improved', color: 'text-blue-400' },
+  { id: 'verified_then_recurred', label: 'Recurred', color: 'text-amber-400' },
 ];
 
 export function OutcomesDrawer({ onClose }: { onClose: () => void }) {
@@ -54,6 +55,7 @@ export function OutcomesDrawer({ onClose }: { onClose: () => void }) {
       case 'verified': return <CheckCircle className="w-3.5 h-3.5 text-emerald-400" />;
       case 'improved': return <ArrowUp className="w-3.5 h-3.5 text-blue-400" />;
       case 'still_failing': return <XCircle className="w-3.5 h-3.5 text-amber-400" />;
+      case 'verified_then_recurred': return <RotateCcw className="w-3.5 h-3.5 text-amber-400" />;
       default: return <Clock className="w-3.5 h-3.5 text-slate-500" />;
     }
   };
@@ -65,6 +67,9 @@ export function OutcomesDrawer({ onClose }: { onClose: () => void }) {
       case 'still_failing': return 'Still Failing';
       case 'pending': return 'Pending';
       case 'unverifiable': return 'Unverifiable';
+      // Not "Verified": the verdict was retroactively withdrawn when the same
+      // condition returned, so the label must carry the whole arc.
+      case 'verified_then_recurred': return 'Verified, then recurred';
       default: return outcome;
     }
   };
@@ -118,6 +123,14 @@ export function OutcomesDrawer({ onClose }: { onClose: () => void }) {
                 <span className="text-emerald-400">{summary.verification.resolved} resolved</span>
                 <span className="text-amber-400">{summary.verification.still_failing} still failing</span>
                 {summary.verification.improved > 0 && <span className="text-blue-400">{summary.verification.improved} improved</span>}
+                {(summary.verification.recurred ?? 0) > 0 && (
+                  <span
+                    className="text-amber-400"
+                    title="Fixes that verified healthy, then the same condition returned within the recurrence window — counted against the success rate."
+                  >
+                    {summary.verification.recurred} recurred
+                  </span>
+                )}
                 <span className="text-slate-500">{summary.verification.pending} pending</span>
               </div>
             )}

--- a/src/kubeview/views/toolbox/OrcaAnalyticsSection.tsx
+++ b/src/kubeview/views/toolbox/OrcaAnalyticsSection.tsx
@@ -120,7 +120,7 @@ export function OrcaAnalyticsSection() {
         <div className="bg-slate-900 border border-slate-800 rounded-lg p-4">
           <h3 className="text-xs font-medium text-slate-300 mb-1">Fix Outcomes</h3>
           <p className="text-[11px] text-slate-500 mb-3">How well automated fixes resolve issues (last 30 days).</p>
-          <div className="grid grid-cols-4 gap-4 text-center text-xs">
+          <div className={cn('grid gap-4 text-center text-xs', (fixSummary.verification.recurred ?? 0) > 0 ? 'grid-cols-5' : 'grid-cols-4')}>
             <div>
               <div className="text-slate-400">Success Rate</div>
               <div className="text-lg font-bold text-emerald-400">{(fixSummary.success_rate * 100).toFixed(0)}%</div>
@@ -133,6 +133,12 @@ export function OrcaAnalyticsSection() {
               <div className="text-slate-400">Still Failing</div>
               <div className="text-lg font-bold text-red-400">{fixSummary.verification.still_failing}</div>
             </div>
+            {(fixSummary.verification.recurred ?? 0) > 0 && (
+              <div title="Fixes that verified healthy, then the same condition returned within the recurrence window.">
+                <div className="text-slate-400">Recurred</div>
+                <div className="text-lg font-bold text-amber-400">{fixSummary.verification.recurred}</div>
+              </div>
+            )}
             <div>
               <div className="text-slate-400">Rollback Rate</div>
               <div className="text-lg font-bold text-amber-400">{(fixSummary.rollback_rate * 100).toFixed(0)}%</div>


### PR DESCRIPTION
## What changed

The agent backend now emits two values the UI had no rendering for: `verificationStatus` / `verification_report.status` of **`verified_then_recurred`** (a previously verified fix whose condition returned within the recurrence window — broadcast with the *original* `actionId` and the *new* finding's `findingId`), and the action outcome **`recurred`**, reported as a separate count by the fix success rate endpoint. See pulse-agent `API_CONTRACT.md` (verification_report section) and `sre_agent/monitor/recurrence.py`.

This PR renders both, everywhere verification status and fix outcomes appear:

- **Engine types** (`monitorClient.ts`, `fixHistory.ts`, `analyticsApi.ts`): unions extended; `FixHistorySummary.verification` gains an optional `recurred` count (absent on older agents); new `verificationStatusLabel()` helper renders the token as "verified, then recurred".
- **Incident Lifecycle drawer**: the Verification stage maps `verified_then_recurred` to the failed stage marker and shows an amber badge. Previously the action-path mapping dropped the unknown status into *pending*, silently hiding the downgrade.
- **Outcomes drawer** (Mission Control): new "Recurred" filter chip, amber icon and "Verified, then recurred" badge, and a "N recurred" line in the verification breakdown with a tooltip explaining it counts against the success rate.
- **Agent Health card** and **ORCA analytics** (Toolbox): recurred counts, rendered only when the agent reports them.
- **History feed** (Incident Center): a recurred fix's timeline entry is downgraded to warning severity and its title reads "completed (verified, then recurred)".

## Why

A verdict of `verified` has a time horizon. When the agent retroactively withdraws it, the UI must stop asserting the success — a green check on a fix the agent itself no longer claims teaches operators to distrust every green check. The state reads as a warning (amber) everywhere, and the label always carries the whole arc: truncating to "verified" would flip its meaning.

## Notes for reviewers

- The store already matches verification reports to actions by `actionId`, so the retroactive downgrade lands on the original action row with no store changes.
- The agent's `/fix-history/summary` endpoint does not yet bucket `verified_then_recurred` (those actions currently inflate its `pending` count). The UI's `recurred` field is optional and renders only when present, so it lights up as soon as the agent starts reporting it.
- Tests: new `RecurredFix.test.tsx` covers the History feed, lifecycle drawer (both the live report and the action-row path), and Outcomes drawer; label helper cases added to the engine tests. Full suite: 2,281 tests pass; type-check, lint, and production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)